### PR TITLE
Implement itemgroup functionality

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -71,7 +71,6 @@ json_data = "[
 		\"id\": \"pistol_magazine\",
 		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\",
 			\"mob_loot\"
 		],
 		\"max_stack_size\": \"1\",
@@ -199,6 +198,9 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"bottle_plastic_water\",
 		\"image\": \"./Mods/Core/Items/bottle_water_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"10\",
 		\"name\": \"Plastic bottle with water\",
 		\"sprite\": \"bottle_water_32.png\",
@@ -213,6 +215,9 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"canned_food\",
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Canned food\\t\",
 		\"sprite\": \"canned_food_32.png\",
@@ -256,6 +261,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"hammer\",
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Hammer\",
 		\"sprite\": \"hammer_32.png\",
@@ -271,6 +279,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"screwdriver\",
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Screwdriver\",
 		\"sprite\": \"screwdriver_32.png\",
@@ -286,6 +297,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"bandage_basic\",
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Bandage\",
 		\"sprite\": \"bandage_32.png\",
@@ -301,6 +315,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"bottle_antibiotics\",
 		\"image\": \"./Mods/Core/Items/antibiotics_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Bottle of antibiotics\",
 		\"sprite\": \"antibiotics_32.png\",
@@ -391,6 +408,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Flashlight\",
 		\"sprite\": \"flashlight_32.png\",
@@ -421,6 +441,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"pack_sigarrettes\",
 		\"image\": \"./Mods/Core/Items/sigarrette_pack_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Pack of sigarrettes\",
 		\"sprite\": \"sigarrette_pack_32.png\",
@@ -481,6 +504,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"battery_small\",
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Small battery\",
 		\"sprite\": \"battery_32.png\",
@@ -586,6 +612,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"bottle_disinfectant\",
 		\"image\": \"./Mods/Core/Items/bottle_disinfectant_32.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\"
+		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Bottle of disinfectant\",
 		\"sprite\": \"bottle_disinfectant_32.png\",

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -11,6 +11,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"plank_2x4\",
 		\"image\": \"./Mods/Core/Items/plank.png\",
+		\"itemgroups\": [
+			\"mob_loot\"
+		],
 		\"max_stack_size\": \"3\",
 		\"name\": \"Plank 2x4\",
 		\"sprite\": \"plank.png\",
@@ -25,6 +28,9 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"steel_scrap\",
 		\"image\": \"./Mods/Core/Items/steel_scrap.png\",
+		\"itemgroups\": [
+			\"mob_loot\"
+		],
 		\"max_stack_size\": \"100\",
 		\"name\": \"Steel scrap\",
 		\"sprite\": \"steel_scrap.png\",
@@ -42,6 +48,9 @@ json_data = "[
 		\"height\": \"1\",
 		\"id\": \"bullet_9mm\",
 		\"image\": \"./Mods/Core/Items/9mm.png\",
+		\"itemgroups\": [
+			\"mob_loot\"
+		],
 		\"max_stack_size\": \"100\",
 		\"name\": \"bullet 9mm\",
 		\"sprite\": \"9mm.png\",
@@ -61,6 +70,10 @@ json_data = "[
 		\"height\": \"1\",
 		\"id\": \"pistol_magazine\",
 		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
