### PR TITLE
Rotate chunks on the tactical map

### DIFF
--- a/Defaults/Blocks/Materials/construction_ghost_material.tres
+++ b/Defaults/Blocks/Materials/construction_ghost_material.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://ot2fpooebty0"]
+
+[ext_resource type="Texture2D" uid="uid://bpjkd6sssic7b" path="res://Mods/Core/Tiles/2.png" id="1_2cd6c"]
+
+[resource]
+albedo_color = Color(0, 0.768627, 0.768627, 0.545098)
+albedo_texture = ExtResource("1_2cd6c")
+uv1_scale = Vector3(3, 2, 1)

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -202,3 +202,31 @@ func process_next_chunk():
 		var chunk_pos = unload_queue.pop_front()
 		is_processing_chunk = true
 		unload_chunk(chunk_pos)
+
+
+# Returns the chunk instance at the given position
+# chunk_pos starts at 0,0 and increaes like 0,1, 0,2 ... 4,4, 4,5 etc.
+func get_chunk(chunk_pos: Vector2) -> Chunk:
+	if loaded_chunks.has(chunk_pos):
+		return loaded_chunks[chunk_pos]
+	else:
+		# Handle the case where the chunk is not found.
+		print_debug("Chunk at position ", chunk_pos, " not found.")
+		return null
+
+
+# Returns the chunk instance at the given position
+# chunk_pos starts at 0,0 and increaes like 0,32, 0,64 ... 96,0, 96,32 etc.
+func get_global_chunk(chunk_pos: Vector2) -> Chunk:
+	# Convert global position to chunk index
+	var chunk_index = chunk_pos / Vector2(level_width, level_height)
+	chunk_index = chunk_index.floor()  # Ensure index is an integer vector
+	return get_chunk(chunk_index)
+
+
+# Returns which chunk the mob is in right now
+# position_in_3d_space can be any position, like 12,2,6 or 139,-6,14
+func get_chunk_from_position(position_in_3d_space: Vector3) -> Chunk:
+	var chunk_x = floor(position_in_3d_space.x / 32) * 32
+	var chunk_z = floor(position_in_3d_space.z / 32) * 32
+	return get_global_chunk(Vector2(chunk_x, chunk_z))

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditor.gd
@@ -4,6 +4,7 @@ extends Control
 @export var tileGrid: GridContainer = null
 @export var mapwidthTextEdit: TextEdit = null
 @export var mapheightTextEdit: TextEdit = null
+@export var panWindow: Control = null
 
 var tileSize: int = 128
 var mapHeight: int = 3
@@ -12,19 +13,70 @@ var contentSource: String = "":
 	set(newSource):
 		contentSource = newSource
 		tileGrid.load_tacticalmap_json_file()
+		
+
 
 # In tacticalmapeditor.gd
 func _ready() -> void:
 	# Connect the signal from TileGrid to this script
 	tileGrid.connect("map_dimensions_changed",_on_map_dimensions_changed)
+	setPanWindowSize()
+
 
 func _on_map_height_text_changed() -> void:
 	mapHeight = int(mapheightTextEdit.text)
 	tileGrid.resetGrid()
+	setPanWindowSize()
+
 
 func _on_map_width_text_changed() -> void:
 	mapWidth = int(mapwidthTextEdit.text)
 	tileGrid.resetGrid()
+	setPanWindowSize()
+
+
+
+func setPanWindowSize():
+	var minSize: int = 512  # Minimum size for either width or height
+	var maxSize: int = 2048  # Maximum size to prevent it from being too big
+
+	# Calculate base sizes from tile size and map dimensions
+	var baseWidth: float = tileSize * mapWidth
+	var baseHeight: float = tileSize * mapHeight
+
+	# Apply a scaling factor that diminishes the added size per tile
+	var scalingFactor: float = 0.75  # Adjust this factor based on desired growth rate
+	var adjustedWidth: float = minSize + (baseWidth - minSize) * scalingFactor
+	var adjustedHeight: float = minSize + (baseHeight - minSize) * scalingFactor
+
+	# Clamp values between minimum and maximum sizes
+	var finalWidth: float = clamp(adjustedWidth, minSize, maxSize)
+	var finalHeight: float = clamp(adjustedHeight, minSize, maxSize)
+
+	# Set the custom minimum size for the panWindow using the calculated dimensions
+	panWindow.custom_minimum_size = Vector2(finalWidth, finalHeight)
+
+	# Ensure the tileGrid's size respects the map dimensions ratio
+	var gridWidth: float = mapWidth * tileSize
+	var gridHeight: float = mapHeight * tileSize
+	var aspectRatio: float = gridWidth / gridHeight
+
+	# Calculate max dimensions for the tileGrid based on panWindow dimensions
+	var maxGridWidth: float = finalWidth * 0.9
+	var maxGridHeight: float = finalHeight * 0.9
+
+	# Adjust grid size respecting aspect ratio
+	if aspectRatio > 1:
+		# Width is the limiting factor
+		maxGridHeight = min(maxGridHeight, maxGridWidth / aspectRatio)
+	else:
+		# Height is the limiting factor
+		maxGridWidth = min(maxGridWidth, maxGridHeight * aspectRatio)
+
+	# Set the custom minimum size for the tileGrid
+	tileGrid.custom_minimum_size = Vector2(maxGridWidth, maxGridHeight)
+
+
 
 #The editor is closed, destroy the instance
 #TODO: Check for unsaved changes

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTile.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTile.gd
@@ -16,6 +16,7 @@ var tileData: Dictionary = defaultTileData.duplicate():
 			$TileSprite.texture = load(defaultTexture)
 signal tile_clicked(clicked_tile: Control)
 
