### PR TITLE
Fix corpse spawn error

### DIFF
--- a/Scripts/Enemy.gd
+++ b/Scripts/Enemy.gd
@@ -27,8 +27,10 @@ func _get_hit(damage):
 		_die()
 	
 func _die():
-	var corpse = corpse_scene.instantiate()
-	#$"../../../..".add_child(corpse)
-	get_tree().get_root().call_deferred("add_child", corpse)
-	corpse.global_position = global_position
+	add_corpse.call_deferred(global_position)
 	queue_free()
+	
+func add_corpse(pos: Vector3):
+	var corpse = corpse_scene.instantiate()
+	get_tree().get_root().add_child(corpse)
+	corpse.global_position = pos


### PR DESCRIPTION
This error occurred before this PR when an enemy dies: `E 0:00:15:0309   Enemy.gd:33 @ _die(): Condition "!is_inside_tree()" is true. Returning: Transform3D()`

This is because the global position was set before the corpse instance was added to the tree. Even thought the 'add_child'  code is before the global position code, it was executed after because it was deferred.

By combining the adding of the child and setting the position into one call_deferred function, the error goes away.