+		\"itemgroups\": [
+			\"kitchen_cupboard\",
+			\"mob_loot\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Pistol magazine\",
 		\"sprite\": \"pistol_magazine.png\",

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -23,6 +23,11 @@
 		"sprite": "chair_32.png"
 	},
 	{
+		"Function": {
+			"container": {
+				"itemgroup": "kitchen_cupboard"
+			}
+		},
 		"categories": [
 			"Urban",
 			"Kitchen",

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -2,7 +2,22 @@
 	{
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
+		"items": [
+			"pistol_magazine"
+		],
 		"name": "Kitchen cupboard",
 		"sprite": "canned_food_32.png"
+	},
+	{
+		"description": "Loot that's dropped by a mob",
+		"id": "mob_loot",
+		"items": [
+			"bullet_9mm",
+			"pistol_magazine",
+			"steel_scrap",
+			"plank_2x4"
+		],
+		"name": "Mob loot",
+		"sprite": "machete_32.png"
 	}
 ]

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -3,7 +3,16 @@
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
 		"items": [
-			"pistol_magazine"
+			"screwdriver",
+			"hammer",
+			"bandage_basic",
+			"bottle_antibiotics",
+			"flashlight_basic",
+			"pack_sigarrettes",
+			"battery_small",
+			"bottle_disinfectant",
+			"canned_food",
+			"bottle_plastic_water"
 		],
 		"name": "Kitchen cupboard",
 		"sprite": "canned_food_32.png"

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -65,7 +65,6 @@
 		"id": "pistol_magazine",
 		"image": "./Mods/Core/Items/pistol_magazine.png",
 		"itemgroups": [
-			"kitchen_cupboard",
 			"mob_loot"
 		],
 		"max_stack_size": "1",
@@ -193,6 +192,9 @@
 		"height": "2",
 		"id": "bottle_plastic_water",
 		"image": "./Mods/Core/Items/bottle_water_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "10",
 		"name": "Plastic bottle with water",
 		"sprite": "bottle_water_32.png",
@@ -207,6 +209,9 @@
 		"height": "2",
 		"id": "canned_food",
 		"image": "./Mods/Core/Items/canned_food_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "5",
 		"name": "Canned food\t",
 		"sprite": "canned_food_32.png",
@@ -250,6 +255,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "hammer",
 		"image": "./Mods/Core/Items/hammer_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "1",
 		"name": "Hammer",
 		"sprite": "hammer_32.png",
@@ -265,6 +273,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "screwdriver",
 		"image": "./Mods/Core/Items/screwdriver_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "1",
 		"name": "Screwdriver",
 		"sprite": "screwdriver_32.png",
@@ -280,6 +291,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "bandage_basic",
 		"image": "./Mods/Core/Items/bandage_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "20",
 		"name": "Bandage",
 		"sprite": "bandage_32.png",
@@ -295,6 +309,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "bottle_antibiotics",
 		"image": "./Mods/Core/Items/antibiotics_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "5",
 		"name": "Bottle of antibiotics",
 		"sprite": "antibiotics_32.png",
@@ -385,6 +402,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "flashlight_basic",
 		"image": "./Mods/Core/Items/flashlight_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "1",
 		"name": "Flashlight",
 		"sprite": "flashlight_32.png",
@@ -415,6 +435,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "pack_sigarrettes",
 		"image": "./Mods/Core/Items/sigarrette_pack_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "5",
 		"name": "Pack of sigarrettes",
 		"sprite": "sigarrette_pack_32.png",
@@ -475,6 +498,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "battery_small",
 		"image": "./Mods/Core/Items/battery_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "20",
 		"name": "Small battery",
 		"sprite": "battery_32.png",
@@ -580,6 +606,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "bottle_disinfectant",
 		"image": "./Mods/Core/Items/bottle_disinfectant_32.png",
+		"itemgroups": [
+			"kitchen_cupboard"
+		],
 		"max_stack_size": "5",
 		"name": "Bottle of disinfectant",
 		"sprite": "bottle_disinfectant_32.png",

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -5,6 +5,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "plank_2x4",
 		"image": "./Mods/Core/Items/plank.png",
+		"itemgroups": [
+			"mob_loot"
+		],
 		"max_stack_size": "3",
 		"name": "Plank 2x4",
 		"sprite": "plank.png",
@@ -19,6 +22,9 @@
 		"height": "2",
 		"id": "steel_scrap",
 		"image": "./Mods/Core/Items/steel_scrap.png",
+		"itemgroups": [
+			"mob_loot"
+		],
 		"max_stack_size": "100",
 		"name": "Steel scrap",
 		"sprite": "steel_scrap.png",
@@ -36,6 +42,9 @@
 		"height": "1",
 		"id": "bullet_9mm",
 		"image": "./Mods/Core/Items/9mm.png",
+		"itemgroups": [
+			"mob_loot"
+		],
 		"max_stack_size": "100",
 		"name": "bullet 9mm",
 		"sprite": "9mm.png",
@@ -55,6 +64,10 @@
 		"height": "1",
 		"id": "pistol_magazine",
 		"image": "./Mods/Core/Items/pistol_magazine.png",
+		"itemgroups": [
+			"kitchen_cupboard",
+			"mob_loot"
+		],
 		"max_stack_size": "1",
 		"name": "Pistol magazine",
 		"sprite": "pistol_magazine.png",

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -5,6 +5,7 @@
 		"hearing_range": "1000",
 		"id": "scrapwalker",
 		"idle_move_speed": "0.5",
+		"loot_group": "mob_loot",
 		"melee_damage": "20",
 		"melee_range": "1.5",
 		"move_speed": "1.1",

--- a/Scripts/Helper/json_helper.gd
+++ b/Scripts/Helper/json_helper.gd
@@ -108,7 +108,10 @@ func create_new_json_file(filename: String = "", isArray: bool = true):
 
 	# Extract the directory path from the filename and check if it exists.
 	var directory_path = filename.get_base_dir()
-	var dir = DirAccess.open("res://")
+	var base_dir = "./"
+	if directory_path.begins_with("user://"):
+		base_dir = "user://"
+	var dir = DirAccess.open(base_dir)
 	if not dir.dir_exists(directory_path):
 		# Create the directory if it does not exist.
 		var err = dir.make_dir_recursive(directory_path)

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -72,10 +72,26 @@ func _die():
 	add_corpse.call_deferred(global_position)
 	queue_free()
 
+
 func add_corpse(pos: Vector3):
 	var newItem: ContainerItem = ContainerItem.new()
+	
+	# Retrieve mob data from Gamedata
+	var mob_data = Gamedata.get_data_by_id(Gamedata.data.mobs, mobJSON.id)
+	if mob_data.is_empty():
+		print_debug("No mob data found for ID: " + str(mobJSON.id))
+		return
+
+	# Check if the mob data has a 'loot_group' property
+	if "loot_group" in mob_data:
+		# Set the itemgroup property of the new ContainerItem
+		newItem.itemgroup = mob_data["loot_group"]
+	else:
+		print_debug("No loot_group found for mob ID: " + str(mobJSON.id))
+	
 	newItem.add_to_group("mapitems")
 	newItem.construct_self(pos)
+	# Finally add the new item with possibly set loot group to the tree
 	get_tree().get_root().add_child.call_deferred(newItem)
 
 

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -9,20 +9,38 @@ extends Node3D
 var inventory: InventoryStacked
 var containerpos: Vector3
 var sprite_3d: Sprite3D
+var itemgroup: String # The ID of an itemgroup that it creates loot from
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	position = containerpos
-	create_random_loot()
+	create_loot()
 
 
-func create_random_loot():
-	if inventory.get_children() == []:
-		inventory.create_and_add_item.call_deferred("plank_2x4")
-		inventory.create_and_add_item.call_deferred("bullet_9mm")
-		inventory.create_and_add_item.call_deferred("pistol_magazine")
-		inventory.create_and_add_item.call_deferred("steel_scrap")
+func create_loot():
+	# Check if the inventory is not already populated
+	if inventory.get_items() == []:
+		# Attempt to retrieve the itemgroup data from Gamedata
+		var itemgroup_data = Gamedata.get_data_by_id(Gamedata.data.itemgroups, itemgroup)
+		
+		# Check if the itemgroup data exists and has items
+		if itemgroup_data and "items" in itemgroup_data:
+			# Loop over each item ID in the itemgroup's 'items' property
+			for item_id in itemgroup_data["items"]:
+				# Fetch the individual item data for verification
+				var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
+				
+				# Check if the item data is valid before adding
+				if item_data and not item_data.is_empty():
+					# Create and add the item to the inventory deferred to ensure all properties are set
+					inventory.create_and_add_item.call_deferred(item_id)
+				else:
+					print_debug("No valid data found for item ID: " + str(item_id))
+		else:
+			# Fallback if no valid itemgroup data found or the itemgroup is empty
+			print_debug("Invalid or empty itemgroup data for itemgroup ID: " + str(itemgroup))
+			# Optional: add fallback items if needed, or handle the case accordingly
 
 
 func create_inventory():

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -2,7 +2,7 @@ class_name ContainerItem
 extends Node3D
 
 # This is a standalone class that you can use to make a container of a 3d node
-# For example, adding this a child to furniture will allow the player to add and remove
+# For example, adding this as a child to furniture will allow the player to add and remove
 # items from it when it's in proximity
 
 
@@ -72,6 +72,8 @@ func create_sprite():
 func create_area3d():
 	var area3d = Area3D.new()
 	add_child(area3d)
+	area3d.collision_layer = 1 << 6  # Set to layer 7
+	area3d.collision_mask = 1 << 6   # Set mask to layer 7
 	area3d.owner = self
 	var collisionshape3d = CollisionShape3D.new()
 	var sphereshape3d = SphereShape3D.new()

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -206,6 +206,8 @@ bus = &"Sounds"
 
 [node name="ItemDetector" type="Area3D" parent="TacticalMap/Entities/Player"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1205, 0)
+collision_layer = 64
+collision_mask = 64
 script = ExtResource("15_r1xed")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/ItemDetector"]


### PR DESCRIPTION
Requires #95 

- Mobs now get their loot from itemgroups instead of being hardcoded
- Containers and the player's itemdetector now work on layer 7. The player's itemdetector is what allows the inventory window to access containers
- Furniture can have an itemgroup assigned to it. When it is spawned, it will create a container as a child node and fill it with items from the itemgroup. If the furniture is marked as container, but doesn't have an itemgroup assigned, it will be an empty container
- Saving and loading is not yet implemented, so when a chunk is unloaded and loaded again, the container will be re-filled.
- The spawning of items is very basic. You cannot set a spawn chance for items or a custom amount. It will just spawn whatever is set as the item's stack size.


https://github.com/Khaligufzel/CataX/assets/50166150/36cc677b-409f-4de5-bdb5-603debd212c4