+
 func _on_texture_rect_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		match event.button_index:
@@ -23,12 +24,19 @@ func _on_texture_rect_gui_input(event: InputEvent) -> void:
 				if event.pressed:
 					tile_clicked.emit(self)
 
+
 func set_rotation_amount(amount: int) -> void:
+	$TileSprite.pivot_offset = size / 2
 	$TileSprite.rotation_degrees = amount
-	tileData.rotation = amount
-	
+	if amount == 0:
+		tileData.erase("rotation")
+	else:
+		tileData.rotation = amount
+
+
 func get_rotation_amount() -> int:
 	return $TileSprite.rotation_degrees
+
 
 func set_tile_id(id: String) -> void:
 	if id == "":
@@ -38,23 +46,33 @@ func set_tile_id(id: String) -> void:
 		tileData.id = id
 		$TileSprite.texture = Gamedata.data.maps.sprites[id.replace("json", "png")]
 
+
 func _on_texture_rect_mouse_entered() -> void:
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 		tile_clicked.emit(self)
 
+
 func set_default() -> void:
 	tileData = defaultTileData.duplicate()
+
 
 func highlight() -> void:
 	$TileSprite.modulate = Color(0.227, 0.635, 0.757)
 
+
 func unhighlight() -> void:
 	$TileSprite.modulate = Color(1,1,1)
+
 
 func set_clickable(clickable: bool):
 	if !clickable:
 		mouse_filter = MOUSE_FILTER_IGNORE
 		$TileSprite.mouse_filter = MOUSE_FILTER_IGNORE
 
+
 func get_tile_texture():
 	return $TileSprite.texture
+
+
+func _on_tile_sprite_resized():
+	$TileSprite.pivot_offset = size / 2

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TileGrid.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TileGrid.gd
@@ -128,3 +128,11 @@ func loadLevel():
 
 func _on_entities_container_tile_brush_selection_change(tilebrush):
 	selected_brush = tilebrush
+
+
+# The user has pressed the rotate right button on the toolbar
+# We need to set the rotation so that the brush will apply rotation to the tile
+func _on_rotate_right_pressed():
+	rotationAmount += 90
+	rotationAmount = rotationAmount % 360 # Keep rotation within 0-359 degrees
+	buttonRotateRight.text = str(rotationAmount)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditor.tscn
@@ -26,7 +26,7 @@ unicode = 114
 [sub_resource type="Shortcut" id="Shortcut_hehp2"]
 events = [SubResource("InputEventKey_nrfa0")]
 
