### PR TITLE
Chunks are more seamless

### DIFF
--- a/Defaults/Projectiles/DefaultBullet.tscn
+++ b/Defaults/Projectiles/DefaultBullet.tscn
@@ -17,8 +17,6 @@ script = ExtResource("1_tleh8")
 
 [node name="BulletSprite" type="Sprite3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
-cast_shadow = 0
-alpha_cut = 1
 texture = ExtResource("2_a3c22")
 
 [node name="BulletCollisionShape" type="CollisionShape3D" parent="."]

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -13,8 +13,8 @@ var level_height : int = 32
 
 
 # Parameters for dynamic chunk loading
-var creation_radius = 1
-var survival_radius = 2
+var creation_radius = 2
+var survival_radius = 3
 var loaded_chunks = {} # Dictionary to store loaded chunks with their positions as keys
 var player_position = Vector2.ZERO # Player's position, updated regularly
 # Chunks are loaded and unloaded one at a time. The load_queue will be processed before the unload_queue
@@ -138,7 +138,7 @@ func load_chunk(chunk_pos: Vector2):
 	newChunk.mypos = Vector3(chunk_pos.x * level_width, 0, chunk_pos.y * level_height)
 	newChunk.level_manager = level_manager
 	newChunk.level_generator = self
-	newChunk.chunk_loaded.connect(_on_chunk_un_loaded)
+	newChunk.chunk_part_loaded.connect(_on_chunk_un_loaded)
 	newChunk.chunk_unloaded.connect(_on_chunk_un_loaded)
 	if Helper.loaded_chunk_data.chunks.has(chunk_pos):
 		# If the chunk has been loaded before, we use that data

--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -17,7 +17,7 @@ func _process(_delta):
 func update_visibility(player_y: float):
 	# Update level visibility
 	for level in get_tree().get_nodes_in_group("maplevels"):
-		var is_above_player = level.global_position.y > player_y
+		var is_above_player = level.y > player_y
 		level.visible = not is_above_player
 
 	# Update furniture visibility

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -5,7 +5,7 @@ extends Node3D
 # This script is it's own class and is not assigned to any particular node
 # You can call Chunk.new() to create a new instance of this class
 # This script will manage the internals of a map chunk
-# A chunk is made up of blocks, slopes, furniture and mobs
+# A chunk is made up of blocks, slopes, furniture, mobs and items
 # The first time a chunk is loaded, it will be from a map definition
 # Each time after that, it will load whatever whas saved when the player exited the map
 # When the player exits the map, the chunk will get saved so it can be loaded later
@@ -14,10 +14,10 @@ extends Node3D
 # On top of the blocks we spawn mobs and furniture
 # Loading and unloading of chunks is managed by levelGenerator.gd
 
-# Reference to the level manager. Some nodes that could be moved to other chunks should be parented to this
+# Reference to the level manager. Some nodes that could be moved to other chunks 
+# should be parented to this (like moveable furniture and mobs)
 var level_manager : Node3D
 var level_generator : Node3D
-
 
 # Constants
 const MAX_LEVELS = 21
@@ -36,8 +36,7 @@ var chunk_data: Dictionary # The json data that defines this chunk
 # A map is defined by the mapeditor. This variable holds the data that is processed from the map
 # editor format into something usable for this chunk's generation
 var processed_level_data: Dictionary = {}
-var mutex: Mutex = Mutex.new() # Used to synchonize the thread with the main thread
-var thread: Thread # Used to offload calculations from the main thread
+var mutex: Mutex = Mutex.new() # Used to ensure thread safety
 var mypos: Vector3 # The position in 3d space. Expect y to be 0
 # Variables to enable navigation.
 var navigation_region: NavigationRegion3D
@@ -76,32 +75,13 @@ func initialize_chunk_data():
 
 func generate_new_chunk():
 	block_positions = create_block_position_dictionary_new_arraymesh()
-	thread = Thread.new()
-	thread.start(generate_chunk_mesh)
-
-
-# The chunk mesh has finished generating. we check if the thread is finished and then we start
-# to add furniture and items to the map
-func generate_chunk_mesh_finished():
+	await Helper.task_manager.create_task(generate_chunk_mesh).completed
 	# Even though the chunk is not completely generated, we emit the signal now to prevent further
 	# delays in generating or unloading the next chunk. Might remove this or move it to another place.
 	chunk_loaded.emit()
-	# Wait for the thread to complete, and get the returned value.
-	if is_instance_valid(thread) and thread.is_started():
-		mutex.lock()
-		thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
-		mutex.unlock()
-	if is_new_chunk(): # This chunk is created for the first time
-		processed_level_data = process_level_data()
-		thread = Thread.new()
-		thread.start(add_furnitures_to_new_block)
-	else: # This chunk has been loaded from previously saved data
-		for item: Dictionary in chunk_data.items:
-			add_item_to_map(item)
-		# We duplicate the furnituredata for thread safety
-		thread = Thread.new()
-		thread.start(add_furnitures_to_map.bind(chunk_data.furniture.duplicate()))
+	processed_level_data = process_level_data()
+	await Helper.task_manager.create_task(add_furnitures_to_new_block).completed
+	await Helper.task_manager.create_task(add_block_mobs).completed
 
 
 # Collects the furniture and mob data from the mapdata to be spawned later
@@ -155,13 +135,21 @@ func create_block_position_dictionary_new_arraymesh() -> Dictionary:
 	return new_block_positions
 
 
-# Generate the map layer by layer
-# For each layer, add all the blocks with proper rotation
-# If a block has an mob, add it too
+# Generate a chunk that was previously saved
+# After generating the mesh we add the items, furniture and mobs
 func generate_saved_chunk() -> void:
 	block_positions = chunk_data.block_positions
-	thread = Thread.new()
-	thread.start(generate_chunk_mesh)
+	await Helper.task_manager.create_task(generate_chunk_mesh).completed
+	# Even though the chunk is not completely generated, we emit the signal now to prevent further
+	# delays in generating or unloading the next chunk. Might remove this or move it to another place.
+	chunk_loaded.emit()
+	for item: Dictionary in chunk_data.items:
+		add_item_to_map(item)
+	
+	# We duplicate the furnituredata for thread safety
+	var furnituredata: Dictionary = chunk_data.furniture.duplicate()
+	await Helper.task_manager.create_task(add_furnitures_to_map.bind(furnituredata)).completed
+	await Helper.task_manager.create_task(add_mobs_to_map).completed
 
 
 # When a map is loaded for the first time we spawn the mob on the block
@@ -176,14 +164,6 @@ func add_block_mobs():
 		# Pass the position and the mob json to the newmob and have it construct itself
 		newMob.construct_self(mypos+mobdata.pos, mobdata.json)
 		level_manager.add_child.call_deferred(newMob)
-	add_block_mobs_finished.call_deferred()
-
-
-func add_block_mobs_finished():
-	if is_instance_valid(thread) and thread.is_started():
-		# If a thread is already running, let it finish before we start another.
-		thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
 
 
 # When a map is loaded for the first time we spawn the furniture on the block
@@ -218,18 +198,11 @@ func add_furnitures_to_new_block():
 	# Optional: One final delay after the last block if the total_blocks is not perfectly divisible by delay_every_n_blocks
 	if total_furniture % delay_every_n_furniture != 0:
 		OS.delay_msec(10)
-	add_furnitures_to_new_block_finished.call_deferred()
 
 
-func add_furnitures_to_new_block_finished():
-	if is_instance_valid(thread) and thread.is_started():
-		# If a thread is already running, let it finish before we start another.
-		thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
-	thread = Thread.new()
-	thread.start(add_block_mobs)
-
-
+# Returns an array of furniture data that will be saved for this chunk
+# Furniture that has it's x and z position in the boundary of the chunk's position and size
+# will be included in the chunk data. So basically if the furniture is 'in' or 'on' the chunk.
 func get_furniture_data() -> Array:
 	var furnitureData: Array = []
 	var mapFurniture = get_tree().get_nodes_in_group("furniture")
@@ -348,14 +321,6 @@ func add_mobs_to_map() -> void:
 		var mobpos: Vector3 = Vector3(mob.global_position_x,mob.global_position_y,mob.global_position_z)
 		newMob.construct_self(mobpos, mob)
 		level_manager.add_child.call_deferred(newMob)
-	add_mobs_to_map_finished.call_deferred()
-
-
-func add_mobs_to_map_finished():
-	if is_instance_valid(thread) and thread.is_started():
-		# If a thread is already running, let it finish before we start another.
-		thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
 
 
 # Called by generate_items function when a save is loaded
@@ -401,25 +366,10 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 	# Optional: One final delay after the last furniture if the total_furniture is not perfectly divisible by delay_every_n_furniture
 	if total_furniture % delay_every_n_furniture != 0:
 		OS.delay_msec(10)
-	
-	add_furnitures_to_map_finised.call_deferred()
-
-
-func add_furnitures_to_map_finised():
-	if is_instance_valid(thread) and thread.is_started():
-		if thread.is_alive():
-			print_debug("The thread is still alive, blocking calling thread")
-		# If a thread is already running, let it finish before we start another.
-		thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
-	thread = Thread.new()
-	thread.start(add_mobs_to_map)
-	#add_block_mobs()
 
 
 # Returns all the chunk data used for saving and loading
-func get_chunk_data() -> Dictionary:
-	var chunkdata: Dictionary = {}
+func get_chunk_data(chunkdata: Dictionary) -> void:
 	mutex.lock()
 	chunkdata.chunk_x = mypos.x
 	chunkdata.chunk_z = mypos.z
@@ -434,38 +384,16 @@ func get_chunk_data() -> Dictionary:
 	chunk_mesh_body.queue_free()
 	navigation_region.queue_free()
 	NavigationServer3D.free_rid(navigation_map_id)
-	finish_unload_chunk.call_deferred()
-	return chunkdata
 
 
 # Called by LevelGenerator.gd which manages the chunks and also by Helper.save_helper when
 # switching to a different map. We start a new thread to collect map data and save it in
 # the helper variable. First we wait until the current thread is finished.
 func unload_chunk():
-	if is_instance_valid(thread) and thread.is_started():
-	# Wait for the thread to complete, and get the returned value.
-		mutex.lock()
-		thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
-		mutex.unlock()
-	thread = Thread.new()
-	thread.start(get_chunk_data)
-
-
-# The thread has done it's work and the mapdata is gathered. We now save it to the Helper variable
-# This happens when LevelGenerator.gd unloads chunks and when Helper.save_helper saves the map
-# Lastly we emit the unloaded signal so that Helper and LevelGenerator know to act and also to call 
-# the _finish_unload function
-func finish_unload_chunk():
-	var chunkdata: Dictionary
-	mutex.lock()
-	if is_instance_valid(thread) and thread.is_started():
-		chunkdata = thread.wait_to_finish()
-		thread = null # Threads are reference counted, so this is how we free them.
-
+	var chunkdata: Dictionary = {}
+	await Helper.task_manager.create_task(get_chunk_data.bind(chunkdata)).completed
 	var chunkposition: Vector2 = Vector2(int(chunkdata.chunk_x/32),int(chunkdata.chunk_z/32))
 	Helper.loaded_chunk_data.chunks[chunkposition] = chunkdata
-	mutex.unlock()
 	chunk_unloaded.emit()
 
 
@@ -805,7 +733,7 @@ func generate_chunk_mesh():
 	create_colliders(chunk_mesh_body)
 	
 	update_navigation_mesh()
-	generate_chunk_mesh_finished.call_deferred()
+	#generate_chunk_mesh_finished.call_deferred()
 
 
 func setup_cube(pos: Vector3, blockrotation: int, verts, uvs, normals, indices, top_face_uv):
@@ -993,6 +921,7 @@ func get_block_rotation(shape: String, tilerotation: int = 0) -> int:
 		return myRotation-180
 	return myRotation
 
-
+# New chunks will have the id in the chunk data. In that case it returns true
+# Previously saved chunks will not have id in the data and it returns false
 func is_new_chunk() -> bool:
 	return chunk_data.has("id")

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -147,7 +147,7 @@ func generate_saved_chunk() -> void:
 		add_item_to_map(item)
 	
 	# We duplicate the furnituredata for thread safety
-	var furnituredata: Dictionary = chunk_data.furniture.duplicate()
+	var furnituredata: Array = chunk_data.furniture.duplicate()
 	await Helper.task_manager.create_task(add_furnitures_to_map.bind(furnituredata)).completed
 	await Helper.task_manager.create_task(add_mobs_to_map).completed
 

--- a/Scripts/ChunkLevel.gd
+++ b/Scripts/ChunkLevel.gd
@@ -1,12 +1,19 @@
 class_name ChunkLevel
 extends Node3D
 
+# This class is intended to be used to represent a level inside a chunk in the tacticalmap
+# A chunk can have a maximum of 21 levels, from -10 to +10
+# A level can hold a maximum of 1024 blocks using the 32x32 dimensions
+# One of the purposes of the chunklevel is to control the visibility of levels above the player
+
 var levelposition: Vector3
 var blocklist: Array
+var y: int
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	position = levelposition
+	add_to_group("maplevels")
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -89,11 +89,6 @@ func set_sprite(newSprite: Texture):
 		add_child.call_deferred(sprite)
 	var uniqueTexture = newSprite.duplicate(true) # Duplicate the texture
 	sprite.texture = uniqueTexture
-	# We need to set the alpha cut and cast shadow because a chunk will generate a mesh for the map
-	# that will have some transparancy settings that will also make the mobs transparent
-	# That's why we need to make sure only the fully transparant pixel are invisible
-	sprite.alpha_cut = SpriteBase3D.ALPHA_CUT_DISCARD
-	sprite.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
 	# Create a new SphereShape3D for the collision shape
 	var new_shape = SphereShape3D.new()

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -44,11 +44,6 @@ func set_sprite(newSprite: Texture):
 		add_child.call_deferred(sprite)
 	var uniqueTexture = newSprite.duplicate(true) # Duplicate the texture
 	sprite.texture = uniqueTexture
-	# We need to set the alpha cut and cast shadow because a chunk will generate a mesh for the map
-	# that will have some transparancy settings that will also make the mobs transparent
-	# That's why we need to make sure only the fully transparant pixel are invisible
-	sprite.alpha_cut = SpriteBase3D.ALPHA_CUT_DISCARD
-	sprite.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
 	# Calculate new dimensions for the collision shape
 	var sprite_width = newSprite.get_width()

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -23,13 +23,22 @@ const save_Helper_Class = preload("res://Scripts/Helper/save_helper.gd")
 var save_helper: Node = null
 const signal_broker_Class = preload("res://Scripts/Helper/signal_broker.gd")
 var signal_broker: Node = null
+const task_manager_Class = preload("res://Scripts/Helper/task_manager.gd")
+var task_manager: Node = null
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	json_helper = json_Helper_Class.new()
 	save_helper = save_Helper_Class.new()
 	signal_broker = signal_broker_Class.new()
+	task_manager = task_manager_Class.new()
 	add_child(save_helper)
+
+
+func _process(_delta: float) -> void:
+	# task_manager can't _process on it's own so we call it from here
+	task_manager._process(_delta)
+
 
 # Called when the game is over and everything will need to be reset to default
 func reset():

--- a/Scripts/Helper/task_manager.gd
+++ b/Scripts/Helper/task_manager.gd
@@ -1,0 +1,72 @@
+extends Node
+
+# This is a helper script that manages tasks that can be used to offload work to a thread
+# To use this task manager you can use:
+# var task = Helper.task_manager.create_task(do_work)
+# await task.completed
+# This allows you to sequentially perform tasks while not blocking the main thread
+# From https://gist.github.com/mashumafi/fced71eaf2ac3f90c158fd05d21379a3
+# https://www.youtube.com/watch?v=Sz9cEJ4l_Yk
+
+class Task:
+	var id : int
+
+	signal completed
+
+	func _init(id: int):
+		self.id = id
+
+	func get_processed_element_count() -> int:
+		return 1 if is_completed() else 0
+
+	func is_completed() -> bool:
+		return WorkerThreadPool.is_task_completed(self.id)
+
+	func wait() -> void:
+		WorkerThreadPool.wait_for_task_completion(self.id)
+
+
+class GroupTask:
+	extends Task
+
+	func get_processed_element_count() -> int:
+		return WorkerThreadPool.get_group_processed_element_count(self.id)
+
+	func is_completed() -> bool:
+		return WorkerThreadPool.is_group_task_completed(self.id)
+
+	func wait() -> void:
+		WorkerThreadPool.wait_for_group_task_completion(self.id)
+
+var tasks := []
+var mutex := Mutex.new()
+
+func create_task(action: Callable, high_priority := false, description := "") -> Task:
+	var task_id := WorkerThreadPool.add_task(action, high_priority, description)
+	var task := Task.new(task_id)
+	mutex.lock()
+	tasks.append(task)
+	mutex.unlock()
+	return task
+
+
+func create_group_task(action: Callable, elements : int, tasks_needed := -1, high_priority := false, description := "") -> GroupTask:
+	var group_task_id := WorkerThreadPool.add_group_task(action, elements, tasks_needed, high_priority, description)
+	var group_task := GroupTask.new(group_task_id)
+	mutex.lock()
+	tasks.append(group_task)
+	mutex.unlock()
+	return group_task
+
+func _process(_delta: float) -> void:
+	mutex.lock()
+	var completed_tasks := tasks.filter(
+		func completed(task: Task):
+			return task.is_completed()
+	)
+
+	for completed_task in completed_tasks:
+		var task : Task = completed_task
+		task.completed.emit()
+		tasks.erase(task)
+	mutex.unlock()

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -89,10 +89,7 @@ func set_sprite(newSprite: Resource):
 	var new_mesh = original_mesh.duplicate()  # Clone the mesh
 	var material := StandardMaterial3D.new()
 	material.albedo_texture = newSprite
-	# We use TRANSPARENCY_ALPHA_DEPTH_PRE_PASS because a chunk will generate a mesh for the map
-	# that will have some transparancy settings that will also make the mobs transparent
-	# That's why we need to make sure only the fully transparant pixel are invisible
-	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA_DEPTH_PRE_PASS
+	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
 	new_mesh.surface_set_material(0, material)
 	meshInstance.mesh = new_mesh  # Set the new mesh to MeshInstance3D
 

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -58,12 +58,6 @@ func create_sprite():
 	sprite_3d.texture_filter = BaseMaterial3D.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
 	sprite_3d.render_priority = 0
 	sprite_3d.texture = load("res://Textures/enemy.png")
-	
-	# We use SpriteBase3D.ALPHA_CUT_DISCARD because a chunk will generate a mesh for the map
-	# that will have some transparancy settings that will also make the container transparent
-	# That's why we need to make sure only the fully transparant pixel are invisible
-	sprite_3d.alpha_cut = SpriteBase3D.ALPHA_CUT_DISCARD
-	sprite_3d.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
 	# Add to the scene tree
 	add_child.call_deferred(sprite_3d)

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -129,16 +129,12 @@ spot_angle_attenuation = 0.183011
 
 [node name="Sprite3D2" type="Sprite3D" parent="TacticalMap/Entities/Player"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
-cast_shadow = 0
 pixel_size = 0.002
-alpha_cut = 1
 texture = ExtResource("10_ghgoh")
 
 [node name="EquippedRight" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "shoot_audio_player", "reload_audio_player")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.190849, -0.123334, 0)
-cast_shadow = 0
 pixel_size = 0.002
-alpha_cut = 1
 texture = ExtResource("10_3jjqt")
 script = ExtResource("12_xwnuw")
 projectiles = NodePath("../../../Projectiles")
@@ -154,9 +150,7 @@ reload_audio_player = NodePath("../../Shooting/ReloadAudio")
 
 [node name="EquippedLeft" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "shoot_audio_player", "reload_audio_player")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.194626, 0.116675, 0)
