### PR TITLE
Recipe editor

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -181,6 +181,9 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"bottle_plastic_empty\",
 		\"image\": \"./Mods/Core/Items/bottle_empty_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"10\",
 		\"name\": \"Empty plastic bottle\",
 		\"sprite\": \"bottle_empty_32.png\",
@@ -216,7 +219,8 @@ json_data = "[
 		\"id\": \"canned_food\",
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Canned food\\t\",
@@ -262,7 +266,8 @@ json_data = "[
 		\"id\": \"hammer\",
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Hammer\",
@@ -280,7 +285,8 @@ json_data = "[
 		\"id\": \"screwdriver\",
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Screwdriver\",
@@ -298,7 +304,8 @@ json_data = "[
 		\"id\": \"bandage_basic\",
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Bandage\",
@@ -393,6 +400,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"radio_handheld\",
 		\"image\": \"./Mods/Core/Items/battery_powered_radio_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Handheld radio\",
 		\"sprite\": \"battery_powered_radio_32.png\",
@@ -409,7 +419,8 @@ json_data = "[
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Flashlight\",
@@ -442,7 +453,8 @@ json_data = "[
 		\"id\": \"pack_sigarrettes\",
 		\"image\": \"./Mods/Core/Items/sigarrette_pack_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Pack of sigarrettes\",
@@ -505,7 +517,8 @@ json_data = "[
 		\"id\": \"battery_small\",
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
 		\"itemgroups\": [
-			\"kitchen_cupboard\"
+			\"kitchen_cupboard\",
+			\"cabinet_general\"
 		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Small battery\",
@@ -630,6 +643,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"radio_two_way\",
 		\"image\": \"./Mods/Core/Items/radio_two_way_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Two way radio\",
 		\"sprite\": \"radio_two_way_32.png\",
@@ -660,6 +676,9 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"kit_fishing_small\",
 		\"image\": \"./Mods/Core/Items/kit_fishing_small_32.png\",
+		\"itemgroups\": [
+			\"cabinet_general\"
+		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Small fishing kit\",
 		\"sprite\": \"kit_fishing_small_32.png\",

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -8,12 +8,8 @@ json_data = "[
 	{
 		\"description\": \"A wooden plank that could be used for all kinds of crafting and construction\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"plank_2x4\",
 		\"image\": \"./Mods/Core/Items/plank.png\",
-		\"itemgroups\": [
-			\"mob_loot\"
-		],
 		\"max_stack_size\": \"3\",
 		\"name\": \"Plank 2x4\",
 		\"sprite\": \"plank.png\",
@@ -28,9 +24,6 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"steel_scrap\",
 		\"image\": \"./Mods/Core/Items/steel_scrap.png\",
-		\"itemgroups\": [
-			\"mob_loot\"
-		],
 		\"max_stack_size\": \"100\",
 		\"name\": \"Steel scrap\",
 		\"sprite\": \"steel_scrap.png\",
@@ -48,9 +41,6 @@ json_data = "[
 		\"height\": \"1\",
 		\"id\": \"bullet_9mm\",
 		\"image\": \"./Mods/Core/Items/9mm.png\",
-		\"itemgroups\": [
-			\"mob_loot\"
-		],
 		\"max_stack_size\": \"100\",
 		\"name\": \"bullet 9mm\",
 		\"sprite\": \"9mm.png\",
@@ -70,9 +60,6 @@ json_data = "[
 		\"height\": \"1\",
 		\"id\": \"pistol_magazine\",
 		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
-		\"itemgroups\": [
-			\"mob_loot\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Pistol magazine\",
 		\"sprite\": \"pistol_magazine.png\",
@@ -181,9 +168,6 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"bottle_plastic_empty\",
 		\"image\": \"./Mods/Core/Items/bottle_empty_32.png\",
-		\"itemgroups\": [
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"10\",
 		\"name\": \"Empty plastic bottle\",
 		\"sprite\": \"bottle_empty_32.png\",
@@ -201,9 +185,6 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"bottle_plastic_water\",
 		\"image\": \"./Mods/Core/Items/bottle_water_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\"
-		],
 		\"max_stack_size\": \"10\",
 		\"name\": \"Plastic bottle with water\",
 		\"sprite\": \"bottle_water_32.png\",
@@ -218,10 +199,6 @@ json_data = "[
 		\"height\": \"2\",
 		\"id\": \"canned_food\",
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Canned food\\t\",
 		\"sprite\": \"canned_food_32.png\",
@@ -265,10 +242,6 @@ json_data = "[
 		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"hammer\",
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Hammer\",
 		\"sprite\": \"hammer_32.png\",
@@ -281,13 +254,8 @@ json_data = "[
 	{
 		\"description\": \"A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"screwdriver\",
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Screwdriver\",
 		\"sprite\": \"screwdriver_32.png\",
@@ -300,13 +268,8 @@ json_data = "[
 	{
 		\"description\": \"A basic bandage that will help to heal a wound\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"bandage_basic\",
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Bandage\",
 		\"sprite\": \"bandage_32.png\",
@@ -319,12 +282,8 @@ json_data = "[
 	{
 		\"description\": \"A small bottle that contains antibiotics. It helps to recover from disease.\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"bottle_antibiotics\",
 		\"image\": \"./Mods/Core/Items/antibiotics_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\"
-		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Bottle of antibiotics\",
 		\"sprite\": \"antibiotics_32.png\",
@@ -397,12 +356,8 @@ json_data = "[
 	{
 		\"description\": \"A small radio that can be powered by batteries or an electical cord.\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"radio_handheld\",
 		\"image\": \"./Mods/Core/Items/battery_powered_radio_32.png\",
-		\"itemgroups\": [
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Handheld radio\",
 		\"sprite\": \"battery_powered_radio_32.png\",
@@ -415,13 +370,8 @@ json_data = "[
 	{
 		\"description\": \"A basic battery powered flashlight. It will shine a beam of light when it is turned on\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Flashlight\",
 		\"sprite\": \"flashlight_32.png\",
@@ -449,13 +399,8 @@ json_data = "[
 	{
 		\"description\": \"It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"pack_sigarrettes\",
 		\"image\": \"./Mods/Core/Items/sigarrette_pack_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Pack of sigarrettes\",
 		\"sprite\": \"sigarrette_pack_32.png\",
@@ -468,7 +413,6 @@ json_data = "[
 	{
 		\"description\": \"A piece of clothing that offers protection from environmental hazards\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"gas_mask\",
 		\"image\": \"./Mods/Core/Items/gasmask_32.png\",
 		\"max_stack_size\": \"1\",
@@ -513,13 +457,8 @@ json_data = "[
 	{
 		\"description\": \"A very common type of battery that fits most battery-powered devices\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"battery_small\",
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\",
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"20\",
 		\"name\": \"Small battery\",
 		\"sprite\": \"battery_32.png\",
@@ -622,12 +561,8 @@ json_data = "[
 	{
 		\"description\": \"A small bottle that contains disinfectant. It helps to disinfect wounds\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"bottle_disinfectant\",
 		\"image\": \"./Mods/Core/Items/bottle_disinfectant_32.png\",
-		\"itemgroups\": [
-			\"kitchen_cupboard\"
-		],
 		\"max_stack_size\": \"5\",
 		\"name\": \"Bottle of disinfectant\",
 		\"sprite\": \"bottle_disinfectant_32.png\",
@@ -640,12 +575,8 @@ json_data = "[
 	{
 		\"description\": \"A small radio that allows you to communicate with someone over a large distance\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"radio_two_way\",
 		\"image\": \"./Mods/Core/Items/radio_two_way_32.png\",
-		\"itemgroups\": [
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Two way radio\",
 		\"sprite\": \"radio_two_way_32.png\",
@@ -673,12 +604,8 @@ json_data = "[
 	{
 		\"description\": \"\\n    A true survival fishing kit in a very small, lightweight package!\\n    Contains 118 foot line and winder\\n    2 lures, 2 hooks\\n    2 swivels, 2 weghts\\n    Comes in a strong durable heavy duty resealable plastic bag\",
 		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"kit_fishing_small\",
 		\"image\": \"./Mods/Core/Items/kit_fishing_small_32.png\",
-		\"itemgroups\": [
-			\"cabinet_general\"
-		],
 		\"max_stack_size\": \"1\",
 		\"name\": \"Small fishing kit\",
 		\"sprite\": \"kit_fishing_small_32.png\",

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -38,9 +38,6 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\"
-				],
-				\"items\": [
-					\"pistol_magazine\"
 				]
 			}
 		},
@@ -66,9 +63,6 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\"
-				],
-				\"items\": [
-					\"pistol_magazine\"
 				]
 			}
 		},
@@ -80,26 +74,9 @@ json_data = "[
 		\"width\": \"1\"
 	},
 	{
-		\"Craft\": {
-			\"craft_amount\": 1,
-			\"craft_time\": 10,
-			\"flags\": {
-				\"requires_light\": false
-			},
-			\"required_resources\": [
-				{
-					\"amount\": 1,
-					\"id\": \"steel_scrap\"
-				},
-				{
-					\"amount\": 10,
-					\"id\": \"bullet_9mm\"
-				}
-			]
-		},
 		\"Magazine\": {
-			\"current_ammo\": 19,
-			\"max_ammo\": 20,
+			\"current_ammo\": \"19\",
+			\"max_ammo\": \"20\",
 			\"used_ammo\": \"bullet_9mm\"
 		},
 		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
@@ -396,6 +373,9 @@ json_data = "[
 			\"core\": {
 				\"itemgroups\": [
 					\"kitchen_cupboard\"
+				],
+				\"items\": [
+					\"jadet\"
 				]
 			}
 		},
@@ -606,6 +586,9 @@ json_data = "[
 			\"core\": {
 				\"itemgroups\": [
 					\"cabinet_general\"
+				],
+				\"items\": [
+					\"pistoldgazine\"
 				]
 			}
 		},
@@ -775,6 +758,34 @@ json_data = "[
 		\"two_handed\": false,
 		\"volume\": \"50\",
 		\"weight\": \"0.4\",
+		\"width\": \"4\"
+	},
+	{
+		\"Craft\": {
+			\"craft_amount\": 1,
+			\"craft_time\": 10,
+			\"flags\": {
+				\"requires_light\": false
+			},
+			\"required_resources\": [
+				{
+					\"amount\": 1,
+					\"id\": \"bottle_antibiotics\"
+				}
+			]
+		},
+		\"description\": \"A piece of clothing to wear on the torso. It will keep you warm and offers a bit of protection.\",
+		\"height\": \"2\",
+		\"iamge\": \"res://Textures/plank.png\",
+		\"id\": \"jadet\",
+		\"image\": \"./Mods/Core/Items/jacket_32.png\",
+		\"max_stack_size\": \"1\",
+		\"name\": \"Jacket\",
+		\"sprite\": \"jacket_32.png\",
+		\"stack_size\": \"1\",
+		\"two_handed\": false,
+		\"volume\": \"100\",
+		\"weight\": \"1\",
 		\"width\": \"4\"
 	}
 ]"

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -38,6 +38,9 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\"
+				],
+				\"items\": [
+					\"pistol_magazine\"
 				]
 			}
 		},