-[node name="TacticalMapEditor" type="Control" node_paths=PackedStringArray("tileGrid", "mapwidthTextEdit", "mapheightTextEdit")]
+[node name="TacticalMapEditor" type="Control" node_paths=PackedStringArray("tileGrid", "mapwidthTextEdit", "mapheightTextEdit", "panWindow")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -34,9 +34,10 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_bfw3n")
-tileGrid = NodePath("HSplitContainer/MapeditorContainer/HBoxContainer/TileGrid")
+tileGrid = NodePath("HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid")
 mapwidthTextEdit = NodePath("HSplitContainer/MapeditorContainer/Toolbar/MapWidth")
 mapheightTextEdit = NodePath("HSplitContainer/MapeditorContainer/Toolbar/MapHeight")
+panWindow = NodePath("HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow")
 
 [node name="HSplitContainer" type="HSplitContainer" parent="."]
 layout_mode = 1
@@ -118,16 +119,34 @@ theme_override_icons/unchecked = ExtResource("6_w0gff")
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="TileGrid" type="GridContainer" parent="HSplitContainer/MapeditorContainer/HBoxContainer" node_paths=PackedStringArray("mapEditor", "buttonRotateRight")]
+[node name="MapScrollWindow" type="ScrollContainer" parent="HSplitContainer/MapeditorContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.95
+
+[node name="PanWindow" type="ColorRect" parent="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow"]
+custom_minimum_size = Vector2(500, 500)
+layout_mode = 2
+color = Color(0.596078, 0.341176, 0.701961, 1)
+
+[node name="TileGrid" type="GridContainer" parent="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow" node_paths=PackedStringArray("mapEditor", "buttonRotateRight")]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 theme_override_constants/h_separation = 0
 theme_override_constants/v_separation = 0
 columns = 3
 script = ExtResource("7_ji7x2")
 tileScene = ExtResource("8_pt28t")
-mapEditor = NodePath("../../../..")
-buttonRotateRight = NodePath("../../Toolbar/RotateRight")
+mapEditor = NodePath("../../../../../..")
+buttonRotateRight = NodePath("../../../../Toolbar/RotateRight")
 
 [node name="EntitiesContainer" type="VBoxContainer" parent="HSplitContainer"]
 layout_mode = 2
@@ -138,7 +157,8 @@ scrolling_Flow_Container = ExtResource("10_lnsqy")
 tileBrush = ExtResource("11_bh5ke")
 
 [connection signal="button_up" from="HSplitContainer/MapeditorContainer/Toolbar/CloseButton" to="." method="_on_close_button_button_up"]
-[connection signal="button_up" from="HSplitContainer/MapeditorContainer/Toolbar/SaveButton" to="HSplitContainer/MapeditorContainer/HBoxContainer/TileGrid" method="save_map_json_file"]
+[connection signal="button_up" from="HSplitContainer/MapeditorContainer/Toolbar/SaveButton" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="save_map_json_file"]
 [connection signal="text_changed" from="HSplitContainer/MapeditorContainer/Toolbar/MapWidth" to="." method="_on_map_width_text_changed"]
 [connection signal="text_changed" from="HSplitContainer/MapeditorContainer/Toolbar/MapHeight" to="." method="_on_map_height_text_changed"]
-[connection signal="tile_brush_selection_change" from="HSplitContainer/EntitiesContainer" to="HSplitContainer/MapeditorContainer/HBoxContainer/TileGrid" method="_on_entities_container_tile_brush_selection_change"]
+[connection signal="pressed" from="HSplitContainer/MapeditorContainer/Toolbar/RotateRight" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="_on_rotate_right_pressed"]
+[connection signal="tile_brush_selection_change" from="HSplitContainer/EntitiesContainer" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="_on_entities_container_tile_brush_selection_change"]

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditorTile.tscn
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditorTile.tscn
@@ -6,9 +6,11 @@
 [node name="TacticalMapEditorTile" type="Control"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 3
-anchors_preset = 0
-offset_right = 128.0
-offset_bottom = 128.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_jobrn")
@@ -20,7 +22,9 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+pivot_offset = Vector2(64, 64)
 texture = ExtResource("2_gashh")
 expand_mode = 3
 
 [connection signal="gui_input" from="TileSprite" to="." method="_on_texture_rect_gui_input"]
+[connection signal="resized" from="TileSprite" to="." method="_on_tile_sprite_resized"]

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -32,12 +32,14 @@ var tileData: Dictionary = defaultTileData.duplicate():
 			$MobFurnitureSprite.hide()
 signal tile_clicked(clicked_tile: Control)
 
+
 func _on_texture_rect_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		match event.button_index:
 			MOUSE_BUTTON_LEFT:
 				if event.pressed:
 					tile_clicked.emit(self)
+
 
 func set_rotation_amount(amount: int) -> void:
 	$TileSprite.rotation_degrees = amount
@@ -46,12 +48,15 @@ func set_rotation_amount(amount: int) -> void:
 	else:
 		tileData.rotation = amount
 
+
 func get_rotation_amount() -> int:
 	return $TileSprite.rotation_degrees
+
 
 func set_scale_amount(scaleAmount: int) -> void:
 	custom_minimum_size.x = scaleAmount
 	custom_minimum_size.y = scaleAmount
+
 
 func set_tile_id(id: String) -> void:
 	if id == "":
@@ -60,6 +65,7 @@ func set_tile_id(id: String) -> void:
 	else:
 		tileData.id = id
 		$TileSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.tiles, id).albedo_texture
+
 
 func set_mob_id(id: String) -> void:
 	if id == "":
@@ -76,6 +82,7 @@ func set_mob_id(id: String) -> void:
 		$MobFurnitureSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.mobs, id)
 		$MobFurnitureSprite.show()
 
+
 func set_furniture_id(id: String) -> void:
 	if id == "":
 		tileData.erase("furniture")
@@ -91,13 +98,15 @@ func set_furniture_id(id: String) -> void:
 		$MobFurnitureSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture, id)
 		$MobFurnitureSprite.show()
 
+
 func set_mob_rotation(rotationDegrees):
 	$MobFurnitureSprite.rotation_degrees = rotationDegrees
 	if rotationDegrees == 0:
 		tileData.mob.erase("rotation")
 	else:
 		tileData.mob.rotation = rotationDegrees
-		
+
+
 func set_furniture_rotation(rotationDegrees):
 	$MobFurnitureSprite.rotation_degrees = rotationDegrees
 	if rotationDegrees == 0:
@@ -105,24 +114,30 @@ func set_furniture_rotation(rotationDegrees):
 	else:
 		tileData.furniture.rotation = rotationDegrees
 
+
 func _on_texture_rect_mouse_entered() -> void:
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 		tile_clicked.emit(self)
 
+
 func set_default() -> void:
 	tileData = defaultTileData.duplicate()
+
 
 func highlight() -> void:
 	$TileSprite.modulate = Color(0.227, 0.635, 0.757)
 
+
 func unhighlight() -> void:
 	$TileSprite.modulate = Color(1,1,1)
+
 
 func set_clickable(clickable: bool):
 	if !clickable:
 		mouse_filter = MOUSE_FILTER_IGNORE
 		$TileSprite.mouse_filter = MOUSE_FILTER_IGNORE
 		$MobFurnitureSprite.mouse_filter = MOUSE_FILTER_IGNORE
+
 
 #This function sets the texture to some static resource that helps the user visualize that something is above
 #If this tile has a texture in its data, set it to the above texture instead
@@ -134,9 +149,11 @@ func set_above():
 	else:
 		$TileSprite.texture = null
 
+
 func _on_texture_rect_resized():
 	$TileSprite.pivot_offset = size / 2
 	$MobFurnitureSprite.pivot_offset = size / 2
+
 
 func get_tile_texture():
 	return $TileSprite.texture

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -3,7 +3,7 @@ extends Node3D
 @export var construction_ghost : MeshInstance3D
 var is_building = false
 
-@export var player_path: NodePath
+@export var LevelGenerator: Node3D
 @export var hud : NodePath
 
 # Called when the node enters the scene tree for the first time.
@@ -46,5 +46,10 @@ func _on_hud_construction_chosen(_construction: String):
 	is_building = true
 	General.is_allowed_to_shoot = false
 
+
 func on_construction_clicked(construction_data: Dictionary):