-cast_shadow = 0
 pixel_size = 0.002
-alpha_cut = 1
 texture = ExtResource("11_4n80n")
 script = ExtResource("12_xwnuw")
 projectiles = NodePath("../../../Projectiles")


### PR DESCRIPTION
Requires #75 to work.

Chunks are still loaded and unloaded one by one, but multiple chunks can be loaded somewhat at the same time. What happens is that the levelgenerator will load a chunk, and when it's ready and does some basic stuff, it will signal that it's partially loaded and the next chunk can start loading.

I also increased the chunk loading radius from 1 to 2 and the unloading radius from 2 to 3. This means we play in a bigger area, which could impact memory. The benefit is that it is more seamless.

It still runs well even when I set the player speed to 4 instead of 1. 

I did try simultaneous loading and unloading of chunks, but this leads to stuttering. The profiler shows about 120 ms on physic process at the peak which is noticable. I think this is because of the collision shapes of the blocks and furniture. I tried to spread out the unloading of physics shapes for blocks, but somehow the stuttering became worse. This could be because the amount of unloading calls makes it stutter. When one chunk is unloaded in a single moment, it takes less unloading calls then when each separate collision shape is loaded over multiple frames?

The game runs okay now so this will be it for now in with regards to chunks. We can optimize more:
- use the physicsserver to attempt creation and destruction of physicsshapes on a thread (for blocks and furniture)
- Try to spread out the destruction of furniture when unloading a chunk
- Use object pooling so destruction is not needed as much
- Somehow merge collision shapes for blocks so fewer collisionshapes are added. Probably not an option if this prevents determining where the user wants to place a new block during construction