### PR TITLE
Itemgroups editor

### DIFF
--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -1,0 +1,8 @@
+[
+	{
+		"description": "Anything you can find in a kitchen cupboard",
+		"id": "kitchen_cupboard",
+		"name": "Kitchen cupboard",
+		"sprite": "canned_food_32.png"
+	}
+]

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://b8i6wfk3fngy4" path="res://Scenes/ContentManager/Custom_Widgets/Editable_Item_List.tscn" id="2_ekwf5"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_o3k3a"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("furnitureImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "CategoriesList", "furnitureSelector", "imageNameStringLabel", "moveableCheckboxButton", "edgeSnappingOptionButton", "doorOptionButton")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("furnitureImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "CategoriesList", "furnitureSelector", "imageNameStringLabel", "moveableCheckboxButton", "edgeSnappingOptionButton", "doorOptionButton", "containerCheckBox", "containerTextEdit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -23,6 +23,8 @@ imageNameStringLabel = NodePath("VBoxContainer/FormGrid/ImageNameStringLabel")
 moveableCheckboxButton = NodePath("VBoxContainer/FormGrid/UnmoveableCheckBox")
 edgeSnappingOptionButton = NodePath("VBoxContainer/FormGrid/SnappingOptionButton")
 doorOptionButton = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/DoorOptionButton")