-	print_debug("Block placed at: ", construction_data.pos, "with type ", construction_data.id)
+	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
+	if chunk:
+		chunk.add_block(construction_data.id,construction_data.pos)
+		print_debug("Block placed at: ", construction_data.pos, " with type ", construction_data.id)
+

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -1,17 +1,9 @@
 extends Node3D
 
-@export var tile_map_path : NodePath
-var tile_map : TileMap
-
-@export var ghost_sprite_path : NodePath
-var ghost_sprite : Sprite2D
-
+@export var construction_ghost : MeshInstance3D
 var is_building = false
 
-var build_range = 30
-
 @export var player_path: NodePath
-
 @export var hud : NodePath
 
 # Called when the node enters the scene tree for the first time.
@@ -27,7 +19,7 @@ func _ready():
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	if is_building:
-		ghost_sprite.visible = true
+		construction_ghost.visible = true
 		
 		# 3d
 #		ghost_sprite.global_position = get_global_mouse_position()
@@ -44,7 +36,7 @@ func _input(_event):
 	if Input.is_action_pressed("click_right") && is_building:
 		is_building = false
 		General.is_allowed_to_shoot = true
-		ghost_sprite.visible = false
+		construction_ghost.visible = false
 
 func make_tile_ghost():
 	pass
@@ -53,3 +45,6 @@ func _on_hud_construction_chosen(_construction: String):
 	print("Building test")
 	is_building = true
 	General.is_allowed_to_shoot = false
+
+func on_construction_clicked(construction_data: Dictionary):
+	print_debug("Block placed at: ", construction_data.pos, "with type ", construction_data.id)

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -8,6 +8,8 @@ var is_building = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	# Connect the build menu visibility_changed signal to a local method
+	Helper.signal_broker.build_window_visibility_changed.connect(_on_build_menu_visibility_change)
 #	tile_map = get_node(tile_map_path)
 	
 	#3D
@@ -53,3 +55,11 @@ func on_construction_clicked(construction_data: Dictionary):
 		chunk.add_block(construction_data.id,construction_data.pos)
 		print_debug("Block placed at: ", construction_data.pos, " with type ", construction_data.id)
 
+
+# Respond to visibility changes of this node
+func _on_build_menu_visibility_change(buildmenu):
+	if !is_building:
+		return
+	# Set the visibility of the construction_ghost to match the building menu's visibility
+	construction_ghost.visible = buildmenu.is_visible()
+	is_building = buildmenu.is_visible()

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -73,7 +73,7 @@ func initialize_chunk_data():
 		#This contains the data of one segment, loaded from maps.data, for example generichouse.json
 		var mapsegmentData: Dictionary = Helper.json_helper.load_json_dictionary_file(\
 			Gamedata.data.maps.dataPath + chunk_data.id)
-		if mapsegmentData.has("rotation") and not mapsegmentData.rotation == 0:
+		if chunk_data.has("rotation") and not chunk_data.rotation == 0:
 			rotate_map(mapsegmentData)
 		_mapleveldata = mapsegmentData.levels
 		generate_new_chunk()
@@ -1083,9 +1083,15 @@ func setup_cube(pos: Vector3, blockrotation: int, verts, uvs, normals, indices, 
 # This function will loop over all levels and rotate them if they contain tile data.
 
 func rotate_map(mapsegmentData: Dictionary) -> void:
+	var rotationdegrees = int(chunk_data.get("rotation", 0)) % 360  # Ensure rotation is a valid degree
+
+	var num_rotations = rotationdegrees / 90  # Determine how many 90-degree rotations are needed
+
 	for i in range(len(mapsegmentData.levels)):
-		var level_data = mapsegmentData.levels[i]
-		mapsegmentData.levels[i] = rotate_level_clockwise(level_data)
+		var current_level = mapsegmentData.levels[i]
+		for _y in range(num_rotations):  # Apply 90-degree rotation multiple times
+			current_level = rotate_level_clockwise(current_level)
+		mapsegmentData.levels[i] = current_level
 
 
 # Function to rotate a single level's data 90 degrees clockwise

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -73,6 +73,8 @@ func initialize_chunk_data():
 		#This contains the data of one segment, loaded from maps.data, for example generichouse.json
 		var mapsegmentData: Dictionary = Helper.json_helper.load_json_dictionary_file(\
 			Gamedata.data.maps.dataPath + chunk_data.id)
+		if mapsegmentData.has("rotation") and not mapsegmentData.rotation == 0:
+			rotate_map(mapsegmentData)
 		_mapleveldata = mapsegmentData.levels
 		generate_new_chunk()
 	else: # This chunk is created from previously saved data
@@ -341,8 +343,8 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 	
 	var total_furniture = furnitureDataArray.size()
 	 # Ensure we at least get 1 to avoid division by zero
-	#var delay_every_n_furniture = max(1, total_furniture / 15)
-	var delay_every_n_furniture = max(1, int(total_furniture / 15))
+	var delay_every_n_furniture = max(1, int(float(total_furniture) / 15.0))
+
 	for i in range(total_furniture):
 		var furnitureData = furnitureDataArray[i]
 		mutex.lock()
@@ -1075,3 +1077,43 @@ func setup_cube(pos: Vector3, blockrotation: int, verts, uvs, normals, indices, 
 		back_base_index, back_base_index + 1, back_base_index + 2,
 		back_base_index, back_base_index + 2, back_base_index + 3
 	])
