### PR TITLE
Allow multiple recipes per item

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
@@ -18,7 +18,7 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[node name="ItemCraftEditor" type="Control" node_paths=PackedStringArray("craftAmountNumber", "craftTimeNumber", "requiresLightCheckbox", "resourcesGridContainer")]
+[node name="ItemCraftEditor" type="Control" node_paths=PackedStringArray("craftAmountNumber", "craftTimeNumber", "requiresLightCheckbox", "resourcesGridContainer", "recipesContainer")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -30,6 +30,7 @@ craftAmountNumber = NodePath("Craft/CraftAmountNumber")
 craftTimeNumber = NodePath("Craft/CraftTimeNumber")
 requiresLightCheckbox = NodePath("Craft/RequiresLightCheckBox")
 resourcesGridContainer = NodePath("Craft/PanelContainer/ResourcesGridContainer")
+recipesContainer = NodePath("Craft/HBoxContainer/RecipeContainerOptionButton")
 
 [node name="Craft" type="GridContainer" parent="."]
 layout_mode = 1
@@ -41,7 +42,26 @@ grow_vertical = 2
 size_flags_vertical = 3
 columns = 2
 
-[node name="CraftAmountLabel" type="Label" parent="Craft"]
+[node name="RecipeSelectLabel" type="Label" parent="Craft"]
+layout_mode = 2
+text = "Selected recipe:"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Craft"]
+layout_mode = 2
+
+[node name="RecipeContainerOptionButton" type="OptionButton" parent="Craft/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="AddRecipeButton" type="Button" parent="Craft/HBoxContainer"]
+layout_mode = 2
+text = "+"
+
+[node name="RemoveRecipeButton" type="Button" parent="Craft/HBoxContainer"]
+layout_mode = 2
+text = "-"
+
+[node name="CraftAmountLabel2" type="Label" parent="Craft"]
 layout_mode = 2
 text = "Craft amount"
 
@@ -84,3 +104,7 @@ text = "Flags"
 layout_mode = 2
 tooltip_text = "Enable this if the item weapon occupies both hands when held. Disable this if the item occupies one hand when held"
 text = "Requires light"
+
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="button_up" from="Craft/HBoxContainer/AddRecipeButton" to="." method="_on_add_recipe_button_button_up"]
+[connection signal="button_up" from="Craft/HBoxContainer/RemoveRecipeButton" to="." method="_on_remove_recipe_button_button_up"]

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -942,6 +942,11 @@ func generate_chunk_mesh_for_level(y_level: int):
 # Rebuilds the navigationmesh for all blocks in the chunk
 # We can't do this for a specific level, since we have 1 navigationmesh
 # If we had multiple navigationmeshes, we could create one per level, which is more optimized
+# See also https://docs.godotengine.org/en/latest/tutorials/navigation/navigation_using_navigationmeshes.html#baking-navigation-mesh-chunks-for-large-worlds
+# We can try to align the edges for more seamless navigation
+#If you know your final chunk size and the border size  increase the bake bound by 2*border_size
+#in general the border size should be large enough to have all the important source geometry from the neighbours included. If not enough geometry from the neighbour chunks is included or the border size is too small edges might end up not aligned again when baked. 
+#a reasonable starting size is 10-15% of a chunk size as the border size but that all depends on how large your chunks are or how complex the geometry.
 func update_all_navigation_data():
 	for key in block_positions.keys():
 		var block_data: Dictionary = block_positions[key]

--- a/Scripts/ItemCraftEditor.gd
+++ b/Scripts/ItemCraftEditor.gd
@@ -7,46 +7,91 @@ extends Control
 @export var craftTimeNumber: SpinBox = null
 @export var requiresLightCheckbox: CheckBox = null
 @export var resourcesGridContainer: GridContainer = null
+@export var recipesContainer: OptionButton = null  # Dropdown to select which recipe to edit
 
+var current_recipe_index = 0
+var craft_recipes = []
 
 func _ready():
-	pass
+	recipesContainer.item_selected.connect(_on_recipe_selected)
 
 
-# Called by the main item editor when the user presses the save button
-func get_properties() -> Dictionary:
-	var properties = {
-		"craft_amount": craftAmountNumber.value,
-		"craft_time": craftTimeNumber.value,
-		"flags": {"requires_light": requiresLightCheckbox.button_pressed},
-		"required_resources": []
-	}
-	
-	# Iterate over children of resourcesGridContainer to collect resource data
+func _on_recipe_selected(index: int):
+	if index != current_recipe_index:
+		_update_current_recipe()  # Save any changes made to the current recipe
+	current_recipe_index = index
+	load_recipe_into_ui(craft_recipes[current_recipe_index])
+
+
+# Loads a recipe into the UI elements
+func load_recipe_into_ui(recipe: Dictionary):
+	craftAmountNumber.value = recipe.get("craft_amount", 1)
+	craftTimeNumber.value = recipe.get("craft_time", 10)
+	requiresLightCheckbox.button_pressed = recipe.get("flags", {}).get("requires_light", false)
+
+	# Clear previous entries
+	for child in resourcesGridContainer.get_children():
+		child.queue_free()
+
+	# Load resources from the selected recipe
+	for resource in recipe.get("required_resources", []):
+		add_resource_entry(resource["id"], resource["amount"])
+
+
+# Gathers the properties from the UI for saving
+func get_properties() -> Array:
+	# First update the current viewed recipe with UI values
+	_update_current_recipe()
+
+	# Return the array of all recipes
+	return craft_recipes
+
+
+# Updates the current recipe data based on UI elements
+func _update_current_recipe():
+	if current_recipe_index >= 0 and current_recipe_index < craft_recipes.size():
+		craft_recipes[current_recipe_index] = {
+			"craft_amount": craftAmountNumber.value,
+			"craft_time": craftTimeNumber.value,
+			"flags": {"requires_light": requiresLightCheckbox.button_pressed},
+			"required_resources": _get_resources_from_ui()
+		}
+
+
+# Helper to get resources from UI
+func _get_resources_from_ui() -> Array:
+	var resources = []
 	var children = resourcesGridContainer.get_children()
 	for i in range(0, children.size(), 3): # Step by 3 to handle label-spinbox-deleteButton triples
 		var label = children[i] as Label
 		var spinBox = children[i + 1] as SpinBox
-		properties["required_resources"].append({"id": label.text, "amount": spinBox.value})
+		resources.append({"id": label.text, "amount": spinBox.value})
+	return resources
+
+
+# Sets properties for all recipes and initializes the recipe editor
+func set_properties(recipes: Array):
+	craft_recipes = recipes
+	recipesContainer.clear()
 	
-	return properties
+	if craft_recipes.is_empty():
+		add_new_recipe()  # Automatically add a new recipe if the list is empty
+		load_recipe_into_ui(craft_recipes[0])
+	else:
+		for idx in range(len(craft_recipes)):
+			recipesContainer.add_item("Recipe " + str(idx + 1))
+		load_recipe_into_ui(craft_recipes[0])
 
 
-# Called by the main item editor when the editor is loaded
-func set_properties(properties: Dictionary) -> void:
-	# Clear existing resources by freeing all children
-	for child in resourcesGridContainer.get_children():
-		child.queue_free()
-
-	# Set the craft amount, time, and flags
-	craftAmountNumber.value = properties.get("craft_amount", 1)
-	craftTimeNumber.value = properties.get("craft_time", 0)
-	requiresLightCheckbox.button_pressed = properties.get("flags", {}).get("requires_light", false)
-
-	# Populate resources grid using the new function
-	if properties.has("required_resources"):
-		for resource in properties["required_resources"]:
-			add_resource_entry(resource["id"], resource["amount"])
+# Helper function to add a new recipe
+func add_new_recipe():
+	var new_recipe = {
+		"craft_amount": 1,
+		"craft_time": 10,
+		"flags": {"requires_light": false},
+		"required_resources": []
+	}
+	craft_recipes.append(new_recipe)
 
 
 # This function should return true if the dragged data can be dropped here
@@ -91,11 +136,15 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 		
 		# Add the resource entry using the new function
 		add_resource_entry(item_id, 1)
+		# Check if the current recipe exists and update it directly
+		if current_recipe_index >= 0 and current_recipe_index < craft_recipes.size():
+			var current_recipe = craft_recipes[current_recipe_index]
+			current_recipe["required_resources"].append({"id": item_id, "amount": 1})
 	else:
 		print_debug("Dropped data does not contain an 'id' key.")
 
 
-
+# Deleting a resource UI element
 func _delete_resource(elements_to_remove: Array) -> void:
 	for element in elements_to_remove:
 		resourcesGridContainer.remove_child(element)
@@ -103,18 +152,55 @@ func _delete_resource(elements_to_remove: Array) -> void:
 
 
 func add_resource_entry(item_id: String, amount: int = 1):
-	# Create a label for the item ID
+	# Create UI elements for the resource
 	var label = Label.new()
 	label.text = item_id
 	resourcesGridContainer.add_child(label)
 	
-	# Create a SpinBox for the amount
 	var amountSpinBox = SpinBox.new()
 	amountSpinBox.value = amount
 	resourcesGridContainer.add_child(amountSpinBox)
 	
-	# Create a delete button
 	var deleteButton = Button.new()
 	deleteButton.text = "X"
 	deleteButton.pressed.connect(_delete_resource.bind([label, amountSpinBox, deleteButton]))
 	resourcesGridContainer.add_child(deleteButton)
+
+
+# This editor becomes visible when the user checks the 'craft' checkbox in the main item editor
+func _on_visibility_changed():
+	set_properties(craft_recipes)
+
+
+func _on_add_recipe_button_button_up():
+	# Save the changes to the currently selected recipe before adding a new one
+	_update_current_recipe()
+
+	# Add a new recipe
+	add_new_recipe()
+
+	# Update the dropdown and select the new recipe
+	update_recipe_dropdown()
+	current_recipe_index = craft_recipes.size() - 1  # Update the current index to the new recipe
+	recipesContainer.select(current_recipe_index)  # Select the newly added recipe
+
+	# Load the newly added recipe into the UI
+	load_recipe_into_ui(craft_recipes[current_recipe_index])
+
+
+func _on_remove_recipe_button_button_up():
+	if craft_recipes.size() > 1:  # Ensure there's more than one recipe to allow removal
+		craft_recipes.remove_at(current_recipe_index)  # Corrected method call here
+		update_recipe_dropdown()
+		current_recipe_index = max(current_recipe_index - 1, 0)
+		recipesContainer.select(current_recipe_index)  # Select the new current recipe
+		load_recipe_into_ui(craft_recipes[current_recipe_index])
+	else:
+		print("Cannot remove the last recipe.")
+
+
+# Helper function to update the recipe dropdown
+func update_recipe_dropdown():
+	recipesContainer.clear()
+	for idx in range(len(craft_recipes)):
+		recipesContainer.add_item("Recipe " + str(idx + 1))


### PR DESCRIPTION
How many ways are there to craft a nail? More then one, right?
This PR allows you to specify an arbitrary amount of recipes per item.

- Added a dropdown and add/delete buttons to manage the amount of recipes
- Changed the reference management to handle the new data structure
- Tested that items are properly removed from the recipe if the item is deleted
- added some comments about navigation to chunk.gd for future implementation

The json looks like this:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/a2698a18-73d8-44b1-bffa-d48155e42445)
