### PR TITLE
Add chatgpt plugin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Godot 4+ specific ignores
 .godot/
+addons/GPTIntegration/


### PR DESCRIPTION
If you have this chatgpt addon installed, this PR will make sure the addon doesn't show up as changed files when comparing to your fork. 

This could lead to everyone downloading some random addon and putting it in .gitignore, but I don't think that's a problem.