+containerCheckBox = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/ContainerCheckBox")
+containerTextEdit = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/ContainerTextEdit")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -166,6 +168,8 @@ text = "Door:"
 
 [node name="DoorOptionButton" type="OptionButton" parent="VBoxContainer/FormGrid/FunctionControlContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
 tooltip_text = "Lets this furniture function as a door. The player can interact with it and it will open and close. Selecting None prevents this furniture from working as a door. Selecting Open will spawn this furniture in an open state. Selecting Closed will spawn this furniture in a closed state"
 item_count = 3
 selected = 0
@@ -176,10 +180,44 @@ popup/item_1/id = 1
 popup/item_2/text = "Closed"
 popup/item_2/id = 2
 
+[node name="ContainerCheckBox" type="CheckBox" parent="VBoxContainer/FormGrid/FunctionControlContainer"]
+layout_mode = 2
+size_flags_horizontal = 10
+size_flags_stretch_ratio = 0.1
+tooltip_text = "Check this if the furniture should act as a 
+container. It will be empty, unless you 
+drag an itemgroup to the field on the 
+right. If this is checked off, the furniture 
+will not be able to contain items."
+text = "Container"
+
+[node name="ContainerTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid/FunctionControlContainer"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+tooltip_text = "If container is checked on, you can drag an
+itemgroup to this field to fill the container with the
+contents of the itemgroup when it is
+spawned. If container is not checked on, it
+will not act as a container."
+focus_next = NodePath("../../DescriptionTextEdit")
+focus_previous = NodePath("../../FurnitureImageDisplay")
+mouse_filter = 1
+placeholder_text = "Drag an itemgroup from the left to here"
+editable = false
+
+[node name="ClearContainerButton" type="Button" parent="VBoxContainer/FormGrid/FunctionControlContainer"]
+layout_mode = 2
+tooltip_text = "Press this to clear the itemgroup field"
+text = "X"
+
 [node name="Sprite_selector" parent="." instance=ExtResource("3_o3k3a")]
 visible = false
 
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="gui_input" from="VBoxContainer/FormGrid/FurnitureImageDisplay" to="." method="_on_furniture_image_display_gui_input"]
+[connection signal="toggled" from="VBoxContainer/FormGrid/FunctionControlContainer/ContainerCheckBox" to="." method="_on_container_check_box_toggled"]
+[connection signal="button_up" from="VBoxContainer/FormGrid/FunctionControlContainer/ClearContainerButton" to="." method="_on_clear_container_button_button_up"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -126,8 +126,10 @@ layout_mode = 2
 text = "Items"
 
 [node name="ItemList" type="ItemList" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
+mouse_filter = 1
 
 [node name="Sprite_selector" parent="." instance=ExtResource("4_tvfec")]
 visible = false

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -1,0 +1,104 @@
+[gd_scene load_steps=4 format=3 uid="uid://bw61ihylsl1p7"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd" id="1_ulsfi"]
+[ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_fq8lh"]
+[ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="4_tvfec"]
+
+[node name="ItemgroupEditor" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_ulsfi")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="CloseButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Close"
+
+[node name="SaveButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Save"
+
+[node name="FormGrid" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+columns = 2
+
+[node name="ImageLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Sprite:"
+
+[node name="ItemgroupImageDisplay" type="TextureRect" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(128, 128)
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_stretch_ratio = 0.4
+tooltip_text = "Select the sprite that best represents this itemgroup"
+focus_next = NodePath("../NameTextEdit")
+focus_mode = 2
+texture = ExtResource("2_fq8lh")
+expand_mode = 3
+
+[node name="ImageNameLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Sprite name:"
+
+[node name="ImageNameStringLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+
+[node name="IDLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "ID:"
+
+[node name="IDTextLabel" type="Label" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="NameLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Name"
+
+[node name="NameTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+tooltip_text = "Enter the name of this itemgroup"
+focus_next = NodePath("../DescriptionTextEdit")
+focus_previous = NodePath("../ItemgroupImageDisplay")
+
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Description"
+
+[node name="DescriptionTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.9
+tooltip_text = "Enter the description of this itemgroup"
+focus_previous = NodePath("../NameTextEdit")
+wrap_mode = 1
+
+[node name="Sprite_selector" parent="." instance=ExtResource("4_tvfec")]
+visible = false
+
+[connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
+[connection signal="gui_input" from="VBoxContainer/FormGrid/ItemgroupImageDisplay" to="." method="_on_furniture_image_display_gui_input"]
+[connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_fq8lh"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="4_tvfec"]
 
-[node name="ItemgroupEditor" type="Control"]
+[node name="ItemgroupEditor" type="Control" node_paths=PackedStringArray("itemgroupImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemgroupSelector", "imageNameStringLabel")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -12,6 +12,12 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ulsfi")
+itemgroupImageDisplay = NodePath("VBoxContainer/FormGrid/ItemgroupImageDisplay")
+IDTextLabel = NodePath("VBoxContainer/FormGrid/IDTextLabel")
+NameTextEdit = NodePath("VBoxContainer/FormGrid/NameTextEdit")
+DescriptionTextEdit = NodePath("VBoxContainer/FormGrid/DescriptionTextEdit")
+itemgroupSelector = NodePath("Sprite_selector")
+imageNameStringLabel = NodePath("VBoxContainer/FormGrid/ImageNameStringLabel")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -100,5 +106,5 @@ visible = false
 
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
-[connection signal="gui_input" from="VBoxContainer/FormGrid/ItemgroupImageDisplay" to="." method="_on_furniture_image_display_gui_input"]
+[connection signal="gui_input" from="VBoxContainer/FormGrid/ItemgroupImageDisplay" to="." method="_on_itemgroup_image_display_gui_input"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -95,9 +95,9 @@ layout_mode = 2
 text = "Description"
 
 [node name="DescriptionTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 3
 size_flags_stretch_ratio = 0.9
 tooltip_text = "Enter the description of this itemgroup"
 focus_previous = NodePath("../NameTextEdit")
@@ -128,6 +128,8 @@ text = "Items"
 [node name="ItemList" type="ItemList" parent="VBoxContainer/FormGrid"]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
 mouse_filter = 1
 

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_fq8lh"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="4_tvfec"]
 
-[node name="ItemgroupEditor" type="Control" node_paths=PackedStringArray("itemgroupImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemgroupSelector", "imageNameStringLabel")]
+[node name="ItemgroupEditor" type="Control" node_paths=PackedStringArray("itemgroupImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemgroupSelector", "imageNameStringLabel", "selectedItemNameDisplay", "itemList")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -18,6 +18,8 @@ NameTextEdit = NodePath("VBoxContainer/FormGrid/NameTextEdit")
 DescriptionTextEdit = NodePath("VBoxContainer/FormGrid/DescriptionTextEdit")
 itemgroupSelector = NodePath("Sprite_selector")
 imageNameStringLabel = NodePath("VBoxContainer/FormGrid/ImageNameStringLabel")
+selectedItemNameDisplay = NodePath("VBoxContainer/FormGrid/SelectedItemControls/SelectedItemNameDisplay")
+itemList = NodePath("VBoxContainer/FormGrid/ItemList")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -101,10 +103,39 @@ tooltip_text = "Enter the description of this itemgroup"
 focus_previous = NodePath("../NameTextEdit")
 wrap_mode = 1
 
+[node name="SelectedItemLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Selected item"
+
+[node name="SelectedItemControls" type="HBoxContainer" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+
+[node name="SelectedItemName" type="Label" parent="VBoxContainer/FormGrid/SelectedItemControls"]
+layout_mode = 2
+
+[node name="SelectedItemNameDisplay" type="Label" parent="VBoxContainer/FormGrid/SelectedItemControls"]
+layout_mode = 2
+
+[node name="RemoveItemButton" type="Button" parent="VBoxContainer/FormGrid/SelectedItemControls"]
+layout_mode = 2
+tooltip_text = "Removes the selected item from the list"
+text = "Remove"
+
+[node name="ItemsLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Items"
+
+[node name="ItemList" type="ItemList" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
+
 [node name="Sprite_selector" parent="." instance=ExtResource("4_tvfec")]
 visible = false
 
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="gui_input" from="VBoxContainer/FormGrid/ItemgroupImageDisplay" to="." method="_on_itemgroup_image_display_gui_input"]
+[connection signal="button_up" from="VBoxContainer/FormGrid/SelectedItemControls/RemoveItemButton" to="." method="_on_remove_item_button_button_up"]
+[connection signal="empty_clicked" from="VBoxContainer/FormGrid/ItemList" to="." method="_on_item_list_empty_clicked"]
+[connection signal="item_selected" from="VBoxContainer/FormGrid/ItemList" to="." method="_on_item_list_item_selected"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/MobEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/MobEditor.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_woy6i"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_847a0"]
 
-[node name="MobEditor" type="Control" node_paths=PackedStringArray("mobImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "mobSelector", "melee_damage_numedit", "melee_range_numedit", "health_numedit", "moveSpeed_numedit", "idle_move_speed_numedit", "sightRange_numedit", "senseRange_numedit", "hearingRange_numedit")]
+[node name="MobEditor" type="Control" node_paths=PackedStringArray("mobImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "mobSelector", "melee_damage_numedit", "melee_range_numedit", "health_numedit", "moveSpeed_numedit", "idle_move_speed_numedit", "sightRange_numedit", "senseRange_numedit", "hearingRange_numedit", "ItemGroupTextEdit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -26,6 +26,7 @@ idle_move_speed_numedit = NodePath("VBoxContainer/FormGrid/IdleMoveSpeedSpinBox"
 sightRange_numedit = NodePath("VBoxContainer/FormGrid/SightRangeSpinBox")
 senseRange_numedit = NodePath("VBoxContainer/FormGrid/SenseRangeSpinbox")
 hearingRange_numedit = NodePath("VBoxContainer/FormGrid/HearingRangeSpinbox")
+ItemGroupTextEdit = NodePath("VBoxContainer/FormGrid/HBoxContainer/LootItemGroupTextEdit")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -186,10 +187,35 @@ tooltip_text = "The maximum distance at which it can detect entities trough hear
 max_value = 5000.0
 value = 1000.0
 
+[node name="LootItemGroupLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Loot itemgroup"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+
+[node name="LootItemGroupTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid/HBoxContainer"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+tooltip_text = "Drag an itemgroup from the list of itemgroups on the left onto this textbox. When this mob dies, it will drop loot from that group. If no group is specified, the mob will not drop any loot"
+focus_next = NodePath("../../DescriptionTextEdit")
+focus_previous = NodePath("../../MobImageDisplay")
+mouse_filter = 1
+placeholder_text = "Drop an itemgroup here"
+editable = false
+
+[node name="ItemGroupClearButton" type="Button" parent="VBoxContainer/FormGrid/HBoxContainer"]
+layout_mode = 2
+tooltip_text = "Clears the id of the itemgroup"
+text = "Clear itemgroup"
+
 [node name="Sprite_selector" parent="." instance=ExtResource("3_847a0")]
 visible = false
 
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="gui_input" from="VBoxContainer/FormGrid/MobImageDisplay" to="." method="_on_mob_image_display_gui_input"]
+[connection signal="button_up" from="VBoxContainer/FormGrid/HBoxContainer/ItemGroupClearButton" to="." method="_on_item_group_clear_button_button_up"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -133,7 +133,7 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 	if dropped_data and "id" in dropped_data:
 		var item_id = dropped_data["id"]
 		var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
-		if item_data.empty():
+		if item_data.is_empty():
 			print_debug("No item data found for ID: " + item_id)
 			return
 		
@@ -152,7 +152,7 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 # The user clicked in the list, but not on any of the items
 # Deselect all items and reset the selectedItemNameDisplay label
 func _on_item_list_empty_clicked(at_position, mouse_button_index):
-	itemList.unselect_all()  # Deselect any selected items
+	itemList.deselect_all()  # Deselect any selected items
 	selectedItemNameDisplay.text = "No item selected"  # Reset the display label
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -30,12 +30,12 @@ var contentData: Dictionary = {}:
 	set(value):
 		contentData = value
 		load_itemgroup_data()
-		itemgroupSelector.sprites_collection = Gamedata.data.itemgroup.sprites
+		itemgroupSelector.sprites_collection = Gamedata.data.itemgroups.sprites
 
 
 func load_itemgroup_data():
-	if itemgroupImageDisplay and contentData.has("sprite"):
-		itemgroupImageDisplay.texture = Gamedata.data.itemgroup.sprites[contentData["sprite"]]
+	if itemgroupImageDisplay and contentData.has("sprite") and not contentData["sprite"].is_empty():
+		itemgroupImageDisplay.texture = Gamedata.data.itemgroups.sprites[contentData["sprite"]]
 		imageNameStringLabel.text = contentData["sprite"]
 	if IDTextLabel:
 		IDTextLabel.text = str(contentData["id"])

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -114,7 +114,23 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 
 # This function should return true if the dragged data can be dropped here
 func _can_drop_data(_newpos, data) -> bool:
+	# Check if the data dictionary has the 'id' property
+	if not data or not data.has("id"):
+		return false
+	
+	# Fetch item data by ID from the Gamedata to ensure it exists and is valid
+	var item_data = Gamedata.get_data_by_id(Gamedata.data.items, data["id"])
+	if item_data.is_empty():
+		return false
+
+	# Check if the ID of the dragged item already exists in the itemList
+	for i in range(itemList.get_item_count()):
+		if itemList.get_item_metadata(i) == data["id"]:
+			return false
+
+	# If all checks pass, return true
 	return true
+
 
 
 # This function handles the data being dropped

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -1,0 +1,100 @@
+extends Control
+
+# This scene is intended to be used inside the content editor
+# It is supposed to edit exactly one itemgroup
+# It expects to save the data to a JSON file that contains all itemgroup data from a mod
+# To load data, provide the name of the itemgroup data file and an ID
+
+@export var itemgroupImageDisplay: TextureRect = null
+@export var IDTextLabel: Label = null
+@export var NameTextEdit: TextEdit = null
+@export var DescriptionTextEdit: TextEdit = null
+@export var itemgroupSelector: Popup = null
+@export var imageNameStringLabel: Label = null
+# For controlling the focus when the tab button is pressed
+var control_elements: Array = []
+
+# This signal will be emitted when the user presses the save button
+# This signal should alert Gamedata that the itemgroup data array should be saved to disk
+# The content editor has connected this signal to Gamedata already
+signal data_changed()
+
+func _ready():
+	control_elements = [itemgroupImageDisplay,NameTextEdit,DescriptionTextEdit]
+
+
+# The data that represents this itemgroup
+# The data is selected from the Gamedata.data.itemgroup.data array
+# based on the ID that the user has selected in the content editor
+var contentData: Dictionary = {}:
+	set(value):
+		contentData = value
+		load_itemgroup_data()
+		itemgroupSelector.sprites_collection = Gamedata.data.itemgroup.sprites
+
+
+func load_itemgroup_data():
+	if itemgroupImageDisplay and contentData.has("sprite"):
+		itemgroupImageDisplay.texture = Gamedata.data.itemgroup.sprites[contentData["sprite"]]
+		imageNameStringLabel.text = contentData["sprite"]
+	if IDTextLabel:
+		IDTextLabel.text = str(contentData["id"])
+	if NameTextEdit and contentData.has("name"):
+		NameTextEdit.text = contentData["name"]
+	if DescriptionTextEdit and contentData.has("description"):
+		DescriptionTextEdit.text = contentData["description"]
+
+
+# This function will select the option in the option_button that matches the given string.
+# If no match is found, it does nothing.
+func select_option_by_string(option_button: OptionButton, option_string: String) -> void:
+	for i in range(option_button.get_item_count()):
+		if option_button.get_item_text(i) == option_string:
+			option_button.selected = i
+			return
+	print_debug("No matching option found for the string: " + option_string)
+
+
+#The editor is closed, destroy the instance
+#TODO: Check for unsaved changes
+func _on_close_button_button_up():
+	queue_free()
+
+
+# This function takes all data from the form elements stores them in the contentData
+# Since contentData is a reference to an item in Gamedata.data.itemgroup.data
+# the central array for itemgroupdata is updated with the changes as well
+# The function will signal to Gamedata that the data has changed and needs to be saved
+func _on_save_button_button_up():
+	contentData["sprite"] = imageNameStringLabel.text
+	contentData["name"] = NameTextEdit.text
+	contentData["description"] = DescriptionTextEdit.text
+	data_changed.emit()
+
+
+func _input(event):
+	if event.is_action_pressed("ui_focus_next"):
+		for myControl in control_elements:
+			if myControl.has_focus():
+				if Input.is_key_pressed(KEY_SHIFT):  # Check if Shift key
+					if !myControl.focus_previous.is_empty():
+						myControl.get_node(myControl.focus_previous).grab_focus()
+				else:
+					if !myControl.focus_next.is_empty():
+						myControl.get_node(myControl.focus_next).grab_focus()
+				break
+		get_viewport().set_input_as_handled()
+
+
+#When the itemgroupImageDisplay is clicked, the user will be prompted to select an image from 
+# "res://Mods/Core/Itemgroups/". The texture of the itemgroupImageDisplay will change to the selected image
+func _on_itemgroup_image_display_gui_input(event):
+	if event is InputEventMouseButton and event.pressed:
+		itemgroupSelector.show()
+
+
+func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
+	var itemgroupTexture: Resource = clicked_sprite.get_texture()
+	itemgroupImageDisplay.texture = itemgroupTexture
+	imageNameStringLabel.text = itemgroupTexture.resource_path.get_file()
+

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -15,14 +15,9 @@ extends Control
 @export var itemList: ItemList = null
 # For controlling the focus when the tab button is pressed
 var control_elements: Array = []
-
-# This signal will be emitted when the user presses the save button
-# This signal should alert Gamedata that the itemgroup data array should be saved to disk
-# The content editor has connected this signal to Gamedata already
-signal data_changed()
-
-func _ready():
-	control_elements = [itemgroupImageDisplay,NameTextEdit,DescriptionTextEdit]
+# Will keep track of the id's in the itemgroup list when it was loaded or saved
+# This is used to compare the list when it is saved and see the difference
+var old_list: Array[String] = []
 
 
 # The data that represents this itemgroup
@@ -35,6 +30,18 @@ var contentData: Dictionary = {}:
 		itemgroupSelector.sprites_collection = Gamedata.data.itemgroups.sprites
 
 
+# This signal will be emitted when the user presses the save button
+# This signal should alert Gamedata that the itemgroup data array should be saved to disk
+# The content editor has connected this signal to Gamedata already
+signal data_changed()
+signal itemlist_changed(itemgroup: String, oldlist: Array[String], newlist: Array[String])
+
+
+func _ready():
+	control_elements = [itemgroupImageDisplay,NameTextEdit,DescriptionTextEdit]
+	itemlist_changed.connect(Gamedata.on_itemgroup_changed)
+
+
 func load_itemgroup_data():
 	if itemgroupImageDisplay and contentData.has("sprite") and not contentData["sprite"].is_empty():
 		itemgroupImageDisplay.texture = Gamedata.data.itemgroups.sprites[contentData["sprite"]]
@@ -45,6 +52,18 @@ func load_itemgroup_data():
 		NameTextEdit.text = contentData["name"]
 	if DescriptionTextEdit and contentData.has("description"):
 		DescriptionTextEdit.text = contentData["description"]
+	# Load the items into the itemList
+	itemList.clear()  # Clear the list before populating
+	if contentData.has("items"):
+		for item_id in contentData["items"]:
+			# Get item data and sprite from the game data
+			var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
+			if not item_data.is_empty():
+				var item_sprite = Gamedata.get_sprite_by_id(Gamedata.data.items, item_id)
+				var item_index = itemList.add_item(item_data.get("name", "Unnamed Item"), item_sprite)
+				itemList.set_item_metadata(item_index, item_id)
+				old_list.append(item_id)  # Add to old list for comparison
+	_refresh_old_list()
 
 
 # This function will select the option in the option_button that matches the given string.
@@ -73,15 +92,22 @@ func _on_save_button_button_up():
 	contentData["description"] = DescriptionTextEdit.text
 	
 	# Collect all item IDs from the itemList and update the contentData accordingly
-	var items_array = []
+	var newlist: Array[String] = []
 	for i in range(itemList.get_item_count()):
-		items_array.append(itemList.get_item_metadata(i))  # Assuming metadata holds the item ID
+		var item_id = itemList.get_item_metadata(i)  # Assuming metadata holds the item ID
+		newlist.append(item_id)
 	
-	if items_array.size() > 0:
-		contentData["items"] = items_array
+	if newlist.size() > 0:
+		contentData["items"] = newlist
 	elif contentData.has("items"):
 		contentData.erase("items")  # Delete the "items" property if the list is empty
 	
+	# Check if there are any changes between old and new item lists
+	if _is_itemList_changed():
+		itemlist_changed.emit(contentData.id, old_list, newlist)
+	
+	# Update the old_list as the new baseline for future changes
+	old_list = newlist.duplicate()
 	data_changed.emit()
 
 
@@ -130,7 +156,6 @@ func _can_drop_data(_newpos, data) -> bool:
 
 	# If all checks pass, return true
 	return true
-
 
 
 # This function handles the data being dropped
@@ -193,3 +218,29 @@ func _on_remove_item_button_button_up():
 		print_debug("Item removed at index: " + str(selected_index))
 	else:
 		print_debug("No item selected to remove")
+
+
+# Function to refresh old_list with the current item IDs in itemList
+func _refresh_old_list():
+	old_list.clear()  # Clear the current contents of old_list
+	for i in range(itemList.get_item_count()):
+		var item_id = itemList.get_item_metadata(i)  # Get the item ID stored in metadata
+		old_list.append(item_id)  # Add the item ID to old_list
+
+
+# Function to compare old_list with the current itemList IDs
+func _is_itemList_changed() -> bool:
+	var current_list: Array = []
+	for i in range(itemList.get_item_count()):
+		var item_id = itemList.get_item_metadata(i)  # Assuming metadata holds the item ID
+		current_list.append(item_id)
+	
+	# Check if old_list and current_list have the same size and the same elements in the same order
+	if old_list.size() != current_list.size():
+		return true  # Sizes are different, lists are not the same
+	
+	for i in range(old_list.size()):
+		if old_list[i] != current_list[i]:
+			return true  # Found a difference in one of the positions
+	
+	return false  # No differences found

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -19,6 +19,7 @@ extends Control
 @export var sightRange_numedit: SpinBox
 @export var senseRange_numedit: SpinBox
 @export var hearingRange_numedit: SpinBox
+@export var ItemGroupTextEdit: TextEdit = null
 # This signal will be emitted when the user presses the save button
 # This signal should alert Gamedata that the mob data array should be saved to disk
 # The content editor has connected this signal to Gamedata already
@@ -60,6 +61,8 @@ func load_mob_data() -> void:
 		senseRange_numedit.get_line_edit().text = contentData["sense_range"]
 	if hearingRange_numedit != null and contentData.has("hearing_range"):
 		hearingRange_numedit.get_line_edit().text = contentData["hearing_range"]
+	if ItemGroupTextEdit != null and contentData.has("loot_group"):
+		ItemGroupTextEdit.text = contentData["loot_group"]
 	
 
 #The editor is closed, destroy the instance
@@ -83,6 +86,10 @@ func _on_save_button_button_up() -> void:
 	contentData["sight_range"] = sightRange_numedit.get_line_edit().text
 	contentData["sense_range"] = senseRange_numedit.get_line_edit().text
 	contentData["hearing_range"] = hearingRange_numedit.get_line_edit().text
+	if ItemGroupTextEdit.text:
+		contentData["loot_group"] = ItemGroupTextEdit.text
+	else:
+		contentData.erase("loot_group")
 	data_changed.emit()
 
 #When the mobImageDisplay is clicked, the user will be prompted to select an image from 
@@ -96,3 +103,45 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	var mobTexture: Resource = clicked_sprite.get_texture()
 	mobImageDisplay.texture = mobTexture
 	PathTextLabel.text = mobTexture.resource_path.get_file()
+
+
+
+
+# This function should return true if the dragged data can be dropped here
+func _can_drop_data(_newpos, data) -> bool:
+	# Check if the data dictionary has the 'id' property
+	if not data or not data.has("id"):
+		return false
+	
+	# Fetch itemgroup data by ID from the Gamedata to ensure it exists and is valid
+	var item_data = Gamedata.get_data_by_id(Gamedata.data.itemgroups, data["id"])
+	if item_data.is_empty():
+		return false
+
+	# If all checks pass, return true
+	return true
+
+
+# This function handles the data being dropped
+func _drop_data(newpos, data) -> void:
+	if _can_drop_data(newpos, data):
+		_handle_item_drop(data, newpos)
+
+
+# Called when the user has successfully dropped data onto the ItemGroupTextEdit
+# We have to check the dropped_data for the id property
+func _handle_item_drop(dropped_data, _newpos) -> void:
+	# Assuming dropped_data is a Dictionary that includes an 'id'
+	if dropped_data and "id" in dropped_data:
+		var item_id = dropped_data["id"]
+		var item_data = Gamedata.get_data_by_id(Gamedata.data.itemgroups, item_id)
+		if item_data.is_empty():
+			print_debug("No item data found for ID: " + item_id)
+			return
+		ItemGroupTextEdit.text = item_id
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+
+func _on_item_group_clear_button_button_up():
+	ItemGroupTextEdit.clear()

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -105,8 +105,6 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	PathTextLabel.text = mobTexture.resource_path.get_file()
 
 
-
-
 # This function should return true if the dragged data can be dropped here
 func _can_drop_data(_newpos, data) -> bool:
 	# Check if the data dictionary has the 'id' property

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -7,6 +7,7 @@ extends Control
 @export var furnitureEditor: PackedScene = null
 @export var itemEditor: PackedScene = null
 @export var mobEditor: PackedScene = null
+@export var itemgroupEditor: PackedScene = null
 @export var content: VBoxContainer = null
 @export var tabContainer: TabContainer = null
 var selectedMod: String = "Core"
@@ -20,6 +21,8 @@ func _ready():
 	load_content_list(Gamedata.data.tiles, "Terrain Tiles")
 	load_content_list(Gamedata.data.mobs, "Mobs")
 	load_content_list(Gamedata.data.furniture, "Furniture")
+	load_content_list(Gamedata.data.itemgroups, "Item Groups")
+
 
 func load_content_list(data: Dictionary, strHeader: String):
 	# Instantiate a contentlist
@@ -58,6 +61,9 @@ func _on_content_item_activated(data: Dictionary, itemID: String):
 		instantiate_editor(data, itemID, mapEditor)
 	if data == Gamedata.data.tacticalmaps:
 		instantiate_editor(data, itemID, tacticalmapEditor)
+	if data == Gamedata.data.itemgroups:
+		instantiate_editor(data, itemID, itemgroupEditor)
+
 
 #This will add an editor to the content editor tab view. 
 #The editor that should be instantiated is passed trough in the newEditor parameter

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -80,11 +80,11 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 		#We pass trough the data collection that the changed data belongs to
 		newContentEditor.data_changed.connect(Gamedata.on_data_changed.bind(data))
 		newContentEditor.data_changed.connect(_on_editor_data_changed.bind(data))
-	
 	else:
 		#If the data source does not end with json, it's a directory
 		#So now we pass in the file we want the editor to edit
 		newContentEditor.contentSource = data.dataPath + itemID + ".json"
+
 
 # function to handle data changes
 func _on_editor_data_changed(data: Dictionary):

--- a/Scenes/ContentManager/content_list.tscn
+++ b/Scenes/ContentManager/content_list.tscn
@@ -111,6 +111,8 @@ text = "Cancel"
 [connection signal="button_up" from="Content/HBoxContainer/AddButton" to="." method="_on_add_button_button_up"]
 [connection signal="button_up" from="Content/HBoxContainer/DuplicateButton" to="." method="_on_duplicate_button_button_up"]
 [connection signal="button_up" from="Content/HBoxContainer/DeleteButton" to="." method="_on_delete_button_button_up"]
+[connection signal="gui_input" from="Content/ContentItems" to="." method="_on_content_items_gui_input"]
 [connection signal="item_activated" from="Content/ContentItems" to="." method="_on_content_items_item_activated"]
+[connection signal="mouse_entered" from="Content/ContentItems" to="." method="_on_content_items_mouse_entered"]
 [connection signal="button_up" from="ID_Input/VBoxContainer/HBoxContainer/OK" to="." method="_on_ok_button_up"]
 [connection signal="button_up" from="ID_Input/VBoxContainer/HBoxContainer/Cancel" to="." method="_on_cancel_button_up"]

--- a/Scenes/ContentManager/contenteditor.tscn
+++ b/Scenes/ContentManager/contenteditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://480xqusluqrk"]
+[gd_scene load_steps=10 format=3 uid="uid://480xqusluqrk"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/contenteditor.gd" id="1_65sl4"]
 [ext_resource type="PackedScene" uid="uid://bhh0v7x4fjsgi" path="res://Scenes/ContentManager/content_list.tscn" id="2_4f21i"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://drby7yfu8t38e" path="res://Scenes/ContentManager/Custom_Editors/MobEditor.tscn" id="5_86se2"]
 [ext_resource type="PackedScene" uid="uid://cng4m3os6smj8" path="res://Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn" id="5_r1dle"]
 [ext_resource type="PackedScene" uid="uid://dmpomdwta1pgq" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn" id="7_i5608"]
+[ext_resource type="PackedScene" uid="uid://bw61ihylsl1p7" path="res://Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn" id="9_mc021"]
 
 [node name="contenteditor" type="Control" node_paths=PackedStringArray("content", "tabContainer")]
 layout_mode = 3
@@ -24,6 +25,7 @@ terrainTileEditor = ExtResource("4_5nnw0")
 furnitureEditor = ExtResource("5_r1dle")
 itemEditor = ExtResource("7_i5608")
 mobEditor = ExtResource("5_86se2")
+itemgroupEditor = ExtResource("9_mc021")
 content = NodePath("HSplitContainer/ContentLists/TabContainer2/Content")
 tabContainer = NodePath("HSplitContainer/TabContainer")
 

--- a/Scripts/Helper/json_helper.gd
+++ b/Scripts/Helper/json_helper.gd
@@ -80,8 +80,12 @@ func folder_names_in_dir(path: String) -> Array:
 		print("An error occurred when trying to access the path.")
 	return dirs
 
+
 #This function takes a json string and saves it as a json file.
 func write_json_file(path: String, json: String):
+	# If the file does not exists, we create a new one.
+	if not FileAccess.file_exists(path):
+		create_new_json_file(path)
 	# Save the JSON string to the selected file location
 	var file = FileAccess.open(path, FileAccess.WRITE)
 	if file:
@@ -89,7 +93,8 @@ func write_json_file(path: String, json: String):
 		file.close()
 	else:
 		print_debug("Unable to write file " + path)
-		
+
+
 # This function will take a path and create a new json file with just {} or [] as the contents.
 #If the file already exists, we do not overwrite it
 func create_new_json_file(filename: String = "", isArray: bool = true):
@@ -100,6 +105,17 @@ func create_new_json_file(filename: String = "", isArray: bool = true):
 	# If the file already exists, alert the user that the file already exists.
 	if FileAccess.file_exists(filename):
 		return
+
+	# Extract the directory path from the filename and check if it exists.
+	var directory_path = filename.get_base_dir()
+	var dir = DirAccess.open("res://")
+	if not dir.dir_exists(directory_path):
+		# Create the directory if it does not exist.
+		var err = dir.make_dir_recursive(directory_path)
+		if err != OK:
+			print_debug("Failed to create directory: " + directory_path)
+			return
+		print_debug("Directory created: " + directory_path)
 
 	var file = FileAccess.open(filename, FileAccess.WRITE)
 	#The file cen contain either one object or one array with a list of objects

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -4,32 +4,26 @@ extends Node
 #It can be accessed by using Gamedata.property
 var data: Dictionary = {}
 
+
+# Dictionary keys for game data categories
+const DATA_CATEGORIES = {
+	"tiles": {"dataPath": "./Mods/Core/Tiles/Tiles.json", "spritePath": "./Mods/Core/Tiles/"},
+	"mobs": {"dataPath": "./Mods/Core/Mobs/Mobs.json", "spritePath": "./Mods/Core/Mobs/"},
+	"items": {"dataPath": "./Mods/Core/Items/Items.json", "spritePath": "./Mods/Core/Items/"},
+	"furniture": {"dataPath": "./Mods/Core/Furniture/Furniture.json", "spritePath": "./Mods/Core/Furniture/"},
+	"overmaptiles": {"spritePath": "./Mods/Core/OvermapTiles/"},
+	"tacticalmaps": {"dataPath": "./Mods/Core/TacticalMaps/"},
+	"maps": {"dataPath": "./Mods/Core/Maps/", "spritePath": "./Mods/Core/Maps/"},
+	"itemgroups": {"dataPath": "./Mods/Core/Itemgroups/Itemgroups.json", "spritePath": "./Mods/Core/Items/"}
+}
+
 # We write down the associated paths for the files to load
 # Next, sprites are loaded from spritesPath into the .sprites property
 # Finally, the data is loaded from dataPath into the .data property
 # Maps tile sprites and map data are different so they 
 # are loaded in using their respective functions
 func _ready():
-	data.tiles = {}
-	data.mobs = {}
-	data.overmaptiles = {}
-	data.maps = {}
-	data.tacticalmaps = {}
-	data.furniture = {}
-	data.items = {}
-	data.tiles.dataPath = "./Mods/Core/Tiles/Tiles.json"
-	data.tiles.spritePath = "./Mods/Core/Tiles/"
-	data.mobs.dataPath = "./Mods/Core/Mobs/Mobs.json"
-	data.mobs.spritePath = "./Mods/Core/Mobs/"
-	data.items.dataPath = "./Mods/Core/Items/Items.json"
-	data.items.spritePath = "./Mods/Core/Items/"
-	data.furniture.spritePath = "./Mods/Core/Furniture/"
-	data.furniture.dataPath = "./Mods/Core/Furniture/Furniture.json"
-	data.overmaptiles.spritePath = "./Mods/Core/OvermapTiles/"
-	data.tacticalmaps.dataPath = "./Mods/Core/TacticalMaps/"
-	data.maps.dataPath = "./Mods/Core/Maps/"
-	# Map preview images are stored in the same folder
-	data.maps.spritePath = "./Mods/Core/Maps/"
+	initialize_data_structures()
 	load_sprites()
 	load_tile_sprites()
 	load_data()
@@ -37,6 +31,15 @@ func _ready():
 	data.maps.data = Helper.json_helper.file_names_in_dir(data.maps.dataPath, ["json"])
 	data.tacticalmaps.data = Helper.json_helper.file_names_in_dir(\
 	data.tacticalmaps.dataPath, ["json"])
+
+
+func initialize_data_structures():
+	for category in DATA_CATEGORIES.keys():
+		data[category] = {"data": [], "sprites": {}}
+		if DATA_CATEGORIES[category].has("dataPath"):
+			data[category]["dataPath"] = DATA_CATEGORIES[category]["dataPath"]
+		if DATA_CATEGORIES[category].has("spritePath"):
+			data[category]["spritePath"] = DATA_CATEGORIES[category]["spritePath"]
 
 
 #Loads json data. If no json file exists, it will create an empty array in a new file
@@ -49,6 +52,7 @@ func load_data() -> void:
 				data[dict].data = Helper.json_helper.load_json_array_file(dataPath)
 			else:
 				data[dict].data = []
+
 
 #This loads all the sprites and assigns them to the proper dictionary
 func load_sprites() -> void:
@@ -64,6 +68,7 @@ func load_sprites() -> void:
 				loaded_sprites[png_file] = texture
 			data[dict].sprites = loaded_sprites
 
+
 # This function reads all the files in "res://Mods/Core/Tiles/". It will check if the file is a .png file. If the file is a .png file, it will create a new material with that .png image as the texture. It will put all of the created materials in a dictionary with the name of the file as the key and the material as the value.
 func load_tile_sprites() -> void:
 	var tile_materials: Dictionary = {} # Materials used to represent tiles
@@ -76,6 +81,7 @@ func load_tile_sprites() -> void:
 		material.uv1_scale = Vector3(3,2,1)
 		tile_materials[png_file] = material # Add the material to the dictionary
 	data.tiles.sprites = tile_materials
+
 
 #This function will take two strings called ID and newID
 #It will find an item with this ID in a json file specified by the source variable
@@ -156,6 +162,7 @@ func add_id_to_data(contentData: Dictionary, id: String):
 		#Create a new json file in the directory with only {} in the file
 		Helper.json_helper.create_new_json_file(contentData.dataPath + id + ".json", false)
 
+
 # Will remove an item from the data
 # If the first item in data is a dictionary, we remove an item that has the provided id
 # If the first item in data is a string, we remove the string and the associated json file
@@ -172,6 +179,7 @@ func remove_item_from_data(contentData: Dictionary, id: String):
 		print_debug("Tried to remove item from data, but the data contains \
 		neither Dictionary nor String")
 
+
 func get_array_index_by_id(contentData: Dictionary, id: String) -> int:
 	# Iterate through the array
 	for i in range(len(contentData.data)):
@@ -186,16 +194,19 @@ func get_array_index_by_id(contentData: Dictionary, id: String) -> int:
 	# Return -1 if the ID is not found
 	return -1
 
+
 func save_data_to_file(contentData: Dictionary):
 	var datapath: String = contentData.dataPath
 	if datapath.ends_with(".json"):
 		Helper.json_helper.write_json_file(datapath,JSON.stringify(contentData.data,"\t"))
+
 
 # Takes contentdata and an id and returns the json that belongs to an id
 # For example, contentData can be Gamedata.data.tiles
 # and id can be "plain_grass" and it will return the json data for plain_grass
 func get_data_by_id(contentData: Dictionary, id: String) -> Dictionary:
 	return contentData.data[get_array_index_by_id(contentData,id)]
+
 
 #Takes contentData and an id and returns the sprite associated with the id
 # For example, contentData can be Gamedata.data.tiles
@@ -204,12 +215,14 @@ func get_sprite_by_id(contentData: Dictionary, id: String) -> Resource:
 	var item_json = get_data_by_id(contentData, id)
 	return contentData.sprites[item_json.sprite]
 
+
 # This functino is called when an editor has changed data
 # The contenteditor (that initializes the individual editors)
 # connects the changed_data signal to this function
 # and binds the appropriate data array so it can be saved in this function
 func on_data_changed(contentData: Dictionary):
 	save_data_to_file(contentData)
+
 
 # This will update the given resource file with the provided json data
 # It is intended to save item data from json to the res://ItemProtosets.tres file
@@ -230,7 +243,6 @@ func update_item_protoset_json_data(tres_path: String, new_json_data: String) ->
 		print("Failed to save updated ItemProtoset resource to:", tres_path)
 	else:
 		print("ItemProtoset resource updated and saved successfully to:", tres_path)
-
 
 
 # Function to filter items by type

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -205,7 +205,10 @@ func save_data_to_file(contentData: Dictionary):
 # For example, contentData can be Gamedata.data.tiles
 # and id can be "plain_grass" and it will return the json data for plain_grass
 func get_data_by_id(contentData: Dictionary, id: String) -> Dictionary:
-	return contentData.data[get_array_index_by_id(contentData,id)]
+	var idnr: int = get_array_index_by_id(contentData,id)
+	if idnr < 0:
+		return {}
+	return contentData.data[idnr]
 
 
 #Takes contentData and an id and returns the sprite associated with the id

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -212,8 +212,16 @@ func get_data_by_id(contentData: Dictionary, id: String) -> Dictionary:
 # For example, contentData can be Gamedata.data.tiles
 # and id can be "plain_grass" and it will return the sprite for plain_grass
 func get_sprite_by_id(contentData: Dictionary, id: String) -> Resource:
-	var item_json = get_data_by_id(contentData, id)
-	return contentData.sprites[item_json.sprite]
+	if not contentData.sprites.size() > 0 or not contentData.data.size() > 0:
+		return null
+	var sprite
+	# First, check if the contentData.data is structured as an array
+	if contentData.data[0] is String:
+		sprite = contentData.sprites[id + ".png"]
+	else:
+		var item_json = get_data_by_id(contentData, id)
+		sprite = contentData.sprites[item_json.sprite]
+	return sprite
 
 
 # This functino is called when an editor has changed data


### PR DESCRIPTION
Requires #94 

This PR adds the ability to create itemgroups. Right now an itemgroup can have an id, name, description, a list of items and a sprite to represent the group. The group is very basic and does not allow you to specify an amount per item. Also, itemgroups are not used by the game yet.

To add items, you can drag and drop items from the list to the left of the content editor. You can drag items from any list, but only items from the item list gets accepted by the itemgroup. If an item is already present in an itemgroup, you can't add it again.

When items are added or removed from an itemgroup, the item also gets the itemgroup added to it's data. We can use this to see what itemgroup uses this item from the item editor (not implemented yet). When an itemgroup is deleted, it's reference is also removed from items in that group so no trace is left behind.

An itemgroup can be assigned to mobs to generate loot. Furniture can act as a container and optionally be assigned an itemgroup to fill the container. These are just editor modifications, the actual game functions still have to be implemented.


The item is added to the itemgroup:

![image](https://github.com/Khaligufzel/CataX/assets/50166150/2e829b1d-74e6-4587-b634-7424ca372717)


The itemgroup is added to the item:


![image](https://github.com/Khaligufzel/CataX/assets/50166150/c691216b-6555-4e06-a50f-0170dbbfb64f)



The itemgroup editor (i drew a white arrow where my cursor is dragging an item from the list):

![image](https://github.com/Khaligufzel/CataX/assets/50166150/cbc54616-653f-4226-b21d-dbf2545530b9)
