### PR TITLE
Itemgroup furniture reference

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -181,6 +181,9 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"bottle_plastic_empty\",
 		\"image\": \"./Mods/Core/Items/bottle_empty_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"10\",
 		\"name\": \"Empty plastic bottle\",
 		\"sprite\": \"bottle_empty_32.png\",
@@ -216,7 +219,8 @@ json_data = "[
 		\"id\": \"canned_food\",
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Canned food\\t\",
@@ -262,7 +266,8 @@ json_data = "[
 		\"id\": \"hammer\",
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Hammer\",
@@ -280,7 +285,8 @@ json_data = "[
 		\"id\": \"screwdriver\",
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Screwdriver\",
@@ -298,7 +304,8 @@ json_data = "[
 		\"id\": \"bandage_basic\",
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Bandage\",
@@ -393,6 +400,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"radio_handheld\",
 		\"image\": \"./Mods/Core/Items/battery_powered_radio_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Handheld radio\",
 		\"sprite\": \"battery_powered_radio_32.png\",
@@ -409,7 +419,8 @@ json_data = "[
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Flashlight\",
@@ -442,7 +453,8 @@ json_data = "[
 		\"id\": \"pack_sigarrettes\",
 		\"image\": \"./Mods/Core/Items/sigarrette_pack_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Pack of sigarrettes\",
@@ -505,7 +517,8 @@ json_data = "[
 		\"id\": \"battery_small\",
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Small battery\",
@@ -630,6 +643,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"radio_two_way\",
 		\"image\": \"./Mods/Core/Items/radio_two_way_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Two way radio\",
 		\"sprite\": \"radio_two_way_32.png\",