+
+
+
+# This function will loop over all levels and rotate them if they contain tile data.
+
+func rotate_map(mapsegmentData: Dictionary) -> void:
+	for i in range(len(mapsegmentData.levels)):
+		var level_data = mapsegmentData.levels[i]
+		mapsegmentData.levels[i] = rotate_level_clockwise(level_data)
+
+
+# Function to rotate a single level's data 90 degrees clockwise
+func rotate_level_clockwise(level_data: Array) -> Array:
+	if level_data.size() == 0:
+		return level_data
+
+	var new_level_data: Array[Dictionary] = []
+	# Initialize new_level_data with empty dictionaries
+	for i in range(LEVEL_WIDTH * LEVEL_HEIGHT):
+		new_level_data.append({})
+
+	for y in range(LEVEL_HEIGHT):
+		for x in range(LEVEL_WIDTH):
+			var old_index = y * LEVEL_WIDTH + x
+			var new_x = LEVEL_HEIGHT - y - 1
+			var new_y = x
+			var new_index = new_y * LEVEL_WIDTH + new_x
+			new_level_data[new_index] = level_data[old_index].duplicate(true)
+
+			# Add rotation to the tile's data if it has an "id"
+			if new_level_data[new_index].has("id"):
+				var tile_rotation = int(new_level_data[new_index].get("rotation", 0))
+				new_level_data[new_index]["rotation"] = (tile_rotation + 90) % 360
+			
+			# Rotate furniture if present, initializing rotation to 0 if not set
+			if new_level_data[new_index].has("furniture"):
+				var furniture_rotation = int(new_level_data[new_index]["furniture"].get("rotation", 0))
+				new_level_data[new_index]["furniture"]["rotation"] = (furniture_rotation + 90) % 360
+
+	return new_level_data

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -698,7 +698,7 @@ func generate_chunk_mesh():
 	# Set collision mask to layer 1
 	chunk_mesh_body.collision_mask = 1 # Layer 1 is 1
 	add_child.call_deferred(chunk_mesh_body)
-	create_colliders(chunk_mesh_body)
+	create_colliders()
 	
 	update_navigation_mesh()
 	#generate_chunk_mesh_finished.call_deferred()