@@ -63,6 +66,9 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\"
+				],
+				\"items\": [
+					\"pistol_magazine\"
 				]
 			}
 		},
@@ -74,9 +80,26 @@ json_data = "[
 		\"width\": \"1\"
 	},
 	{
+		\"Craft\": {
+			\"craft_amount\": 1,
+			\"craft_time\": 10,
+			\"flags\": {
+				\"requires_light\": false
+			},
+			\"required_resources\": [
+				{
+					\"amount\": 1,
+					\"id\": \"steel_scrap\"
+				},
+				{
+					\"amount\": 10,
+					\"id\": \"bullet_9mm\"
+				}
+			]
+		},
 		\"Magazine\": {
-			\"current_ammo\": \"19\",
-			\"max_ammo\": \"20\",
+			\"current_ammo\": 19,
+			\"max_ammo\": 20,
 			\"used_ammo\": \"bullet_9mm\"
 		},
 		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -12,6 +12,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/plank.png\",
 		\"max_stack_size\": \"3\",
 		\"name\": \"Plank 2x4\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"mob_loot\"
+				]
+			}
+		},
 		\"sprite\": \"plank.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -26,6 +33,14 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/steel_scrap.png\",
 		\"max_stack_size\": \"100\",
 		\"name\": \"Steel scrap\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"mob_loot\"
+				]
+			}
+		},
 		\"sprite\": \"steel_scrap.png\",
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
@@ -43,6 +58,14 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/9mm.png\",
 		\"max_stack_size\": \"100\",
 		\"name\": \"bullet 9mm\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"mob_loot\"
+				]
+			}
+		},
 		\"sprite\": \"9mm.png\",
 		\"stack_size\": \"20\",
 		\"two_handed\": false,
@@ -62,6 +85,14 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Pistol magazine\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"mob_loot\"
+				]
+			}
+		},
 		\"sprite\": \"pistol_magazine.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -87,6 +118,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/pistol_32.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Pistol 9mm\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"pistol_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -170,6 +208,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/bottle_empty_32.png\",
 		\"max_stack_size\": \"10\",
 		\"name\": \"Empty plastic bottle\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"bottle_empty_32.png\",
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
@@ -187,6 +232,14 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/bottle_water_32.png\",
 		\"max_stack_size\": \"10\",
 		\"name\": \"Plastic bottle with water\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"bottle_water_32.png\",
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
@@ -201,6 +254,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
 		\"max_stack_size\": \"5\",
 		\"name\": \"Canned food\\t\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"canned_food_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -244,6 +304,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Hammer\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"hammer_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -258,6 +325,14 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Screwdriver\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"screwdriver_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -272,6 +347,14 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
 		\"max_stack_size\": \"20\",
 		\"name\": \"Bandage\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"bandage_32.png\",
 		\"stack_size\": \"3\",
 		\"two_handed\": false,
@@ -286,6 +369,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/antibiotics_32.png\",
 		\"max_stack_size\": \"5\",
 		\"name\": \"Bottle of antibiotics\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"antibiotics_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -316,6 +406,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/boots_32.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Boots\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"boots_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -346,6 +443,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/can_oil_32.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Can of oil\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"can_oil_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -374,6 +478,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
 		\"max_stack_size\": \"1\",
 		\"name\": \"Flashlight\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"flashlight_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -389,6 +500,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/can_beer_32.png\",
 		\"max_stack_size\": \"5\",
 		\"name\": \"Can of beer\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"can_beer_32.png\",
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
@@ -461,6 +579,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
 		\"max_stack_size\": \"20\",
 		\"name\": \"Small battery\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"battery_32.png\",
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
@@ -551,6 +676,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/book_novel_32.png\",
 		\"max_stack_size\": \"5\",
 		\"name\": \"Novel\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\"
+				]
+			}
+		},
 		\"sprite\": \"book_novel_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
@@ -565,6 +697,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/bottle_disinfectant_32.png\",
 		\"max_stack_size\": \"5\",
 		\"name\": \"Bottle of disinfectant\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"kitchen_cupboard\"