@@ -660,6 +676,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"kit_fishing_small\",
 		\"image\": \"./Mods/Core/Items/kit_fishing_small_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Small fishing kit\",
 		\"sprite\": \"kit_fishing_small_32.png\",

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -108,6 +108,11 @@
 		"sprite": "bed_wood_100_50.png"
 	},
 	{
+		"Function": {
+			"container": {
+				"itemgroup": "cabinet_general"
+			}
+		},
 		"categories": [
 			"Urban",
 			"Indoor"

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -2,6 +2,9 @@
 	{
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
+		"in_furniture": [
+			"countertop_wood"
+		],
 		"items": [
 			"screwdriver",
 			"hammer",
@@ -28,5 +31,27 @@
 		],
 		"name": "Mob loot",
 		"sprite": "machete_32.png"
+	},
+	{
+		"description": "What you would find in a cabinet in a house, for example in the living room",
+		"id": "cabinet_general",
+		"in_furniture": [
+			"cabinet_wood_00"
+		],
+		"items": [
+			"bottle_plastic_empty",
+			"canned_food",
+			"hammer",
+			"screwdriver",
+			"bandage_basic",
+			"flashlight_basic",
+			"radio_handheld",
+			"pack_sigarrettes",
+			"battery_small",
+			"radio_two_way",
+			"kit_fishing_small"
+		],
+		"name": "General cabinet contents",
+		"sprite": "flashlight_32.png"
 	}
 ]

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -175,6 +175,9 @@
 		"height": "2",
 		"id": "bottle_plastic_empty",
 		"image": "./Mods/Core/Items/bottle_empty_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "10",
 		"name": "Empty plastic bottle",
 		"sprite": "bottle_empty_32.png",
@@ -210,7 +213,8 @@
 		"id": "canned_food",
 		"image": "./Mods/Core/Items/canned_food_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "5",
 		"name": "Canned food\t",
@@ -256,7 +260,8 @@
 		"id": "hammer",
 		"image": "./Mods/Core/Items/hammer_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "1",
 		"name": "Hammer",
@@ -274,7 +279,8 @@
 		"id": "screwdriver",
 		"image": "./Mods/Core/Items/screwdriver_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "1",
 		"name": "Screwdriver",
@@ -292,7 +298,8 @@
 		"id": "bandage_basic",
 		"image": "./Mods/Core/Items/bandage_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "20",
 		"name": "Bandage",
@@ -387,6 +394,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "radio_handheld",
 		"image": "./Mods/Core/Items/battery_powered_radio_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "1",
 		"name": "Handheld radio",
 		"sprite": "battery_powered_radio_32.png",
@@ -403,7 +413,8 @@
 		"id": "flashlight_basic",
 		"image": "./Mods/Core/Items/flashlight_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "1",
 		"name": "Flashlight",
@@ -436,7 +447,8 @@
 		"id": "pack_sigarrettes",
 		"image": "./Mods/Core/Items/sigarrette_pack_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "5",
 		"name": "Pack of sigarrettes",
@@ -499,7 +511,8 @@
 		"id": "battery_small",
 		"image": "./Mods/Core/Items/battery_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "20",
 		"name": "Small battery",
@@ -624,6 +637,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "radio_two_way",
 		"image": "./Mods/Core/Items/radio_two_way_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "1",
 		"name": "Two way radio",
 		"sprite": "radio_two_way_32.png",
@@ -654,6 +670,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "kit_fishing_small",
 		"image": "./Mods/Core/Items/kit_fishing_small_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "1",
 		"name": "Small fishing kit",
 		"sprite": "kit_fishing_small_32.png",

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -274,7 +274,6 @@ func get_items_by_type(item_type: String) -> Array:
 	return filtered_items
 
 
-
 # An itemgroup has been changed. Update items that were added or removed from the list
 # oldlist and newlist are arrays with item id strings in them
 func on_itemgroup_changed(itemgroup: String, oldlist: Array[String], newlist: Array[String]):
@@ -335,6 +334,23 @@ func on_itemgroup_deleted(itemgroup_id: String):
 	if itemgroup_data.is_empty():
 		print("Itemgroup with ID", itemgroup_id, "not found.")
 		return
+	
+	# Handling the in_furniture attribute for furniture items
+	if "in_furniture" in itemgroup_data:
+		var furniture_ids = itemgroup_data["in_furniture"]
+		for furniture_id in furniture_ids:
+			var furniture_data = get_data_by_id(Gamedata.data.furniture, furniture_id)
+			if furniture_data.is_empty():
+				print("Furniture with ID", furniture_id, "not found.")
+				continue
+
+			# Navigate through the nested dictionary safely
+			if "Function" in furniture_data and "container" in furniture_data["Function"]:
+				if "itemgroup" in furniture_data["Function"]["container"]:
+					# Check if this itemgroup matches the one being deleted
+					if furniture_data["Function"]["container"]["itemgroup"] == itemgroup_id:
+						furniture_data["Function"]["container"].erase("itemgroup")
+						changes_made = true
 
 	# The itemgroup data contains a list of item IDs in an 'items' attribute
 	if "items" in itemgroup_data:
@@ -353,10 +369,56 @@ func on_itemgroup_deleted(itemgroup_id: String):
 				# If no more itemgroups are left in the item, consider removing the 'itemgroups' attribute
 				if item_data["itemgroups"].size() == 0:
 					item_data.erase("itemgroups")
-					
+
 	# Save changes to the data file if any changes were made
 	if changes_made:
 		save_data_to_file(Gamedata.data.items)
+		save_data_to_file(Gamedata.data.furniture)
 		print("Itemgroup", itemgroup_id, "has been successfully deleted from all items.")
 	else:
 		print("No changes needed for itemgroup", itemgroup_id)
+
+
+# Some furniture has had their itemgroup changed
+# We need to update the relation between the furniture and the itemgroup
+func on_furniture_itemgroup_changed(furniture_id: String, old_group: String, new_group: String):
+	# Exit if old_group and new_group are the same
+	if old_group == new_group:
+		print_debug("No change in itemgroup. Exiting function.")
+		return
+	var changes_made = false
+
+	# Handle the old itemgroup
+	if old_group != "":
+		var old_itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, old_group)
+		if old_itemgroup_data.has("in_furniture"):
+			# Check if the furniture_id is in the old itemgroup and remove it
+			if furniture_id in old_itemgroup_data["in_furniture"]:
+				old_itemgroup_data["in_furniture"].erase(furniture_id)
+				changes_made = true
+				# If in_furniture is now empty, remove the property
+				if old_itemgroup_data["in_furniture"].size() == 0:
+					old_itemgroup_data.erase("in_furniture")
+
+	# Handle the new itemgroup
+	if new_group != "":
+		var new_itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, new_group)
+		# Ensure the new group has the 'in_furniture' list initialized
+		if not new_itemgroup_data.has("in_furniture"):
+			new_itemgroup_data["in_furniture"] = []
+		# Add the furniture_id to the new itemgroup if it's not already there
+		if furniture_id not in new_itemgroup_data["in_furniture"]:
+			new_itemgroup_data["in_furniture"].append(furniture_id)
+			changes_made = true
+
+	# Save changes if any modifications were made
+	if changes_made:
+		if old_group != "":
+			save_data_to_file(Gamedata.data.itemgroups)
+		if new_group != "" and new_group != old_group:
+			save_data_to_file(Gamedata.data.itemgroups)
+
+	if changes_made:
+		print_debug("Furniture itemgroup changes saved successfully.")
+	else:
+		print_debug("No changes were made to furniture itemgroups.")


### PR DESCRIPTION
Requires #98 

Itemgroups and furniture will now reference each other to establish their relation
- When adding an itemgroup to furniture to fill their container, the itemgroup gets the id of the furniture added to their data
- When removing an itemgroup from furniture, the itemgroup is updated so that the furniture reference is removed
- When an itemgroup is deleted, all references in furniture are removed as well

This does not account for when furniture is deleted, so that's for the todo list.