@@ -804,7 +804,7 @@ func setup_slope(blockrotation: int, pos: Vector3, verts, uvs, normals, indices,
 
 
 # Coroutine for creating colliders with non-blocking delays
-func create_colliders(static_body: StaticBody3D) -> void:
+func create_colliders() -> void:
 	var total_blocks = block_positions.size()
 	# Ensure we at least get 1 to avoid division by zero. Aim for a maximum of 15 steps.
 	var delay_every_n_blocks = max(1, total_blocks / 15)
@@ -816,7 +816,7 @@ func create_colliders(static_body: StaticBody3D) -> void:
 		var block_data = block_positions[key]
 		var block_shape = block_data.get("shape", "cube")
 		var block_rotation = block_data.get("rotation", 0)
-		static_body.add_child.call_deferred(_create_block_collider(block_pos, block_shape, block_rotation))
+		chunk_mesh_body.add_child.call_deferred(_create_block_collider(block_pos, block_shape, block_rotation))
 
 		block_counter += 1
 		# Check if it's time to delay
@@ -903,16 +903,19 @@ func add_block(block_id: String, block_position: Vector3):
 	# Generate a key for the new block position
 	var block_key = "%s,%s,%s" % [block_position.x, block_position.y, block_position.z]
 	
-	# Update block_positions with the new block
+	# Update block_positions with the new block data
 	block_positions[block_key] = {
 		"id": block_id,
-		"rotation": 0,  # Default rotation of 0; implement rotation later
+		"rotation": 0,  # Assume default rotation; adjust if necessary
 	}
 	
-	# Regenerate mesh and update navigation and collision for the affected level
+	# Regenerate mesh for the affected level
 	generate_chunk_mesh_for_level(int(block_position.y))
 	update_navigation_mesh()
-	# You might want to call a specific function to update colliders if necessary
+	
+	# Create and add a new collider for the block
+	var new_collider = _create_block_collider(block_position, "cube", 0)  # Cube shape; rotation 0
+	chunk_mesh_body.add_child.call_deferred(new_collider)
 
 
 # Adjusted to accept atlas data directly

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -933,6 +933,9 @@ func generate_chunk_mesh_for_level(y_level: int):
 			level_nodes[y_level] = level_node
 
 
+# Rebuilds the navigationmesh for all blocks in the chunk
+# We can't do this for a specific level, since we have 1 navigationmesh
+# If we had multiple navigationmeshes, we could create one per level, which is more optimized
 func update_all_navigation_data():
 	for key in block_positions.keys():
 		var block_data: Dictionary = block_positions[key]
@@ -946,6 +949,22 @@ func update_all_navigation_data():
 	update_navigation_mesh()
 
 
+# Creates the vertices for a mesh that makes up a cube
+# Couldn't get it to work with a for-loop, so every side is explicitly defined
+# TODO: instead of making all the faces, only add them if there is no neighboring cube
+# We can do this by checking the neighbor:
+	# Directions corresponding to the faces
+	#var directions = [
+		#Vector3(0, 0, -1), # Front
+		#Vector3(1, 0, 0),  # Right
+		#Vector3(0, 0, 1),  # Back
+		#Vector3(-1, 0, 0), # Left
+		#Vector3(0, 1, 0),  # Top
+	#]
+	#var neighbor_pos = pos + directions[i]
+	#var neighbor_key = "%s,%s,%s" % [neighbor_pos.x, neighbor_pos.y, neighbor_pos.z]
+	#if not block_positions.has(neighbor_key): # Check if there is no block at the neighbor position
+# If it does not have a neighbor, we would add the face.
 func setup_cube(pos: Vector3, blockrotation: int, verts, uvs, normals, indices, top_face_uv):
 	var half_block = 0.5
 

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -871,12 +871,22 @@ func add_block(block_id: String, block_position: Vector3):
 	# Generate a key for the new block position
 	var block_key = "%s,%s,%s" % [block_position.x, block_position.y, block_position.z]
 	
+	# Check if the block already exists
+	if block_positions.has(block_key):
+		print_debug("Block at position ", block_key, " already exists.")
+		return # Exit the function if the block already exists
+	
 	# Update block_positions with the new block data
 	block_positions[block_key] = {
 		"id": block_id,
 		"rotation": 0,  # Assume default rotation; adjust if necessary
 	}
 	
+	# We have to refresh the atlas because the player may introduce a new block ID
+	# TODO: Optimization potential: we can check if the atlas needs an update by checking
+	# if the block id is present in the material_to_blocks variable in the create_atlas function.
+	# Obviously we need access to the material_to_blocks variable and keep it's value persistent.
+	atlas_output = create_atlas()
 	# Regenerate mesh for the affected level
 	generate_chunk_mesh_for_level(int(block_position.y))
 	# Update the navigation data based on all blocks

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -1,0 +1,60 @@
+extends MeshInstance3D
+
+# Reference to the player node
+@export var player: Node3D
+@export var sceneCam: Camera3D
+@export var buildmanager: Node3D
+
+# Settings
+var grid_size = 1.0
+var y_offset = 1.0  # This is the y-coordinate offset relative to the player's position
+var build_range = 5.0  # Maximum build range from the player
+var construction_data: Dictionary
+
+signal construction_clicked(data: Dictionary)
+
+func _ready():
+	construction_clicked.connect(buildmanager.on_construction_clicked)
+
+
+func _process(_delta):
+	if !visible:
+		return
+	var mouse_position = sceneCam.project_position(get_viewport().get_mouse_position(), sceneCam.global_transform.origin.z)
+	
+	# Calculate the raw x, y, and z positions
+	var raw_x = mouse_position.x
+	var raw_z = mouse_position.z
+	var raw_y = player.global_position.y + y_offset  # Adjust y by a fixed offset
+	
+	# Limit x and z to be within the build range from the player before snapping
+	var x_diff = raw_x - player.global_position.x
+	var z_diff = raw_z - player.global_position.z
+	
+	if x_diff > build_range:
+		raw_x = player.global_position.x + build_range
+	elif x_diff < -build_range:
+		raw_x = player.global_position.x - build_range
+		
+	if z_diff > build_range:
+		raw_z = player.global_position.z + build_range
+	elif z_diff < -build_range:
+		raw_z = player.global_position.z - build_range
+	
+	# Snap the adjusted positions to the grid
+	var snapped_x = floor(raw_x / grid_size) * grid_size
+	var snapped_z = floor(raw_z / grid_size) * grid_size
+	var snapped_y = floor(raw_y / grid_size) * grid_size  # Snap y-position
+	
+	# Assign the snapped positions
+	var snapped_position = Vector3(snapped_x, snapped_y, snapped_z)
+	global_transform.origin = snapped_position
+
+
+func _input(event):
+	if !visible:
+		return
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		construction_data = {"pos": global_transform.origin, "id": "concrete_00"}
+		emit_signal("construction_clicked", construction_data)
+		#construction_clicked.emit()

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -7,7 +7,7 @@ extends MeshInstance3D
 
 # Settings
 var grid_size = 1.0
-var y_offset = 1.0  # This is the y-coordinate offset relative to the player's position
+var y_offset = 0.0  # This is the y-coordinate offset relative to the player's position
 var build_range = 5.0  # Maximum build range from the player
 var construction_data: Dictionary
 
@@ -57,4 +57,3 @@ func _input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		construction_data = {"pos": global_transform.origin, "id": "concrete_00"}
 		emit_signal("construction_clicked", construction_data)
-		#construction_clicked.emit()

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -46,7 +46,6 @@ var mouse_press_position: Vector2 = Vector2()
 var selection_state_changed: bool = false
 
 
-
 # Signals for context menu actions
 signal equip_left(items)
 signal equip_right(items)
@@ -66,6 +65,7 @@ func initialize_list():
 # Function to show context menu at specified position
 func show_context_menu(myposition: Vector2):
 	# Create a small Rect2i around the position
+	# We need this because the popup function requires it
 	var popup_rect = Rect2i(int(myposition.x), int(myposition.y), 1, 1)
 	context_menu.popup(popup_rect)
 
@@ -171,7 +171,17 @@ func _add_header_row_to_grid():
 	_create_header("F") # Favorite
 
 
+# When the user right-clicks on one of the inventory items
 func _on_item_right_clicked(clickedItem: Control):
+	var row_name = _get_row_name(clickedItem)
+	
+	# Check if any item is selected
+	if get_selected_inventory_items().size() == 0:
+		# If no item is selected, select the clicked item
+		_deselect_all_items()
+		_toggle_row_selection(row_name, true)
+
+	# Show context menu at the global position of the clicked item
 	show_context_menu(clickedItem.global_position)
 
 

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -5,6 +5,8 @@ var current_level_name : String
 var ready_to_switch_level: Dictionary = {"save_ready": false, "chunks_unloaded": false}
 # Dictionary to hold data of chunks that are unloaded
 var loaded_chunk_data = {"chunks": {}, "mapheight": 0, "mapwidth": 0} 
+# Contains the navigationmap for each chunk, used to give mobs the proper navigationmap
+# When crossing chunk boundary
 var chunk_navigation_maps: Dictionary = {}
 
 # Overmap data
@@ -57,6 +59,7 @@ func reset():
 		item.remove_from_group("mapitems")
 		item.queue_free()
 
+
 #Level_name is a filename in /mods/core/maps
 #global_pos is the absolute position on the overmap
 #see overmap.gd for how global_pos is used there
@@ -80,7 +83,6 @@ func switch_level(level_name: String, global_pos: Vector2) -> void:
 	start_timer()
 	#get_tree().change_scene_to_file.bind("res://level_generation.tscn").call_deferred()
 	#get_tree().change_scene_to_file("res://level_generation.tscn")
-
 
 
 # Function to create and start a timer that will wait to switch the level
@@ -120,7 +122,8 @@ func line(pos1: Vector3, pos2: Vector3, color = Color.WHITE_SMOKE) -> MeshInstan
 	get_tree().get_root().add_child(mesh_instance)
 	
 	return mesh_instance
-	
+
+
 func raycast_from_mouse(m_pos, collision_mask):
 	var ray_start = get_tree().get_first_node_in_group("Camera").project_ray_origin(m_pos)
 	var ray_end = ray_start + get_tree().get_first_node_in_group("Camera").project_ray_normal(m_pos) * 1000
@@ -134,7 +137,8 @@ func raycast_from_mouse(m_pos, collision_mask):
 	query.collide_with_areas = true
 	
 	return space_state.intersect_ray(query)
-	
+
+
 func raycast(start_position : Vector3, end_position : Vector3, layer : int, object_to_ignore):
 	var space_state = get_world_3d().direct_space_state
 	var query = PhysicsRayQueryParameters3D.create(start_position, end_position, layer, object_to_ignore)

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -11,6 +11,10 @@ signal hud_start_progressbar(time_left: float)
 # Nodes can use this signal to interrupt actions
 signal inventory_window_visibility_changed(inventoryWindow: Control)
 
+# Will sent out this signal when the user opens or closes the build window
+# Nodes can use this signal to interrupt actions
+signal build_window_visibility_changed(buildWindow: Control)
+
 # Signalled when an item was equiped in an equipmentslot
 # The item will know what slot it was
 signal item_was_equipped(heldItem: InventoryItem, equipmentSlot: Control)
@@ -28,6 +32,12 @@ func on_start_timer_progressbar(time_left: float):
 # We will forward the signal to anyone that wants it
 func on_inventory_visibility_changed(inventoryWindow: Control):
 	inventory_window_visibility_changed.emit(inventoryWindow)
+
+
+# Called when the build menu signals a visibility change
+# We will forward the signal to anyone that wants it
+func on_build_menu_visibility_changed(inventoryWindow: Control):
+	build_window_visibility_changed.emit(inventoryWindow)
 
 
 # When an equipmentslot has equipped an item

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -48,6 +48,10 @@ func _process(_delta):
 func _ready():
 	# If some node wants to start a progressbar, they will emit a signal trough the broker
 	Helper.signal_broker.hud_start_progressbar.connect(start_progress_bar)
+	# We let the signal broker forward the change in visibility so other nodes can respond
+	var buildmenu = get_node(building_menu)
+	buildmenu.visibility_changed.connect(\
+	Helper.signal_broker.on_build_menu_visibility_changed.bind(buildmenu))
 
 func update_progress_bar():
 	var progressBarNode = get_node(progress_bar_filling)

--- a/hud.tscn
+++ b/hud.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
 [ext_resource type="Script" path="res://Scripts/NonHUDclick.gd" id="2_kpbhl"]
 [ext_resource type="Texture2D" uid="uid://7hppy1l45loq" path="res://Textures/bar_progress.png" id="3_83uwt"]
-[ext_resource type="Resource" uid="uid://b0j7o54q2btuc" path="res://ItemProtosets.tres" id="3_jmlkb"]
+[ext_resource type="Resource" uid="uid://cllbo1owveorj" path="res://ItemProtosets.tres" id="3_jmlkb"]
 [ext_resource type="Texture2D" uid="uid://dcgwgmsmi7mjn" path="res://Textures/bar_border.png" id="3_y43f5"]
 [ext_resource type="Texture2D" uid="uid://tdebfxkpwiva" path="res://Textures/leftarm.png" id="4_wt5t7"]
 [ext_resource type="Texture2D" uid="uid://8pdm2gvd1v3n" path="res://Textures/leftleg.png" id="5_si2ot"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=26 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=29 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
+[ext_resource type="Script" path="res://Scripts/ConstructionGhost.gd" id="5_iwiv4"]
+[ext_resource type="Material" uid="uid://buj4ukj1oh4pq" path="res://Defaults/Blocks/Materials/floor1.tres" id="5_leqrw"]
 [ext_resource type="PackedScene" uid="uid://b34idpsxaylbd" path="res://Scenes/Chunk.tscn" id="6_lxuu0"]
 [ext_resource type="Script" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Script" path="res://Scripts/player.gd" id="8_gposs"]
@@ -25,6 +27,9 @@ ambient_light_source = 1
 ambient_light_color = Color(0.87451, 0, 0.729412, 1)
 ambient_light_energy = 0.0
 reflected_light_source = 1
+
+[sub_resource type="BoxMesh" id="BoxMesh_3r23p"]
+material = ExtResource("5_leqrw")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]
 albedo_color = Color(0, 1, 0, 1)
@@ -75,9 +80,19 @@ sky_mode = 1
 [node name="LevelManager" type="Node3D" parent="TacticalMap"]
 script = ExtResource("2_gm6x7")
 
-[node name="BuildManager" type="Node3D" parent="TacticalMap"]
+[node name="BuildManager" type="Node3D" parent="TacticalMap" node_paths=PackedStringArray("construction_ghost")]
 script = ExtResource("6_y7rk5")
+construction_ghost = NodePath("ConstructionGhost")
+player_path = NodePath("../Entities/Player")
 hud = NodePath("../../HUD")
+
+[node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager")]
+editor_description = "Visualizes the construction of blocks and slopes for the player"
+mesh = SubResource("BoxMesh_3r23p")
+script = ExtResource("5_iwiv4")
+player = NodePath("../../Entities/Player")
+sceneCam = NodePath("../../Entities/Player/Camera3D")
+buildmanager = NodePath("..")
 
 [node name="Entities" type="Node3D" parent="TacticalMap"]
 

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
 [ext_resource type="Script" path="res://Scripts/ConstructionGhost.gd" id="5_iwiv4"]
-[ext_resource type="Material" uid="uid://buj4ukj1oh4pq" path="res://Defaults/Blocks/Materials/floor1.tres" id="5_leqrw"]
+[ext_resource type="Material" uid="uid://ot2fpooebty0" path="res://Defaults/Blocks/Materials/construction_ghost_material.tres" id="5_sijm5"]
 [ext_resource type="PackedScene" uid="uid://b34idpsxaylbd" path="res://Scenes/Chunk.tscn" id="6_lxuu0"]
 [ext_resource type="Script" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Script" path="res://Scripts/player.gd" id="8_gposs"]
@@ -29,7 +29,7 @@ ambient_light_energy = 0.0
 reflected_light_source = 1
 
 [sub_resource type="BoxMesh" id="BoxMesh_3r23p"]
-material = ExtResource("5_leqrw")
+material = ExtResource("5_sijm5")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]
 albedo_color = Color(0, 1, 0, 1)
@@ -80,10 +80,10 @@ sky_mode = 1
 [node name="LevelManager" type="Node3D" parent="TacticalMap"]
 script = ExtResource("2_gm6x7")
 
-[node name="BuildManager" type="Node3D" parent="TacticalMap" node_paths=PackedStringArray("construction_ghost")]
+[node name="BuildManager" type="Node3D" parent="TacticalMap" node_paths=PackedStringArray("construction_ghost", "LevelGenerator")]
 script = ExtResource("6_y7rk5")
 construction_ghost = NodePath("ConstructionGhost")
-player_path = NodePath("../Entities/Player")
+LevelGenerator = NodePath("../LevelGenerator")
 hud = NodePath("../../HUD")
 
 [node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager")]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -28,8 +28,9 @@ ambient_light_color = Color(0.87451, 0, 0.729412, 1)
 ambient_light_energy = 0.0
 reflected_light_source = 1
 
-[sub_resource type="BoxMesh" id="BoxMesh_3r23p"]
+[sub_resource type="PlaneMesh" id="PlaneMesh_usfn3"]
 material = ExtResource("5_sijm5")
+size = Vector2(1, 1)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]
 albedo_color = Color(0, 1, 0, 1)
@@ -89,7 +90,8 @@ hud = NodePath("../../HUD")
 [node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager")]
 editor_description = "Visualizes the construction of blocks and slopes for the player"
 visible = false
-mesh = SubResource("BoxMesh_3r23p")
+cast_shadow = 0
+mesh = SubResource("PlaneMesh_usfn3")
 script = ExtResource("5_iwiv4")
 player = NodePath("../../Entities/Player")
 sceneCam = NodePath("../../Entities/Player/Camera3D")

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -88,6 +88,7 @@ hud = NodePath("../../HUD")
 
 [node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager")]
 editor_description = "Visualizes the construction of blocks and slopes for the player"
+visible = false
 mesh = SubResource("BoxMesh_3r23p")
 script = ExtResource("5_iwiv4")
 player = NodePath("../../Entities/Player")

--- a/scene_selector.tscn
+++ b/scene_selector.tscn
@@ -63,7 +63,8 @@ offset_left = 60.0
 offset_top = 588.0
 offset_right = 100.0
 offset_bottom = 611.0
-text = "w,s,a,d: Movement. tab: inventory. m: overmap. r: reload. Left mouse button: Fire left weapon. Right mouse button: fire right weapon"
+text = "w,s,a,d: Movement. tab: inventory. m: overmap. r: reload. Left mouse button: Fire left weapon. Right mouse button: fire right weapon
+b: Build menu. c: Craft menu"
 
 [connection signal="pressed" from="PlayDemo" to="." method="_on_play_demo_pressed"]
 [connection signal="pressed" from="LoadGameButton" to="." method="_on_load_game_button_pressed"]


### PR DESCRIPTION
Requires #80 to work.
This PR allows you to rotate a tile in the tacticalmapeditor. A tile represents a chunk, so you are rotating one of the cunks in the tactical map. This has the following benefits:
- You can connect roads to a road crossing from any direction
- You can create symmetry. For example, create a hill or crater that's just 4 of the same chunk but rotated to form a circle

This required that the layout of the tactical map editor had to be changed. It couldn't handle rotation of tiles in the grid very well, so I put the grid on a larger pan window and had it scale to the map size. It's still a little wonky with some map dimensions (i.e. 2x10) but it works for now.