+				]
+			}
+		},
 		\"sprite\": \"bottle_disinfectant_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -108,6 +108,11 @@
 		"sprite": "bed_wood_100_50.png"
 	},
 	{
+		"Function": {
+			"container": {
+				"itemgroup": "cabinet_general"
+			}
+		},
 		"categories": [
 			"Urban",
 			"Indoor"

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -25,7 +25,7 @@
 	{
 		"Function": {
 			"container": {
-				"itemgroup": "kitchen_cupboard"
+
 			}
 		},
 		"categories": [
@@ -110,7 +110,7 @@
 	{
 		"Function": {
 			"container": {
-				"itemgroup": "cabinet_general"
+
 			}
 		},
 		"categories": [

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -25,7 +25,7 @@
 	{
 		"Function": {
 			"container": {
-
+				"itemgroup": "kitchen_cupboard"
 			}
 		},
 		"categories": [
@@ -110,7 +110,7 @@
 	{
 		"Function": {
 			"container": {
-
+				"itemgroup": "cabinet_general"
 			}
 		},
 		"categories": [

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -2,55 +2,18 @@
 	{
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
-		"in_furniture": [
-			"countertop_wood"
-		],
-		"items": [
-			"screwdriver",
-			"hammer",
-			"bandage_basic",
-			"bottle_antibiotics",
-			"flashlight_basic",
-			"pack_sigarrettes",
-			"battery_small",
-			"bottle_disinfectant",
-			"canned_food",
-			"bottle_plastic_water"
-		],
 		"name": "Kitchen cupboard",
 		"sprite": "canned_food_32.png"
 	},
 	{
 		"description": "Loot that's dropped by a mob",
 		"id": "mob_loot",
-		"items": [
-			"bullet_9mm",
-			"pistol_magazine",
-			"steel_scrap",
-			"plank_2x4"
-		],
 		"name": "Mob loot",
 		"sprite": "machete_32.png"
 	},
 	{
 		"description": "What you would find in a cabinet in a house, for example in the living room",
 		"id": "cabinet_general",
-		"in_furniture": [
-			"cabinet_wood_00"
-		],
-		"items": [
-			"bottle_plastic_empty",
-			"canned_food",
-			"hammer",
-			"screwdriver",
-			"bandage_basic",
-			"flashlight_basic",
-			"radio_handheld",
-			"pack_sigarrettes",
-			"battery_small",
-			"radio_two_way",
-			"kit_fishing_small"
-		],
 		"name": "General cabinet contents",
 		"sprite": "flashlight_32.png"
 	}

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -2,6 +2,9 @@
 	{
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
+		"in_furniture": [
+			"countertop_wood"
+		],
 		"items": [
 			"screwdriver",
 			"hammer",
@@ -28,5 +31,27 @@
 		],
 		"name": "Mob loot",
 		"sprite": "machete_32.png"
+	},
+	{
+		"description": "What you would find in a cabinet in a house, for example in the living room",
+		"id": "cabinet_general",
+		"in_furniture": [
+			"cabinet_wood_00"
+		],
+		"items": [
+			"bottle_plastic_empty",
+			"canned_food",
+			"hammer",
+			"screwdriver",
+			"bandage_basic",
+			"flashlight_basic",
+			"radio_handheld",
+			"pack_sigarrettes",
+			"battery_small",
+			"radio_two_way",
+			"kit_fishing_small"
+		],
+		"name": "General cabinet contents",
+		"sprite": "flashlight_32.png"
 	}
 ]

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -17,6 +17,9 @@
 			"core": {
 				"furniture": [
 					"countertop_wood"
+				],
+				"mobs": [
+					"scrapwalker"
 				]
 			}
 		},

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -2,19 +2,64 @@
 	{
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
+		"items": [
+			"canned_food",
+			"bottle_plastic_water",
+			"bottle_plastic_empty",
+			"screwdriver",
+			"bandage_basic",
+			"bottle_antibiotics",
+			"can_beer",
+			"bottle_disinfectant"
+		],
 		"name": "Kitchen cupboard",
+		"references": {
+			"core": {
+				"furniture": [
+					"countertop_wood"
+				]
+			}
+		},
 		"sprite": "canned_food_32.png"
 	},
 	{
 		"description": "Loot that's dropped by a mob",
 		"id": "mob_loot",
+		"items": [
+			"bullet_9mm",
+			"pistol_magazine",
+			"steel_scrap",
+			"plank_2x4"
+		],
 		"name": "Mob loot",
 		"sprite": "machete_32.png"
 	},
 	{
 		"description": "What you would find in a cabinet in a house, for example in the living room",
 		"id": "cabinet_general",
+		"items": [
+			"steel_scrap",
+			"bullet_9mm",
+			"pistol_magazine",
+			"pistol_9mm",
+			"bottle_plastic_water",
+			"hammer",
+			"screwdriver",
+			"bandage_basic",
+			"boots",
+			"can_oil",
+			"flashlight_basic",
+			"battery_small",
+			"book_novel"
+		],
 		"name": "General cabinet contents",
+		"references": {
+			"core": {
+				"furniture": [
+					"cabinet_wood_00"
+				]
+			}
+		},
 		"sprite": "flashlight_32.png"
 	}
 ]

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -2,12 +2,8 @@
 	{
 		"description": "A wooden plank that could be used for all kinds of crafting and construction",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "plank_2x4",
 		"image": "./Mods/Core/Items/plank.png",
-		"itemgroups": [
-			"mob_loot"
-		],
 		"max_stack_size": "3",
 		"name": "Plank 2x4",
 		"sprite": "plank.png",
@@ -22,9 +18,6 @@
 		"height": "2",
 		"id": "steel_scrap",
 		"image": "./Mods/Core/Items/steel_scrap.png",
-		"itemgroups": [
-			"mob_loot"
-		],
 		"max_stack_size": "100",
 		"name": "Steel scrap",
 		"sprite": "steel_scrap.png",
@@ -42,9 +35,6 @@
 		"height": "1",
 		"id": "bullet_9mm",
 		"image": "./Mods/Core/Items/9mm.png",
-		"itemgroups": [
-			"mob_loot"
-		],
 		"max_stack_size": "100",
 		"name": "bullet 9mm",
 		"sprite": "9mm.png",
@@ -64,9 +54,6 @@
 		"height": "1",
 		"id": "pistol_magazine",
 		"image": "./Mods/Core/Items/pistol_magazine.png",
-		"itemgroups": [
-			"mob_loot"
-		],
 		"max_stack_size": "1",
 		"name": "Pistol magazine",
 		"sprite": "pistol_magazine.png",
@@ -175,9 +162,6 @@
 		"height": "2",
 		"id": "bottle_plastic_empty",
 		"image": "./Mods/Core/Items/bottle_empty_32.png",
-		"itemgroups": [
-			"cabinet_general"
-		],
 		"max_stack_size": "10",
 		"name": "Empty plastic bottle",
 		"sprite": "bottle_empty_32.png",
@@ -195,9 +179,6 @@
 		"height": "2",
 		"id": "bottle_plastic_water",
 		"image": "./Mods/Core/Items/bottle_water_32.png",
-		"itemgroups": [
-			"kitchen_cupboard"
-		],
 		"max_stack_size": "10",
 		"name": "Plastic bottle with water",
 		"sprite": "bottle_water_32.png",
@@ -212,10 +193,6 @@
 		"height": "2",
 		"id": "canned_food",
 		"image": "./Mods/Core/Items/canned_food_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "5",
 		"name": "Canned food\t",
 		"sprite": "canned_food_32.png",
@@ -259,10 +236,6 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "hammer",
 		"image": "./Mods/Core/Items/hammer_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "1",
 		"name": "Hammer",
 		"sprite": "hammer_32.png",
@@ -275,13 +248,8 @@
 	{
 		"description": "A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "screwdriver",
 		"image": "./Mods/Core/Items/screwdriver_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "1",
 		"name": "Screwdriver",
 		"sprite": "screwdriver_32.png",
@@ -294,13 +262,8 @@
 	{
 		"description": "A basic bandage that will help to heal a wound",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "bandage_basic",
 		"image": "./Mods/Core/Items/bandage_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "20",
 		"name": "Bandage",
 		"sprite": "bandage_32.png",
@@ -313,12 +276,8 @@
 	{
 		"description": "A small bottle that contains antibiotics. It helps to recover from disease.",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "bottle_antibiotics",
 		"image": "./Mods/Core/Items/antibiotics_32.png",
-		"itemgroups": [
-			"kitchen_cupboard"
-		],
 		"max_stack_size": "5",
 		"name": "Bottle of antibiotics",
 		"sprite": "antibiotics_32.png",
@@ -391,12 +350,8 @@
 	{
 		"description": "A small radio that can be powered by batteries or an electical cord.",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "radio_handheld",
 		"image": "./Mods/Core/Items/battery_powered_radio_32.png",
-		"itemgroups": [
-			"cabinet_general"
-		],
 		"max_stack_size": "1",
 		"name": "Handheld radio",
 		"sprite": "battery_powered_radio_32.png",
@@ -409,13 +364,8 @@
 	{
 		"description": "A basic battery powered flashlight. It will shine a beam of light when it is turned on",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "flashlight_basic",
 		"image": "./Mods/Core/Items/flashlight_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "1",
 		"name": "Flashlight",
 		"sprite": "flashlight_32.png",
@@ -443,13 +393,8 @@
 	{
 		"description": "It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "pack_sigarrettes",
 		"image": "./Mods/Core/Items/sigarrette_pack_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "5",
 		"name": "Pack of sigarrettes",
 		"sprite": "sigarrette_pack_32.png",
@@ -462,7 +407,6 @@
 	{
 		"description": "A piece of clothing that offers protection from environmental hazards",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "gas_mask",
 		"image": "./Mods/Core/Items/gasmask_32.png",
 		"max_stack_size": "1",
@@ -507,13 +451,8 @@
 	{
 		"description": "A very common type of battery that fits most battery-powered devices",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "battery_small",
 		"image": "./Mods/Core/Items/battery_32.png",
-		"itemgroups": [
-			"kitchen_cupboard",
-			"cabinet_general"
-		],
 		"max_stack_size": "20",
 		"name": "Small battery",
 		"sprite": "battery_32.png",
@@ -616,12 +555,8 @@
 	{
 		"description": "A small bottle that contains disinfectant. It helps to disinfect wounds",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "bottle_disinfectant",
 		"image": "./Mods/Core/Items/bottle_disinfectant_32.png",
-		"itemgroups": [
-			"kitchen_cupboard"
-		],
 		"max_stack_size": "5",
 		"name": "Bottle of disinfectant",
 		"sprite": "bottle_disinfectant_32.png",
@@ -634,12 +569,8 @@
 	{
 		"description": "A small radio that allows you to communicate with someone over a large distance",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "radio_two_way",
 		"image": "./Mods/Core/Items/radio_two_way_32.png",
-		"itemgroups": [
-			"cabinet_general"
-		],
 		"max_stack_size": "1",
 		"name": "Two way radio",
 		"sprite": "radio_two_way_32.png",
@@ -667,12 +598,8 @@
 	{
 		"description": "\n    A true survival fishing kit in a very small, lightweight package!\n    Contains 118 foot line and winder\n    2 lures, 2 hooks\n    2 swivels, 2 weghts\n    Comes in a strong durable heavy duty resealable plastic bag",
 		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "kit_fishing_small",
 		"image": "./Mods/Core/Items/kit_fishing_small_32.png",
-		"itemgroups": [
-			"cabinet_general"
-		],
 		"max_stack_size": "1",
 		"name": "Small fishing kit",
 		"sprite": "kit_fishing_small_32.png",

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -6,6 +6,13 @@
 		"image": "./Mods/Core/Items/plank.png",
 		"max_stack_size": "3",
 		"name": "Plank 2x4",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"mob_loot"
+				]
+			}
+		},
 		"sprite": "plank.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -20,6 +27,14 @@
 		"image": "./Mods/Core/Items/steel_scrap.png",
 		"max_stack_size": "100",
 		"name": "Steel scrap",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general",
+					"mob_loot"
+				]
+			}
+		},
 		"sprite": "steel_scrap.png",
 		"stack_size": "2",
 		"two_handed": false,
@@ -37,6 +52,14 @@
 		"image": "./Mods/Core/Items/9mm.png",
 		"max_stack_size": "100",
 		"name": "bullet 9mm",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general",
+					"mob_loot"
+				]
+			}
+		},
 		"sprite": "9mm.png",
 		"stack_size": "20",
 		"two_handed": false,
@@ -56,6 +79,14 @@
 		"image": "./Mods/Core/Items/pistol_magazine.png",
 		"max_stack_size": "1",
 		"name": "Pistol magazine",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general",
+					"mob_loot"
+				]
+			}
+		},
 		"sprite": "pistol_magazine.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -81,6 +112,13 @@
 		"image": "./Mods/Core/Items/pistol_32.png",
 		"max_stack_size": "1",
 		"name": "Pistol 9mm",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "pistol_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -164,6 +202,13 @@
 		"image": "./Mods/Core/Items/bottle_empty_32.png",
 		"max_stack_size": "10",
 		"name": "Empty plastic bottle",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "bottle_empty_32.png",
 		"stack_size": "2",
 		"two_handed": false,
@@ -181,6 +226,14 @@
 		"image": "./Mods/Core/Items/bottle_water_32.png",
 		"max_stack_size": "10",
 		"name": "Plastic bottle with water",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general",
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "bottle_water_32.png",
 		"stack_size": "2",
 		"two_handed": false,
@@ -195,6 +248,13 @@
 		"image": "./Mods/Core/Items/canned_food_32.png",
 		"max_stack_size": "5",
 		"name": "Canned food\t",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "canned_food_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -238,6 +298,13 @@
 		"image": "./Mods/Core/Items/hammer_32.png",
 		"max_stack_size": "1",
 		"name": "Hammer",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "hammer_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -252,6 +319,14 @@
 		"image": "./Mods/Core/Items/screwdriver_32.png",
 		"max_stack_size": "1",
 		"name": "Screwdriver",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general",
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "screwdriver_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -266,6 +341,14 @@
 		"image": "./Mods/Core/Items/bandage_32.png",
 		"max_stack_size": "20",
 		"name": "Bandage",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general",
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "bandage_32.png",
 		"stack_size": "3",
 		"two_handed": false,
@@ -280,6 +363,13 @@
 		"image": "./Mods/Core/Items/antibiotics_32.png",
 		"max_stack_size": "5",
 		"name": "Bottle of antibiotics",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "antibiotics_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -310,6 +400,13 @@
 		"image": "./Mods/Core/Items/boots_32.png",
 		"max_stack_size": "1",
 		"name": "Boots",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "boots_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -340,6 +437,13 @@
 		"image": "./Mods/Core/Items/can_oil_32.png",
 		"max_stack_size": "1",
 		"name": "Can of oil",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "can_oil_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -368,6 +472,13 @@
 		"image": "./Mods/Core/Items/flashlight_32.png",
 		"max_stack_size": "1",
 		"name": "Flashlight",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "flashlight_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -383,6 +494,13 @@
 		"image": "./Mods/Core/Items/can_beer_32.png",
 		"max_stack_size": "5",
 		"name": "Can of beer",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "can_beer_32.png",
 		"stack_size": "2",
 		"two_handed": false,
@@ -455,6 +573,13 @@
 		"image": "./Mods/Core/Items/battery_32.png",
 		"max_stack_size": "20",
 		"name": "Small battery",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "battery_32.png",
 		"stack_size": "2",
 		"two_handed": false,
@@ -545,6 +670,13 @@
 		"image": "./Mods/Core/Items/book_novel_32.png",
 		"max_stack_size": "5",
 		"name": "Novel",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"cabinet_general"
+				]
+			}
+		},
 		"sprite": "book_novel_32.png",
 		"stack_size": "1",
 		"two_handed": false,
@@ -559,6 +691,13 @@
 		"image": "./Mods/Core/Items/bottle_disinfectant_32.png",
 		"max_stack_size": "5",
 		"name": "Bottle of disinfectant",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"kitchen_cupboard"
+				]
+			}
+		},
 		"sprite": "bottle_disinfectant_32.png",
 		"stack_size": "1",
 		"two_handed": false,

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -175,6 +175,9 @@
 		"height": "2",
 		"id": "bottle_plastic_empty",
 		"image": "./Mods/Core/Items/bottle_empty_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "10",
 		"name": "Empty plastic bottle",
 		"sprite": "bottle_empty_32.png",
@@ -210,7 +213,8 @@
 		"id": "canned_food",
 		"image": "./Mods/Core/Items/canned_food_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "5",
 		"name": "Canned food\t",
@@ -256,7 +260,8 @@
 		"id": "hammer",
 		"image": "./Mods/Core/Items/hammer_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "1",
 		"name": "Hammer",
@@ -274,7 +279,8 @@
 		"id": "screwdriver",
 		"image": "./Mods/Core/Items/screwdriver_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "1",
 		"name": "Screwdriver",
@@ -292,7 +298,8 @@
 		"id": "bandage_basic",
 		"image": "./Mods/Core/Items/bandage_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "20",
 		"name": "Bandage",
@@ -387,6 +394,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "radio_handheld",
 		"image": "./Mods/Core/Items/battery_powered_radio_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "1",
 		"name": "Handheld radio",
 		"sprite": "battery_powered_radio_32.png",
@@ -403,7 +413,8 @@
 		"id": "flashlight_basic",
 		"image": "./Mods/Core/Items/flashlight_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "1",
 		"name": "Flashlight",
@@ -436,7 +447,8 @@
 		"id": "pack_sigarrettes",
 		"image": "./Mods/Core/Items/sigarrette_pack_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "5",
 		"name": "Pack of sigarrettes",
@@ -499,7 +511,8 @@
 		"id": "battery_small",
 		"image": "./Mods/Core/Items/battery_32.png",
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general"
 		],
 		"max_stack_size": "20",
 		"name": "Small battery",
@@ -624,6 +637,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "radio_two_way",
 		"image": "./Mods/Core/Items/radio_two_way_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "1",
 		"name": "Two way radio",
 		"sprite": "radio_two_way_32.png",
@@ -654,6 +670,9 @@
 		"iamge": "res://Textures/plank.png",
 		"id": "kit_fishing_small",
 		"image": "./Mods/Core/Items/kit_fishing_small_32.png",
+		"itemgroups": [
+			"cabinet_general"
+		],
 		"max_stack_size": "1",
 		"name": "Small fishing kit",
 		"sprite": "kit_fishing_small_32.png",

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -7,7 +7,8 @@
 		"id": "grass_plain",
 		"name": "Plain grass",
 		"shape": "cube",
-		"sprite": "1.png"
+		"sprite": "1.png",
+		"transparent": false
 	},
 	{
 		"categories": [

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you like Godot and want to contribute, feel free to submit a pull request or 
 ## Community
 
 Official Discord:
-[https://discord.gg/jFEc7Yp](https://discord.gg/hWJTUSnW)
+[https://discord.gg/hWJTUSnW](https://discord.gg/hWJTUSnW)
 
 
 ## Credits:

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
@@ -1,6 +1,22 @@
-[gd_scene load_steps=2 format=3 uid="uid://b7jwy5hpj2vyt"]
+[gd_scene load_steps=3 format=3 uid="uid://b7jwy5hpj2vyt"]
 
 [ext_resource type="Script" path="res://Scripts/ItemCraftEditor.gd" id="1_6wvrt"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rvald"]
+content_margin_left = 11.0
+content_margin_top = 11.0
+content_margin_right = 11.0
+content_margin_bottom = 11.0
+bg_color = Color(0.358505, 0.289355, 0.48639, 1)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
 
 [node name="ItemCraftEditor" type="Control" node_paths=PackedStringArray("craftAmountNumber", "craftTimeNumber", "requiresLightCheckbox", "resourcesGridContainer")]
 layout_mode = 3
@@ -13,7 +29,7 @@ script = ExtResource("1_6wvrt")
 craftAmountNumber = NodePath("Craft/CraftAmountNumber")
 craftTimeNumber = NodePath("Craft/CraftTimeNumber")
 requiresLightCheckbox = NodePath("Craft/RequiresLightCheckBox")
-resourcesGridContainer = NodePath("Craft/ResourcesGridContainer")
+resourcesGridContainer = NodePath("Craft/PanelContainer/ResourcesGridContainer")
 
 [node name="Craft" type="GridContainer" parent="."]
 layout_mode = 1
@@ -40,10 +56,15 @@ value = 1.0
 layout_mode = 2
 text = "Required materials"
 
-[node name="ResourcesGridContainer" type="GridContainer" parent="Craft"]
+[node name="PanelContainer" type="PanelContainer" parent="Craft"]
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_rvald")
+
+[node name="ResourcesGridContainer" type="GridContainer" parent="Craft/PanelContainer"]
 custom_minimum_size = Vector2(200, 200)
 layout_mode = 2
-columns = 2
+columns = 3
 
 [node name="CraftTimeLabel" type="Label" parent="Craft"]
 layout_mode = 2

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=2 format=3 uid="uid://b7jwy5hpj2vyt"]
+
+[ext_resource type="Script" path="res://Scripts/ItemCraftEditor.gd" id="1_6wvrt"]
+
+[node name="ItemCraftEditor" type="Control" node_paths=PackedStringArray("craftAmountNumber", "craftTimeNumber", "requiresLightCheckbox", "resourcesGridContainer")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_6wvrt")
+craftAmountNumber = NodePath("Craft/CraftAmountNumber")
+craftTimeNumber = NodePath("Craft/CraftTimeNumber")
+requiresLightCheckbox = NodePath("Craft/RequiresLightCheckBox")
+resourcesGridContainer = NodePath("Craft/ResourcesGridContainer")
+
+[node name="Craft" type="GridContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_vertical = 3
+columns = 2
+
+[node name="CraftAmountLabel" type="Label" parent="Craft"]
+layout_mode = 2
+text = "Craft amount"
+
+[node name="CraftAmountNumber" type="SpinBox" parent="Craft"]
+layout_mode = 2
+tooltip_text = "The width of this item in the inventory. A larger number means it will take up more horizontal inventory slots"
+min_value = 1.0
+max_value = 1000.0
+value = 1.0
+
+[node name="RequiredResourceLabel" type="Label" parent="Craft"]
+layout_mode = 2
+text = "Required materials"
+
+[node name="ResourcesGridContainer" type="GridContainer" parent="Craft"]
+custom_minimum_size = Vector2(200, 200)
+layout_mode = 2
+columns = 2
+
+[node name="CraftTimeLabel" type="Label" parent="Craft"]
+layout_mode = 2
+text = "Craft time"
+
+[node name="CraftTimeNumber" type="SpinBox" parent="Craft"]
+layout_mode = 2
+tooltip_text = "The time it takes to craft"
+min_value = 1.0
+value = 10.0
+
+[node name="FlagsLabel" type="Label" parent="Craft"]
+layout_mode = 2
+text = "Flags"
+
+[node name="RequiresLightCheckBox" type="CheckBox" parent="Craft"]
+layout_mode = 2
+tooltip_text = "Enable this if the item weapon occupies both hands when held. Disable this if the item occupies one hand when held"
+text = "Requires light"

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://dmpomdwta1pgq"]
+[gd_scene load_steps=9 format=3 uid="uid://dmpomdwta1pgq"]
 
 [ext_resource type="Script" path="res://Scripts/ItemEditor.gd" id="1_ef3j7"]
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_ghd7c"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://27f4k2pq2odn" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMagazineEditor.tscn" id="4_x8xa3"]
 [ext_resource type="PackedScene" uid="uid://c2uiumyeepree" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemAmmoEditor.tscn" id="5_mr1dn"]
 [ext_resource type="PackedScene" uid="uid://cq4t64qb15y27" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemFoodEditor.tscn" id="6_htafc"]
+[ext_resource type="PackedScene" uid="uid://b7jwy5hpj2vyt" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn" id="7_itht2"]
 
 [node name="ItemEditor" type="Control" node_paths=PackedStringArray("tabContainer", "itemImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemSelector", "VolumeNumberBox", "WeightNumberBox", "StackSizeNumberBox", "MaxStackSizeNumberBox", "typesContainer", "TwoHandedCheckBox")]
 layout_mode = 3
@@ -239,6 +240,10 @@ visible = false
 layout_mode = 2
 
 [node name="Food" parent="VBoxContainer/TabContainer" instance=ExtResource("6_htafc")]
+visible = false
+layout_mode = 2
+
+[node name="Craft" parent="VBoxContainer/TabContainer" instance=ExtResource("7_itht2")]
 visible = false
 layout_mode = 2
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -22,9 +22,9 @@ extends Control
 @export var ItemGroupTextEdit: TextEdit = null
 # This signal will be emitted when the user presses the save button
 # This signal should alert Gamedata that the mob data array should be saved to disk
-# The content editor has connected this signal to Gamedata already
-signal data_changed()
+signal data_changed(game_data: Dictionary, new_data: Dictionary, old_data: Dictionary)
 
+var olddata: Dictionary # Remember what the value of the data was before editing
 # The data that represents this mob
 # The data is selected from the Gamedata.data.mobs.data array
 # based on the ID that the user has selected in the content editor
@@ -33,6 +33,12 @@ var contentData: Dictionary = {}:
 		contentData = value
 		load_mob_data()
 		mobSelector.sprites_collection = Gamedata.data.mobs.sprites
+		olddata = contentData.duplicate(true)
+
+
+func _ready():
+	data_changed.connect(Gamedata.on_data_changed)
+
 
 #This function update the form based on the contentData that has been loaded
 func load_mob_data() -> void:
@@ -90,7 +96,9 @@ func _on_save_button_button_up() -> void:
 		contentData["loot_group"] = ItemGroupTextEdit.text
 	else:
 		contentData.erase("loot_group")
-	data_changed.emit()
+	data_changed.emit(Gamedata.data.mobs, contentData, olddata)
+	olddata = contentData.duplicate(true)
+
 
 #When the mobImageDisplay is clicked, the user will be prompted to select an image from 
 # "res://Mods/Core/mobs/". The texture of the mobImageDisplay will change to the selected image

--- a/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
@@ -16,10 +16,10 @@ extends Control
 @export var slopeShapeCheckbox: Button = null
 @export var transparentCheckbox: Button = null
 # This signal will be emitted when the user presses the save button
-# This signal should alert Gamedata that the tile data array should be saved to disk
-# The content editor has connected this signal to Gamedata already
-signal data_changed()
+# This signal should alert Gamedata that the mob data array should be saved to disk
+signal data_changed(game_data: Dictionary, new_data: Dictionary, old_data: Dictionary)
 
+var olddata: Dictionary # Remember what the value of the data was before editing
 var control_elements: Array = []
 # The data that represents this tile
 # The data is selected from the Gamedata.data.tiles.data array
@@ -29,6 +29,7 @@ var contentData: Dictionary = {}:
 		contentData = value
 		load_tile_data()
 		tileSelector.sprites_collection = Gamedata.data.tiles.sprites
+		olddata = contentData.duplicate(true)
 
 
 func _ready():
@@ -40,6 +41,8 @@ func _ready():
 		cubeShapeCheckbox,
 		slopeShapeCheckbox
 	]
+	data_changed.connect(Gamedata.on_data_changed)
+
 
 func _input(event):
 	if event.is_action_pressed("ui_focus_next"):
@@ -97,7 +100,8 @@ func _on_save_button_button_up():
 	if slopeShapeCheckbox.button_pressed:
 		contentData["shape"] = "slope"
 	contentData["transparent"] = transparentCheckbox.button_pressed
-	data_changed.emit()
+	data_changed.emit(Gamedata.data.tiles, contentData, olddata)
+	olddata = contentData.duplicate(true)
 
 #When the tileImageDisplay is clicked, the user will be prompted to select an image from 
 # "res://Mods/Core/Tiles/". The texture of the tileImageDisplay will change to the selected image

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -134,7 +134,7 @@ func _on_ok_button_up():
 	if popupAction == "Add":
 			Gamedata.add_id_to_data(contentData, myText)
 	if popupAction == "Duplicate":
-		if contentData.data.datapath.ends_with(".json"):  # It's a json file with items
+		if contentData.dataPath.ends_with(".json"):  # It's a json file with items
 			Gamedata.duplicate_item_in_data(contentData,get_selected_item_text(),myText)
 		else: #It's folder with json files
 			Gamedata.duplicate_file_in_data(contentData,get_selected_item_text(),myText)

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -134,12 +134,10 @@ func _on_ok_button_up():
 	if popupAction == "Add":
 			Gamedata.add_id_to_data(contentData, myText)
 	if popupAction == "Duplicate":
-		# This is true if contentData.data is an array of strings
-		# Else, it will be an array of dictionaries
-		if contentData.data[0] is String:
-			Gamedata.duplicate_file_in_data(contentData,get_selected_item_text(),myText)
-		else:
+		if contentData.data.datapath.ends_with(".json"):  # It's a json file with items
 			Gamedata.duplicate_item_in_data(contentData,get_selected_item_text(),myText)
+		else: #It's folder with json files
+			Gamedata.duplicate_file_in_data(contentData,get_selected_item_text(),myText)
 	popupAction = ""
 	load_data()
 

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -77,20 +77,18 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 	tabContainer.add_child(newContentEditor)
 	tabContainer.current_tab = tabContainer.get_child_count()-1
 	if data.dataPath.ends_with(".json"):
+		var itemdata: Dictionary = data.data[Gamedata.get_array_index_by_id(data,itemID)]
 		#We only pass the data for the specific id to the editor
-		newContentEditor.contentData = data.data[Gamedata.get_array_index_by_id(data,itemID)]
-		#Connect the data_changed signal to the Gamedata.on_data_changed function
-		#We pass trough the data collection that the changed data belongs to
-		newContentEditor.data_changed.connect(Gamedata.on_data_changed.bind(data))
-		newContentEditor.data_changed.connect(_on_editor_data_changed.bind(data))
+		newContentEditor.contentData = itemdata
+		newContentEditor.data_changed.connect(_on_editor_data_changed)
 	else:
 		#If the data source does not end with json, it's a directory
 		#So now we pass in the file we want the editor to edit
 		newContentEditor.contentSource = data.dataPath + itemID + ".json"
 
 
-# function to handle data changes
-func _on_editor_data_changed(data: Dictionary):
+# The content_list that had it's data changed refreshes
+func _on_editor_data_changed(data: Dictionary, _newdata: Dictionary, _olddata: Dictionary):
 	for element in content.get_children():
 		if element.contentData == data:
 			element.load_data()

--- a/Scripts/Helper/json_helper.gd
+++ b/Scripts/Helper/json_helper.gd
@@ -82,7 +82,7 @@ func folder_names_in_dir(path: String) -> Array:
 
 
 #This function takes a json string and saves it as a json file.
-func write_json_file(path: String, json: String):
+func write_json_file(path: String, json: String) -> Error:
 	# If the file does not exists, we create a new one.
 	if not FileAccess.file_exists(path):
 		create_new_json_file(path)
@@ -91,8 +91,10 @@ func write_json_file(path: String, json: String):
 	if file:
 		file.store_string(json)
 		file.close()
+		return OK
 	else:
 		print_debug("Unable to write file " + path)
+	return FAILED
 
 
 # This function will take a path and create a new json file with just {} or [] as the contents.
@@ -157,10 +159,12 @@ func add_id_to_json_file(source: String, id: String):
 
 #This function will take a path to a json file and delete it
 func delete_json_file(path: String):
-	var dir = DirAccess.open(path)
+	var filename: String = path.get_file()
+	var dirname: String = path.replace(filename,"")
+	var dir = DirAccess.open(dirname)
 	if dir:
 		# Delete the file
-		var err = dir.remove(path)
+		var err = dir.remove(filename)
 		if err == OK:
 			print_debug("File deleted successfully: " + path)
 		else:

--- a/Scripts/ItemCraftEditor.gd
+++ b/Scripts/ItemCraftEditor.gd
@@ -1,0 +1,111 @@
+extends Control
+
+# This scene is intended to be used inside the item editor
+# It is supposed to edit exactly one craft recipe
+
+@export var craftAmountNumber: SpinBox = null
+@export var craftTimeNumber: SpinBox = null
+@export var requiresLightCheckbox: CheckBox = null
+@export var resourcesGridContainer: GridContainer = null
+
+
+func _ready():
+	pass
+
+
+func get_properties() -> Dictionary:
+	var properties = {
+		"craft_amount": craftAmountNumber.value,
+		"craft_time": craftTimeNumber.value,
+		"flags": {"requires_light": requiresLightCheckbox.pressed},
+		"resources": []
+	}
+	
+	# Iterate over children of resourcesGridContainer to collect resource data
+	var children = resourcesGridContainer.get_children()
+	for i in range(0, children.size(), 2): # Step by 2 to handle label-spinbox pairs
+		var label = children[i] as Label
+		var spinBox = children[i + 1] as SpinBox
+		properties["resources"].append({"id": label.text, "amount": spinBox.value})
+	
+	return properties
+
+
+func set_properties(properties: Dictionary) -> void:
+	# Clear existing resources
+	resourcesGridContainer.queue_free()
+	resourcesGridContainer = GridContainer.new()
+	add_child(resourcesGridContainer)
+
+	# Set the craft amount, time, and flags
+	craftAmountNumber.value = properties.get("craft_amount", 1)
+	craftTimeNumber.value = properties.get("craft_time", 0)
+	requiresLightCheckbox.button_pressed = properties.get("flags", {}).get("requires_light", false)
+
+	# Populate resources grid using the new function
+	if properties.has("resources"):
+		for resource in properties["resources"]:
+			add_resource_entry(resource["id"], resource["amount"])
+
+
+# This function should return true if the dragged data can be dropped here
+func _can_drop_data(_newpos, data) -> bool:
+	# Check if the data dictionary has the 'id' property
+	if not data or not data.has("id"):
+		return false
+	
+	# Fetch itemgroup data by ID from the Gamedata to ensure it exists and is valid
+	var item_data = Gamedata.get_data_by_id(Gamedata.data.items, data["id"])
+	if item_data.is_empty():
+		return false
+
+	# If all checks pass, return true
+	return true
+
+
+# This function handles the data being dropped
+func _drop_data(newpos, data) -> void:
+	if _can_drop_data(newpos, data):
+		_handle_item_drop(data, newpos)
+
+
+# Called when the user has successfully dropped data onto the ItemGroupTextEdit
+# We have to check the dropped_data for the id property
+func _handle_item_drop(dropped_data, _newpos) -> void:
+	# Dropped_data is a Dictionary that includes an 'id'
+	if dropped_data and "id" in dropped_data:
+		var item_id = dropped_data["id"]
+		var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
+		if item_data.is_empty():
+			print_debug("No item data found for ID: " + item_id)
+			return
+		
+		# Add the resource entry using the new function
+		add_resource_entry(item_id, 1)
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+
+
+func _delete_resource(elements_to_remove: Array) -> void:
+	for element in elements_to_remove:
+		resourcesGridContainer.remove_child(element)
+		element.queue_free()  # Properly free the node to avoid memory leaks
+
+
+func add_resource_entry(item_id: String, amount: int = 1):
+	# Create a label for the item ID
+	var label = Label.new()
+	label.text = item_id
+	resourcesGridContainer.add_child(label)
+	
+	# Create a SpinBox for the amount
+	var amountSpinBox = SpinBox.new()
+	amountSpinBox.value = amount
+	resourcesGridContainer.add_child(amountSpinBox)
+	
+	# Create a delete button
+	var deleteButton = Button.new()
+	deleteButton.text = "X"
+	deleteButton.pressed.connect(_delete_resource.bind([label, amountSpinBox, deleteButton]))
+	resourcesGridContainer.add_child(deleteButton)

--- a/Scripts/ItemEditor.gd
+++ b/Scripts/ItemEditor.gd
@@ -32,12 +32,11 @@ extends Control
 @export var TwoHandedCheckBox: CheckBox = null
 
 
-
 # This signal will be emitted when the user presses the save button
-# This signal should alert Gamedata that the item data array should be saved to disk
-# The content editor has connected this signal to Gamedata already
-signal data_changed()
+# This signal should alert Gamedata that the mob data array should be saved to disk
+signal data_changed(game_data: Dictionary, new_data: Dictionary, old_data: Dictionary)
 
+var olddata: Dictionary # Remember what the value of the data was before editing
 # The data that represents this item
 # The data is selected from the Gamedata.data.items.data array
 # based on the ID that the user has selected in the content editor
@@ -46,9 +45,11 @@ var contentData: Dictionary = {}:
 		contentData = value
 		load_item_data()
 		itemSelector.sprites_collection = Gamedata.data.items.sprites
+		olddata = contentData.duplicate(true)
 		
 func _ready():
 	refresh_tab_visibility()
+	data_changed.connect(Gamedata.on_data_changed)
 
 #This function update the form based on the contentData that has been loaded
 func load_item_data() -> void:
@@ -120,7 +121,8 @@ func _on_save_button_button_up() -> void:
 				# Delete the property if checkbox is not checked and it exists in contentData
 				if contentData.has(child.text):
 					contentData.erase(child.text)
-	data_changed.emit()
+	data_changed.emit(Gamedata.data.items, contentData, olddata)
+	olddata = contentData.duplicate(true)
 
 
 #When the itemImageDisplay is clicked, the user will be prompted to select an image from 

--- a/Scripts/ItemMagazineEditor.gd
+++ b/Scripts/ItemMagazineEditor.gd
@@ -13,8 +13,8 @@ extends Control
 func get_properties() -> Dictionary:
 	return {
 		"used_ammo": UsedAmmoTextEdit.text,
-		"max_ammo": MaxAmmoNumberBox.get_line_edit().text,
-		"current_ammo": CurrentAmmoNumberBox.get_line_edit().text
+		"max_ammo": MaxAmmoNumberBox.value,
+		"current_ammo": CurrentAmmoNumberBox.value
 	}
 
 func set_properties(properties: Dictionary) -> void:

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -20,6 +20,7 @@ func _ready():
 	var magazines = Gamedata.get_items_by_type("Magazine")
 	initialize_magazine_selection(magazines)
 
+
 func initialize_magazine_selection(magazines: Array):
 	for magazine in magazines:
 		var magazine_button = CheckBox.new()

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -107,6 +107,7 @@ func duplicate_item_in_data(contentData: Dictionary, id: String, newID: String):
 		# Add the duplicated item to the JSON data.
 		contentData.data.append(item_to_duplicate)
 		Helper.json_helper.write_json_file(contentData.dataPath,JSON.stringify(contentData.data,"\t"))
+		on_data_changed(contentData,item_to_duplicate,{})
 	else:
 		print_debug("There should be code here for when a file in the gets duplicated")
 
@@ -129,13 +130,14 @@ func duplicate_file_in_data(contentData: Dictionary, original_id: String, new_id
 	var save_result = Helper.json_helper.write_json_file(new_file_path, JSON.stringify(original_content))
 	if save_result == OK:
 		print_debug("File duplicated successfully: " + new_file_path)
-		# Add the new ID to the data array if it's managed as an array of IDs.
-		if contentData.data is Array and typeof(contentData.data[0]) == TYPE_STRING:
+		# Add the new ID to the data array if it's datapath references a folder.
+		var datapath: String = contentData.data.datapath
+		if contentData.data is Array and datapath.ends_with("/"):
 			contentData.data.append(new_id)
-			save_data_to_file(contentData)  # Save the updated data array to file.
+			if datapath.ends_with("/maps/"): # Update references to this duplicated map
+				on_mapdata_changed(datapath,original_content,{})
 	else:
 		print_debug("Failed to duplicate file to: " + new_file_path)
-
 
 
 # This function appends a new object to an existing array

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -399,10 +399,10 @@ func add_reference(data: Dictionary, module: String, type: String, onid: String,
 # Example usage: var changes_made = remove_reference(Gamedata.data.itemgroups, "core", 
 # "furniture", itemgroup_id, furniture_id)
 # This example will remove the specified furniture from the itemgroup's references
-func remove_reference(data: Dictionary, module: String, type: String, fromid: String, refid: String) -> bool:
+func remove_reference(mydata: Dictionary, module: String, type: String, fromid: String, refid: String) -> bool:
 	var changes_made: bool = false
 	if fromid != "":
-		var entitydata = get_data_by_id(data, fromid)
+		var entitydata = get_data_by_id(mydata, fromid)
 		if entitydata.has("references") and entitydata["references"].has(module) and entitydata["references"][module].has(type):
 			var refs = entitydata["references"][module][type]
 			if refid in refs:
@@ -428,8 +428,8 @@ func remove_relations_of_deleted_id(contentData: Dictionary, id: String):
 
 
 # Erases a nested property from a given dictionary based on a dot-separated path
-func erase_property_by_path(data: Dictionary, item_id: String, property_path: String):
-	var entity_data = get_data_by_id(data, item_id)
+func erase_property_by_path(mydata: Dictionary, item_id: String, property_path: String):
+	var entity_data = get_data_by_id(mydata, item_id)
 	if entity_data.is_empty():
 		print_debug("Entity with ID", item_id, "not found.")
 		return false
@@ -511,26 +511,26 @@ func on_furniture_deleted(furniture_id: String):
 # type = the type of reference we want to handle. For example "furniture"
 # callable = a function to execute on each reference ID
 # We will check if data has the ["references"] and [type] properties and execute the callable on each found ID
-func execute_callable_on_references_of_type(data: Dictionary, module: String, type: String, callable: Callable):
+func execute_callable_on_references_of_type(mydata: Dictionary, module: String, type: String, callable: Callable):
 	# Check if 'data' contains a 'references' dictionary and if it contains the specified 'type'
-	if data.has("references") and data["references"].has(module) and data["references"][module].has(type):
+	if mydata.has("references") and mydata["references"].has(module) and mydata["references"][module].has(type):
 		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in data["references"][module][type]:
+		for ref_id in mydata["references"][module][type]:
 			callable.call(ref_id)
 
 
 # Retrieves the value of a nested property from a given dictionary based on a dot-separated path
-func get_property_by_path(data: Dictionary, property_path: String, entity_id: String) -> Variant:
-	var entity_data = get_data_by_id(data, entity_id)
+func get_property_by_path(mydata: Dictionary, property_path: String, entity_id: String) -> Variant:
+	var entity_data = get_data_by_id(mydata, entity_id)
 	if entity_data.is_empty():
 		print_debug("Entity with ID", entity_id, "not found.")
 		return null
 	return get_nested_data(entity_data, property_path)
 
 
-func get_nested_data(data: Dictionary, path: String) -> Variant:
+func get_nested_data(mydata: Dictionary, path: String) -> Variant:
 	var parts = path.split(".")
-	var current = data
+	var current = mydata
 	for part in parts:
 		if current.has(part):
 			current = current[part]

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -274,7 +274,6 @@ func get_items_by_type(item_type: String) -> Array:
 	return filtered_items
 
 
-
 # An itemgroup has been changed. Update items that were added or removed from the list
 # oldlist and newlist are arrays with item id strings in them
 func on_itemgroup_changed(itemgroup: String, oldlist: Array[String], newlist: Array[String]):
@@ -335,6 +334,23 @@ func on_itemgroup_deleted(itemgroup_id: String):
 	if itemgroup_data.is_empty():
 		print("Itemgroup with ID", itemgroup_id, "not found.")
 		return
+	
+	# Handling the in_furniture attribute for furniture items
+	if "in_furniture" in itemgroup_data:
+		var furniture_ids = itemgroup_data["in_furniture"]
+		for furniture_id in furniture_ids:
+			var furniture_data = get_data_by_id(Gamedata.data.furniture, furniture_id)
+			if furniture_data.is_empty():
+				print("Furniture with ID", furniture_id, "not found.")
+				continue
+
+			# Navigate through the nested dictionary safely
+			if "Function" in furniture_data and "container" in furniture_data["Function"]:
+				if "itemgroup" in furniture_data["Function"]["container"]:
+					# Check if this itemgroup matches the one being deleted
+					if furniture_data["Function"]["container"]["itemgroup"] == itemgroup_id:
+						furniture_data["Function"]["container"].erase("itemgroup")
+						changes_made = true
 
 	# The itemgroup data contains a list of item IDs in an 'items' attribute
 	if "items" in itemgroup_data:
@@ -353,10 +369,56 @@ func on_itemgroup_deleted(itemgroup_id: String):
 				# If no more itemgroups are left in the item, consider removing the 'itemgroups' attribute
 				if item_data["itemgroups"].size() == 0:
 					item_data.erase("itemgroups")
-					
+
 	# Save changes to the data file if any changes were made
 	if changes_made:
 		save_data_to_file(Gamedata.data.items)
+		save_data_to_file(Gamedata.data.furniture)
 		print("Itemgroup", itemgroup_id, "has been successfully deleted from all items.")
 	else:
 		print("No changes needed for itemgroup", itemgroup_id)
+
+
+# Some furniture has had their itemgroup changed
+# We need to update the relation between the furniture and the itemgroup
+func on_furniture_itemgroup_changed(furniture_id: String, old_group: String, new_group: String):
+	# Exit if old_group and new_group are the same
+	if old_group == new_group:
+		print_debug("No change in itemgroup. Exiting function.")
+		return
+	var changes_made = false
+
+	# Handle the old itemgroup
+	if old_group != "":
+		var old_itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, old_group)
+		if old_itemgroup_data.has("in_furniture"):
+			# Check if the furniture_id is in the old itemgroup and remove it
+			if furniture_id in old_itemgroup_data["in_furniture"]:
+				old_itemgroup_data["in_furniture"].erase(furniture_id)
+				changes_made = true
+				# If in_furniture is now empty, remove the property
+				if old_itemgroup_data["in_furniture"].size() == 0:
+					old_itemgroup_data.erase("in_furniture")
+
+	# Handle the new itemgroup
+	if new_group != "":
+		var new_itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, new_group)
+		# Ensure the new group has the 'in_furniture' list initialized
+		if not new_itemgroup_data.has("in_furniture"):
+			new_itemgroup_data["in_furniture"] = []
+		# Add the furniture_id to the new itemgroup if it's not already there
+		if furniture_id not in new_itemgroup_data["in_furniture"]:
+			new_itemgroup_data["in_furniture"].append(furniture_id)
+			changes_made = true
+
+	# Save changes if any modifications were made
+	if changes_made:
+		if old_group != "":
+			save_data_to_file(Gamedata.data.itemgroups)
+		if new_group != "" and new_group != old_group:
+			save_data_to_file(Gamedata.data.itemgroups)
+
+	if changes_made:
+		print_debug("Furniture itemgroup changes saved successfully.")
+	else:
+		print_debug("No changes were made to furniture itemgroups.")

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -106,7 +106,7 @@ func duplicate_item_in_data(contentData: Dictionary, id: String, newID: String):
 		item_to_duplicate["id"] = newID
 		# Add the duplicated item to the JSON data.
 		contentData.data.append(item_to_duplicate)
-		Helper.json_helper.write_json_file(contentData.dataPath,JSON.stringify(contentData.data))
+		Helper.json_helper.write_json_file(contentData.dataPath,JSON.stringify(contentData.data,"\t"))
 	else:
 		print_debug("There should be code here for when a file in the gets duplicated")
 
@@ -170,8 +170,7 @@ func remove_item_from_data(contentData: Dictionary, id: String):
 	if contentData.data.is_empty():
 		return
 	if contentData.data[0] is Dictionary:
-		if contentData == Gamedata.data.itemgroups:
-			on_itemgroup_deleted(id)
+		remove_relations_of_deleted_id(contentData, id)
 		contentData.data.remove_at(get_array_index_by_id(contentData, id))
 		save_data_to_file(contentData)
 	elif contentData.data[0] is String:
@@ -244,7 +243,7 @@ func update_item_protoset_json_data(tres_path: String, new_json_data: String) ->
 	# Load the ItemProtoset resource
 	var item_protoset = load(tres_path) as ItemProtoset
 	if not item_protoset:
-		print("Failed to load ItemProtoset resource from:", tres_path)
+		print_debug("Failed to load ItemProtoset resource from:", tres_path)
 		return
 
 	# Update the json_data property
@@ -253,9 +252,9 @@ func update_item_protoset_json_data(tres_path: String, new_json_data: String) ->
 	# Save the resource back to the .tres file
 	var save_result = ResourceSaver.save(item_protoset, tres_path)
 	if save_result != OK:
-		print("Failed to save updated ItemProtoset resource to:", tres_path)
+		print_debug("Failed to save updated ItemProtoset resource to:", tres_path)
 	else:
-		print("ItemProtoset resource updated and saved successfully to:", tres_path)
+		print_debug("ItemProtoset resource updated and saved successfully to:", tres_path)
 
 
 # Function to filter items by type
@@ -278,43 +277,19 @@ func get_items_by_type(item_type: String) -> Array:
 # oldlist and newlist are arrays with item id strings in them
 func on_itemgroup_changed(itemgroup: String, oldlist: Array[String], newlist: Array[String]):
 	var changes_made = false
-
-	# Dictionary to keep track of current memberships
-	var membership = {}
+	# Remove itemgroup from items in the old list that are not in the new list
 	for item_id in oldlist:
-		membership[item_id] = false  # Assume all old items are not in the new list initially
+		if item_id not in newlist:
+			# Call remove_reference to remove the itemgroup from this item
+			changes_made = remove_reference(Gamedata.data.items, "core", "itemgroups", \
+			item_id, itemgroup) or changes_made
 
-	# Process each item in the new list
+	# Add itemgroup to items in the new list that were not in the old list
 	for item_id in newlist:
-		var item_data = get_data_by_id(Gamedata.data.items, item_id)
-		if item_data.is_empty():
-			continue  # Skip if no data is found for this item
-
-		# Ensure the itemgroups field exists and is a list
-		if "itemgroups" not in item_data:
-			item_data["itemgroups"] = []
-		
-		# Add the current itemgroup if it's not already there
-		if itemgroup not in item_data["itemgroups"]:
-			item_data["itemgroups"].append(itemgroup)
-			changes_made = true
-		
-		# Mark this item as processed
-		membership[item_id] = true
-
-	# Check old items to see if they should be removed from the itemgroup
-	for item_id in oldlist:
-		if not membership[item_id]:  # This item was not in the new list
-			var item_data = get_data_by_id(Gamedata.data.items, item_id)
-			if item_data.is_empty() or "itemgroups" not in item_data:
-				continue  # Skip if no data or no itemgroups property is found
-
-			if itemgroup in item_data["itemgroups"]:
-				item_data["itemgroups"].erase(itemgroup)  # Remove the itemgroup from the item
-				# Remove the itemgroups property if it's empty
-				if item_data["itemgroups"].size() == 0:
-					item_data.erase("itemgroups")
-				changes_made = true
+		if item_id not in oldlist:
+			# Call add_reference to add the itemgroup to this item
+			changes_made = add_reference(Gamedata.data.items, "core", "itemgroups", \
+			item_id, itemgroup) or changes_made
 
 	# Save changes if any items were updated
 	if changes_made:
@@ -326,57 +301,39 @@ func on_itemgroup_changed(itemgroup: String, oldlist: Array[String], newlist: Ar
 # We can get the items by calling get_data_by_id(contentData, id) 
 # and getting the items property, which will return an array of item id's
 # For each item, we have to get the item's data, and delete the itemgroup from the item's itemgroups property if it is present
-# Function to handle the deletion of an itemgroup. This will remove the itemgroup from all items that are part of it.
 func on_itemgroup_deleted(itemgroup_id: String):
 	var changes_made = false
 	var itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, itemgroup_id)
-	
-	if itemgroup_data.is_empty():
-		print("Itemgroup with ID", itemgroup_id, "not found.")
-		return
-	
-	# Handling the in_furniture attribute for furniture items
-	if "in_furniture" in itemgroup_data:
-		var furniture_ids = itemgroup_data["in_furniture"]
-		for furniture_id in furniture_ids:
-			var furniture_data = get_data_by_id(Gamedata.data.furniture, furniture_id)
-			if furniture_data.is_empty():
-				print("Furniture with ID", furniture_id, "not found.")
-				continue
 
-			# Navigate through the nested dictionary safely
-			if "Function" in furniture_data and "container" in furniture_data["Function"]:
-				if "itemgroup" in furniture_data["Function"]["container"]:
-					# Check if this itemgroup matches the one being deleted
-					if furniture_data["Function"]["container"]["itemgroup"] == itemgroup_id:
-						furniture_data["Function"]["container"].erase("itemgroup")
-						changes_made = true
+	if itemgroup_data.is_empty():
+		print_debug("Itemgroup with ID", itemgroup_id, "not found.")
+		return
+
+	# This callable will remove this itemgroups from every furniture that reference this itemgroup.
+	var myfunc: Callable = func (furn_id):
+		if erase_property_by_path(Gamedata.data.furniture, furn_id, "Function.container.itemgroup"):
+			changes_made = true
+	# Pass the callable to every furniture in the itemgroup's references
+	# It will call myfunc on every furniture in itemgroup_data.references.core.furniture
+	execute_callable_on_references_of_type(itemgroup_data, "core", "furniture", myfunc)
 
 	# The itemgroup data contains a list of item IDs in an 'items' attribute
+	# Loop over all the items in the list and remove the reference to this itemgroup
 	if "items" in itemgroup_data:
 		var item_ids = itemgroup_data["items"]
 		for item_id in item_ids:
-			var item_data = get_data_by_id(Gamedata.data.items, item_id)
-			if item_data.is_empty():
-				print("Item with ID", item_id, "not found.")
-				continue
+			# Use remove_reference to handle deletion of itemgroup references
+			changes_made = remove_reference(Gamedata.data.items, "core", "itemgroups", \
+			item_id, itemgroup_id) or changes_made
 
-			# Check if the 'itemgroups' attribute exists and contains the itemgroup to be deleted
-			if "itemgroups" in item_data and itemgroup_id in item_data["itemgroups"]:
-				item_data["itemgroups"].erase(itemgroup_id)  # Remove the itemgroup from the list
-				changes_made = true
-
-				# If no more itemgroups are left in the item, consider removing the 'itemgroups' attribute
-				if item_data["itemgroups"].size() == 0:
-					item_data.erase("itemgroups")
 
 	# Save changes to the data file if any changes were made
 	if changes_made:
 		save_data_to_file(Gamedata.data.items)
 		save_data_to_file(Gamedata.data.furniture)
-		print("Itemgroup", itemgroup_id, "has been successfully deleted from all items.")
+		print_debug("Itemgroup", itemgroup_id, "has been successfully deleted from all items.")
 	else:
-		print("No changes needed for itemgroup", itemgroup_id)
+		print_debug("No changes needed for itemgroup", itemgroup_id)
 
 
 # Some furniture has had their itemgroup changed
@@ -389,27 +346,12 @@ func on_furniture_itemgroup_changed(furniture_id: String, old_group: String, new
 	var changes_made = false
 
 	# Handle the old itemgroup
-	if old_group != "":
-		var old_itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, old_group)
-		if old_itemgroup_data.has("in_furniture"):
-			# Check if the furniture_id is in the old itemgroup and remove it
-			if furniture_id in old_itemgroup_data["in_furniture"]:
-				old_itemgroup_data["in_furniture"].erase(furniture_id)
-				changes_made = true
-				# If in_furniture is now empty, remove the property
-				if old_itemgroup_data["in_furniture"].size() == 0:
-					old_itemgroup_data.erase("in_furniture")
+	changes_made = remove_reference(Gamedata.data.itemgroups, "core", "furniture", \
+	old_group, furniture_id) or changes_made
 
-	# Handle the new itemgroup
-	if new_group != "":
-		var new_itemgroup_data = get_data_by_id(Gamedata.data.itemgroups, new_group)
-		# Ensure the new group has the 'in_furniture' list initialized
-		if not new_itemgroup_data.has("in_furniture"):
-			new_itemgroup_data["in_furniture"] = []
-		# Add the furniture_id to the new itemgroup if it's not already there
-		if furniture_id not in new_itemgroup_data["in_furniture"]:
-			new_itemgroup_data["in_furniture"].append(furniture_id)
-			changes_made = true
+	# Handle the new itemgroup the 'or' makes sure changes_made does not change back to false
+	changes_made = add_reference(Gamedata.data.itemgroups, "core", "furniture", \
+	new_group, furniture_id) or changes_made
 
 	# Save changes if any modifications were made
 	if changes_made:
@@ -422,3 +364,176 @@ func on_furniture_itemgroup_changed(furniture_id: String, old_group: String, new
 		print_debug("Furniture itemgroup changes saved successfully.")
 	else:
 		print_debug("No changes were made to furniture itemgroups.")
+
+
+# Adds a reference to an entity
+# data = any data group, like Gamedata.data.itemgroups
+# type = the type of reference, for example furniture
+# onid = where to add the reference to
+# refid = The reference to add on the fromid
+# Example usage: var changes_made = add_reference(Gamedata.data.itemgroups, "core", 
+# "furniture", itemgroup_id, furniture_id)
+# This example will add the specified furniture from the itemgroup's references
+func add_reference(data: Dictionary, module: String, type: String, onid: String, refid: String) -> bool:
+	var changes_made: bool = false
+	if onid != "":
+		var entitydata = get_data_by_id(data, onid)
+		if not entitydata.has("references"):
+			entitydata["references"] = {}
+		if not entitydata["references"].has(module):
+			entitydata["references"][module] = {}
+		if not entitydata["references"][module].has(type):
+			entitydata["references"][module][type] = []
+		
+		if refid not in entitydata["references"][module][type]:
+			entitydata["references"][module][type].append(refid)
+			changes_made = true
+	return changes_made
+
+
+# Removes a reference from an entity. 
+# data = any data group, like Gamedata.data.itemgroups
+# type = the type of reference, for example furniture
+# fromid = where to remove the reference from
+# refid = The reference to remove from the fromid
+# Example usage: var changes_made = remove_reference(Gamedata.data.itemgroups, "core", 
+# "furniture", itemgroup_id, furniture_id)
+# This example will remove the specified furniture from the itemgroup's references
+func remove_reference(data: Dictionary, module: String, type: String, fromid: String, refid: String) -> bool:
+	var changes_made: bool = false
+	if fromid != "":
+		var entitydata = get_data_by_id(data, fromid)
+		if entitydata.has("references") and entitydata["references"].has(module) and entitydata["references"][module].has(type):
+			var refs = entitydata["references"][module][type]
+			if refid in refs:
+				refs.erase(refid)
+				changes_made = true
+				# Clean up if necessary
+				if refs.size() == 0:
+					entitydata["references"][module].erase(type)
+				if entitydata["references"][module].is_empty():
+					entitydata["references"].erase(module)
+				if entitydata["references"].is_empty():
+					entitydata.erase("references")
+	return changes_made
+
+
+func remove_relations_of_deleted_id(contentData: Dictionary, id: String):
+	if contentData == Gamedata.data.itemgroups:
+		on_itemgroup_deleted(id)
+	if contentData == Gamedata.data.items:
+		on_item_deleted(id)
+	if contentData == Gamedata.data.furniture:
+		on_furniture_deleted(id)
+
+
+# Erases a nested property from a given dictionary based on a dot-separated path
+func erase_property_by_path(data: Dictionary, item_id: String, property_path: String):
+	var entity_data = get_data_by_id(data, item_id)
+	if entity_data.is_empty():
+		print_debug("Entity with ID", item_id, "not found.")
+		return false
+
+	# Split the path and process the nesting
+	var path_parts = property_path.split(".")
+	var current_dict = entity_data
+	for i in range(path_parts.size() - 1):  # Navigate to the last dictionary
+		if path_parts[i] in current_dict:
+			current_dict = current_dict[path_parts[i]]
+		else:
+			print_debug("Path not found:", path_parts[i])
+			return false
+
+	# Last part of the path is the key to erase
+	var last_key = path_parts[-1]
+	if last_key in current_dict:
+		current_dict.erase(last_key)
+		print_debug("Property", last_key, "erased successfully.")
+		return true
+	else:
+		print_debug("Property", last_key, "not found.")
+		return false
+
+
+# An item is being deleted from the data
+# We have to remove it from everything that references it
+func on_item_deleted(item_id: String):
+	var changes_made = false
+	var item_data = get_data_by_id(Gamedata.data.items, item_id)
+	
+	if item_data.is_empty():
+		print_debug("Item with ID", item_data, "not found.")
+		return
+	
+	# This callable will remove this item from itemgroups that reference this item.
+	var myfunc: Callable = func (itemgroup_id):
+		var itemlist: Array = get_property_by_path(Gamedata.data.itemgroups, "items", itemgroup_id)
+		if item_id in itemlist:
+			itemlist.erase(item_id)
+			changes_made = true
+	# Pass the callable to every itemgroup in the item's references
+	# It will call myfunc on every itemgroup in item_data.references.core.itemgroups
+	execute_callable_on_references_of_type(item_data, "core", "itemgroups", myfunc)
+
+	# Save changes to the data file if any changes were made
+	if changes_made:
+		save_data_to_file(Gamedata.data.itemgroups)
+	else:
+		print_debug("No changes needed for item", item_id)
+
+
+# Some furniture is being deleted from the data
+# We have to remove it from everything that references it
+func on_furniture_deleted(furniture_id: String):
+	var changes_made = false
+	var furniture_data = get_data_by_id(Gamedata.data.furniture, furniture_id)
+	
+	if furniture_data.is_empty():
+		print_debug("Item with ID", furniture_data, "not found.")
+		return
+
+	var itemgroup: String = get_property_by_path(Gamedata.data.furniture, \
+	"Function.container.itemgroup", furniture_id)
+	# Handle the old itemgroup
+	changes_made = remove_reference(Gamedata.data.itemgroups, "core", "furniture", \
+	itemgroup, furniture_id) or changes_made
+
+	# Save changes to the data file if any changes were made
+	if changes_made:
+		save_data_to_file(Gamedata.data.itemgroups)
+	else:
+		print_debug("No changes needed for item", furniture_id)
+
+
+# Executes a callable function on each reference of the given type
+# data = json data representing one entity
+# module = name of the mod. for example "core"
+# type = the type of reference we want to handle. For example "furniture"
+# callable = a function to execute on each reference ID
+# We will check if data has the ["references"] and [type] properties and execute the callable on each found ID
+func execute_callable_on_references_of_type(data: Dictionary, module: String, type: String, callable: Callable):
+	# Check if 'data' contains a 'references' dictionary and if it contains the specified 'type'
+	if data.has("references") and data["references"].has(module) and data["references"][module].has(type):
+		# If the type exists, execute the callable on each ID found under this type
+		for ref_id in data["references"][module][type]:
+			callable.call(ref_id)
+
+
+# Retrieves the value of a nested property from a given dictionary based on a dot-separated path
+func get_property_by_path(data: Dictionary, property_path: String, entity_id: String) -> Variant:
+	var entity_data = get_data_by_id(data, entity_id)
+	if entity_data.is_empty():
+		print_debug("Entity with ID", entity_id, "not found.")
+		return null
+	return get_nested_data(entity_data, property_path)
+
+
+func get_nested_data(data: Dictionary, path: String) -> Variant:
+	var parts = path.split(".")
+	var current = data
+	for part in parts:
+		if current.has(part):
+			current = current[part]
+		else:
+			return null
+	return current

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -232,7 +232,13 @@ func get_sprite_by_id(contentData: Dictionary, id: String) -> Resource:
 # The contenteditor (that initializes the individual editors)
 # connects the changed_data signal to this function
 # and binds the appropriate data array so it can be saved in this function
-func on_data_changed(contentData: Dictionary):
+func on_data_changed(contentData: Dictionary, newEntityData: Dictionary, oldEntityData: Dictionary):
+	if contentData == Gamedata.data.itemgroups:
+		on_itemgroup_changed(newEntityData, oldEntityData)
+	if contentData == Gamedata.data.mobs:
+		on_mob_changed(newEntityData, oldEntityData)
+	if contentData == Gamedata.data.furniture:
+		on_furniture_changed(newEntityData, oldEntityData)
 	save_data_to_file(contentData)
 
 
@@ -275,8 +281,11 @@ func get_items_by_type(item_type: String) -> Array:
 
 # An itemgroup has been changed. Update items that were added or removed from the list
 # oldlist and newlist are arrays with item id strings in them
-func on_itemgroup_changed(itemgroup: String, oldlist: Array[String], newlist: Array[String]):
+func on_itemgroup_changed(newdata: Dictionary, olddata: Dictionary):
 	var changes_made = false
+	var oldlist: Array = get_nested_data(olddata, "items")
+	var newlist: Array = get_nested_data(newdata, "items")
+	var itemgroup: String = newdata.id
 	# Remove itemgroup from items in the old list that are not in the new list
 	for item_id in oldlist:
 		if item_id not in newlist:
@@ -336,36 +345,6 @@ func on_itemgroup_deleted(itemgroup_id: String):
 		print_debug("No changes needed for itemgroup", itemgroup_id)
 
 
-# Some furniture has had their itemgroup changed
-# We need to update the relation between the furniture and the itemgroup
-func on_furniture_itemgroup_changed(furniture_id: String, old_group: String, new_group: String):
-	# Exit if old_group and new_group are the same
-	if old_group == new_group:
-		print_debug("No change in itemgroup. Exiting function.")
-		return
-	var changes_made = false
-
-	# Handle the old itemgroup
-	changes_made = remove_reference(Gamedata.data.itemgroups, "core", "furniture", \
-	old_group, furniture_id) or changes_made
-
-	# Handle the new itemgroup the 'or' makes sure changes_made does not change back to false
-	changes_made = add_reference(Gamedata.data.itemgroups, "core", "furniture", \
-	new_group, furniture_id) or changes_made
-
-	# Save changes if any modifications were made
-	if changes_made:
-		if old_group != "":
-			save_data_to_file(Gamedata.data.itemgroups)
-		if new_group != "" and new_group != old_group:
-			save_data_to_file(Gamedata.data.itemgroups)
-
-	if changes_made:
-		print_debug("Furniture itemgroup changes saved successfully.")
-	else:
-		print_debug("No changes were made to furniture itemgroups.")
-
-
 # Adds a reference to an entity
 # data = any data group, like Gamedata.data.itemgroups
 # type = the type of reference, for example furniture
@@ -374,10 +353,10 @@ func on_furniture_itemgroup_changed(furniture_id: String, old_group: String, new
 # Example usage: var changes_made = add_reference(Gamedata.data.itemgroups, "core", 
 # "furniture", itemgroup_id, furniture_id)
 # This example will add the specified furniture from the itemgroup's references
-func add_reference(data: Dictionary, module: String, type: String, onid: String, refid: String) -> bool:
+func add_reference(mydata: Dictionary, module: String, type: String, onid: String, refid: String) -> bool:
 	var changes_made: bool = false
 	if onid != "":
-		var entitydata = get_data_by_id(data, onid)
+		var entitydata = get_data_by_id(mydata, onid)
 		if not entitydata.has("references"):
 			entitydata["references"] = {}
 		if not entitydata["references"].has(module):
@@ -537,3 +516,67 @@ func get_nested_data(mydata: Dictionary, path: String) -> Variant:
 		else:
 			return null
 	return current
+
+
+# A mob has been changed.
+func on_mob_changed(newdata: Dictionary, olddata: Dictionary):
+	var old_loot_group: String = olddata.get("loot_group")
+	var new_loot_group: String = newdata.get("loot_group")
+	var mob_id: String = newdata.get("id")
+	# Exit if old_group and new_group are the same
+	if old_loot_group == new_loot_group:
+		print_debug("No change in itemgroup. Exiting function.")
+		return
+	var changes_made = false
+
+	# This furniture will be removed from the old itemgroup's references
+	# The 'or' makes sure changes_made does not change back to false
+	changes_made = remove_reference(Gamedata.data.itemgroups, "core", "mobs", \
+	old_loot_group, mob_id) or changes_made
+
+	# This furniture will be added to the new itemgroup's references
+	# The 'or' makes sure changes_made does not change back to false
+	changes_made = add_reference(Gamedata.data.itemgroups, "core", "mobs", \
+	new_loot_group, mob_id) or changes_made
+	
+	# Save changes if any modifications were made
+	if changes_made:
+		if old_loot_group != "":
+			save_data_to_file(Gamedata.data.itemgroups)
+		if new_loot_group != "" and new_loot_group != old_loot_group:
+			save_data_to_file(Gamedata.data.itemgroups)
+
+
+# Some furniture has been changed
+# We need to update the relation between the furniture and the itemgroup
+func on_furniture_changed(newdata: Dictionary, olddata: Dictionary):
+	var old_group: String = get_nested_data(olddata, "Function.container.itemgroup")
+	var new_group: String = get_nested_data(newdata, "Function.container.itemgroup")
+	var furniture_id: String = newdata.id
+	# Exit if old_group and new_group are the same
+	if old_group == new_group:
+		print_debug("No change in itemgroup. Exiting function.")
+		return
+	var changes_made = false
+
+	# This furniture will be removed from the old itemgroup's references
+	# The 'or' makes sure changes_made does not change back to false
+	changes_made = remove_reference(Gamedata.data.itemgroups, "core", "furniture", \
+	old_group, furniture_id) or changes_made
+
+	# This furniture will be added to the new itemgroup's references
+	# The 'or' makes sure changes_made does not change back to false
+	changes_made = add_reference(Gamedata.data.itemgroups, "core", "furniture", \
+	new_group, furniture_id) or changes_made
+
+	# Save changes if any modifications were made
+	if changes_made:
+		if old_group != "":
+			save_data_to_file(Gamedata.data.itemgroups)
+		if new_group != "" and new_group != old_group:
+			save_data_to_file(Gamedata.data.itemgroups)
+
+	if changes_made:
+		print_debug("Furniture itemgroup changes saved successfully.")
+	else:
+		print_debug("No changes were made to furniture itemgroups.")


### PR DESCRIPTION
Requires #102 

Allows the user to specify a basic recipe for an item
- Specify craft amount, ingredients, craft time and flags
- Items that were added to the recipe will get a reference to the item that holds the recipe
- If an item is deleted, it is also removed from the recipe that uses the item
- If an item has a reference to a recipe, and the recipe is deleted, the reference is also removed
- Recipes cannot exist outside of an item
- An item can only have one recipe
- This pr also includes a fix for the link to our discord on the readme

This is a basic starting point for crafting definitions. In the future I want to allow more recipes per item. I briefly looked at recipe definitions for CDDA and found an example where a recipe can require a specific amount of any similar item, for example salt or italian spices or pepper. Something like this might be implemented in a more advanced version of the recipe editor.

https://github.com/Khaligufzel/CataX/assets/50166150/eb6b0707-50a9-4875-8ed6-c7da35d0816a

