### PR TITLE
Crafting mechanics re-implementation

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -38,6 +38,10 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\"
+				],
+				\"items\": [
+					\"pistol_magazine\",
+					\"screwdriver\"
 				]
 			}
 		},
@@ -63,6 +67,9 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\"
+				],
+				\"items\": [
+					\"pistol_magazine\"
 				]
 			}
 		},
@@ -74,9 +81,28 @@ json_data = "[
 		\"width\": \"1\"
 	},
 	{
+		\"Craft\": [
+			{
+				\"craft_amount\": 1,
+				\"craft_time\": 10,
+				\"flags\": {
+					\"requires_light\": true
+				},
+				\"required_resources\": [
+					{
+						\"amount\": 1,
+						\"id\": \"steel_scrap\"
+					},
+					{
+						\"amount\": 10,
+						\"id\": \"bullet_9mm\"
+					}
+				]
+			}
+		],
 		\"Magazine\": {
-			\"current_ammo\": \"19\",
-			\"max_ammo\": \"20\",
+			\"current_ammo\": 19,
+			\"max_ammo\": 20,
 			\"used_ammo\": \"bullet_9mm\"
 		},
 		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
@@ -212,6 +238,9 @@ json_data = "[
 			\"core\": {
 				\"itemgroups\": [
 					\"kitchen_cupboard\"
+				],
+				\"items\": [
+					\"screwdriver\"
 				]
 			}
 		},
@@ -319,6 +348,25 @@ json_data = "[
 		\"width\": \"4\"
 	},
 	{
+		\"Craft\": [
+			{
+				\"craft_amount\": 1,
+				\"craft_time\": 1,
+				\"flags\": {
+					\"requires_light\": true
+				},
+				\"required_resources\": [
+					{
+						\"amount\": 1,
+						\"id\": \"steel_scrap\"
+					},
+					{
+						\"amount\": 1,
+						\"id\": \"bottle_plastic_empty\"
+					}
+				]
+			}
+		],
 		\"description\": \"A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects\",
 		\"height\": \"2\",
 		\"id\": \"screwdriver\",
@@ -1033,7 +1081,7 @@ json_data = "[
 		\"sprite\": \"bread_maker_32.png\",
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
-		\"volume\": \"30\",
+		\"volume\": \"300\",
 		\"weight\": \"5\"
 	}
 ]"

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -32,6 +32,10 @@
 				"itemgroups": [
 					"cabinet_general",
 					"mob_loot"
+				],
+				"items": [
+					"pistol_magazine",
+					"screwdriver"
 				]
 			}
 		},
@@ -57,6 +61,9 @@
 				"itemgroups": [
 					"cabinet_general",
 					"mob_loot"
+				],
+				"items": [
+					"pistol_magazine"
 				]
 			}
 		},
@@ -68,9 +75,28 @@
 		"width": "1"
 	},
 	{
+		"Craft": [
+			{
+				"craft_amount": 1,
+				"craft_time": 10,
+				"flags": {
+					"requires_light": true
+				},
+				"required_resources": [
+					{
+						"amount": 1,
+						"id": "steel_scrap"
+					},
+					{
+						"amount": 10,
+						"id": "bullet_9mm"
+					}
+				]
+			}
+		],
 		"Magazine": {
-			"current_ammo": "19",
-			"max_ammo": "20",
+			"current_ammo": 19,
+			"max_ammo": 20,
 			"used_ammo": "bullet_9mm"
 		},
 		"description": "In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets",
@@ -206,6 +232,9 @@
 			"core": {
 				"itemgroups": [
 					"kitchen_cupboard"
+				],
+				"items": [
+					"screwdriver"
 				]
 			}
 		},
@@ -313,6 +342,25 @@
 		"width": "4"
 	},
 	{
+		"Craft": [
+			{
+				"craft_amount": 1,
+				"craft_time": 1,
+				"flags": {
+					"requires_light": true
+				},
+				"required_resources": [
+					{
+						"amount": 1,
+						"id": "steel_scrap"
+					},
+					{
+						"amount": 1,
+						"id": "bottle_plastic_empty"
+					}
+				]
+			}
+		],
 		"description": "A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects",
 		"height": "2",
 		"id": "screwdriver",

--- a/Scenes/UI/CraftingMenu.tscn
+++ b/Scenes/UI/CraftingMenu.tscn
@@ -1,0 +1,93 @@
+[gd_scene load_steps=5 format=3 uid="uid://bxyvtsslfr7kt"]
+
+[ext_resource type="Script" path="res://Scripts/CraftingMenu.gd" id="1_10pgr"]
+[ext_resource type="PackedScene" uid="uid://cpcn3qq8okj12" path="res://item_craft_button.tscn" id="2_87dwt"]
+[ext_resource type="FontFile" uid="uid://chm7lbcdeyo0h" path="res://Roboto-Bold.ttf" id="4_xw3mg"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_myv0w"]
+
+[node name="CraftingMenu" type="Panel" node_paths=PackedStringArray("item_button_container", "description", "required_items", "recipeVBoxContainer", "start_crafting_button") groups=["CraftingMenu"]]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -250.0
+offset_top = -321.0
+offset_right = 370.0
+offset_bottom = 323.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+script = ExtResource("1_10pgr")
+item_button_container = NodePath("CraftingList/VBoxContainer")
+item_craft_button = ExtResource("2_87dwt")
+description = NodePath("Panel/VBoxContainer/Description")
+required_items = NodePath("Panel/VBoxContainer/RequiredItems")
+recipeVBoxContainer = NodePath("Panel/VBoxContainer/RecipeVBoxContainer")
+start_crafting_button = NodePath("Panel/VBoxContainer/StartCraftingButton")
+hud = NodePath("..")
+
+[node name="CraftingList" type="ScrollContainer" parent="."]
+layout_mode = 1
+anchors_preset = 9
+anchor_bottom = 1.0
+offset_right = 246.0
+grow_vertical = 2
+horizontal_scroll_mode = 0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CraftingList"]
+custom_minimum_size = Vector2(100, 50)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 11
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -371.0
+grow_horizontal = 0
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Description" type="Label" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+theme_override_fonts/font = ExtResource("4_xw3mg")
+theme_override_font_sizes/font_size = 20
+text = "Description
+"
+label_settings = SubResource("LabelSettings_myv0w")
+autowrap_mode = 3
+
+[node name="RecipeVBoxContainer" type="VBoxContainer" parent="Panel/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="RequiredItems" type="VBoxContainer" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(200, 200)
+layout_mode = 2
+size_flags_vertical = 6
+
+[node name="StartCraftingButton" type="Button" parent="Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+theme_override_fonts/font = ExtResource("4_xw3mg")
+theme_override_font_sizes/font_size = 20
+text = "Craft!"
+
+[connection signal="pressed" from="Panel/VBoxContainer/StartCraftingButton" to="." method="_on_start_crafting_button_pressed"]

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -16,20 +16,47 @@ signal start_craft(item: Dictionary, recipe: Dictionary)
 
 var active_recipe: Dictionary # The currently selected recipe
 var active_item: Dictionary # THe currently selected item in the itemlist
-
+# Dictionary to store buttons with item IDs as keys
+var item_buttons = {}
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	start_craft.connect(ItemManager.on_crafting_menu_start_craft)
-	for item: Dictionary in CraftingRecipesManager.craftable_items:
-		active_item = item
-		var button = Button.new()
-		var button_icon = Gamedata.get_sprite_by_id(Gamedata.data.items, item.get("id"))
-		if button_icon:
-			button.icon = button_icon
-		item_button_container.add_child(button)
-		button.text = item["name"]
-		button.button_up.connect(_on_item_button_clicked.bind(item))
+	Helper.signal_broker.item_stack_size_changed.connect(_on_item_stack_size_changed)
+	Helper.signal_broker.item_removed_from_inventory.connect(_on_item_removed_from_inventory)
+	Helper.signal_broker.item_changed_inventory.connect(_on_item_changed_inventory)
+	create_item_buttons()
+
+
+# Function to create item buttons based on craftable items
+func create_item_buttons():
+	for item in CraftingRecipesManager.craftable_items:
+		create_item_button(item)
+
+
+# Updated function to store button references
+func create_item_button(item: Dictionary):
+	var button = Button.new()
+	var button_icon = Gamedata.get_sprite_by_id(Gamedata.data.items, item.get("id"))
+	if button_icon:
+		button.icon = button_icon
+	button.text = item["name"]
+	button.button_up.connect(_on_item_button_clicked.bind(item))
+
+	# Initially set the button color based on craftability
+	update_button_color(button, item)
+
+	item_button_container.add_child(button)
+	# Store the button reference keyed by item's ID
+	item_buttons[item.get("id")] = button
+
+
+# Function to update a button's color based on the item's craftability
+func update_button_color(button, item):
+	if can_craft_any_recipe(item):
+		button.modulate = Color(0.4, 1, 0.4)  # Green for craftable
+	else:
+		button.modulate = Color(1, 0.4, 0.4)  # Red for not craftable
 
 
 # The user has clicked on one of the item buttons in the itemlist
@@ -81,3 +108,51 @@ func _on_recipe_button_pressed(recipe):
 
 func _on_start_crafting_button_pressed():
 	start_craft.emit(active_item, active_recipe)
+
+
+# Function to determine if any of the item's recipes can be crafted
+func can_craft_any_recipe(item_data: Dictionary) -> bool:
+	# Check if the item data has the 'Craft' property
+	if "Craft" in item_data:
+		# Iterate over each recipe in the 'Craft' property
+		for recipe in item_data["Craft"]:
+			# Call the CraftingRecipesManager to check if the recipe can be crafted
+			if CraftingRecipesManager.can_craft_recipe(recipe):
+				return true  # Return true if any recipe can be crafted
+	# Return false if no recipes can be crafted or if there are no recipes
+	return false
+
+
+# Function to update the color of the button associated with a given item data
+func update_item_button_color(item_data: Dictionary):
+	var item_id = item_data.get("id")
+	if item_id in item_buttons:
+		var button = item_buttons[item_id]
+		update_button_color(button, item_data)
+
+
+func _on_item_stack_size_changed(item: InventoryItem):
+	_update_button_from_inventory_item(item)
+
+
+func _on_item_removed_from_inventory(item: InventoryItem):
+	_update_button_from_inventory_item(item)
+
+
+func _on_item_changed_inventory(item: InventoryItem):
+	_update_button_from_inventory_item(item)
+
+
+# Some inventory item has been moved or changed. Now we want to update the UI so that
+# the player knows what items can be crafted based on the new inventory contents
+# We could update all of the recipes, but we only need to update recipes that
+# reference the item that was added/moved/removed. Therefore,
+# - We get the item references from the inventory item
+# - For each item reference, update the button that represents the item in the ui
+func _update_button_from_inventory_item(item: InventoryItem):
+	var item_id: String = item.get("prototype_id")
+	var item_data: Dictionary = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
+	var item_references: Array = Helper.json_helper.get_nested_data(item_data,"references.core.items")
+	for item_reference in item_references:
+		var item_reference_data = Gamedata.get_data_by_id(Gamedata.data.items, item_reference)
+		update_item_button_color(item_reference_data)

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -1,63 +1,83 @@
 extends Panel
 
-@export var button_container : NodePath
+@export var item_button_container : VBoxContainer
 @export var item_craft_button : PackedScene
 
-@export var button_group : ButtonGroup
+@export var description : Label
+@export var required_items : VBoxContainer
+@export var recipeVBoxContainer : VBoxContainer
 
-@export var description : NodePath
-@export var required_items : NodePath
-
-@export var start_crafting_button : NodePath
+@export var start_crafting_button : Button
 
 @export var hud : NodePath
 
-signal start_craft
+signal start_craft(item: Dictionary, recipe: Dictionary)
 
-var active_recipe
 
-var button_container_node
+var active_recipe: Dictionary # The currently selected recipe
+var active_item: Dictionary # THe currently selected item in the itemlist
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	button_container_node = get_node(button_container)
-	
-	for recipe in CraftingRecipesManager.crafting_recipes:
-		var button = item_craft_button.instantiate()
-		button_container_node.add_child(button)
-		button.text = recipe["name"]
-		button.recipe = recipe
-		button.button_group = button_group
-		button.crafting_menu = [self]
+	start_craft.connect(ItemManager.on_crafting_menu_start_craft)
+	for item: Dictionary in CraftingRecipesManager.craftable_items:
+		active_item = item
+		var button = Button.new()
+		var button_icon = Gamedata.get_sprite_by_id(Gamedata.data.items, item.get("id"))
+		if button_icon:
+			button.icon = button_icon
+		item_button_container.add_child(button)
+		button.text = item["name"]
+		button.button_up.connect(_on_item_button_clicked.bind(item))
 
 
+# The user has clicked on one of the item buttons in the itemlist
+# Update the list of recipes for this item
+func _on_item_button_clicked(item: Dictionary):
+	active_item = item
+	description.text = item["description"]  # Set the description label
+	var recipes = item.get("Craft",[])             # Get the recipe array from the item
+	for element in recipeVBoxContainer.get_children():
+		recipeVBoxContainer.remove_child(element)
+		element.queue_free()  # Properly free the node to avoid memory leaks
 
-func item_craft_button_clicked(recipe):
+	for i in range(recipes.size()):
+		var recipe_button = Button.new()
+		recipe_button.text = "Recipe %d" % (i + 1)
+		recipeVBoxContainer.add_child(recipe_button)
+		recipe_button.button_up.connect(_on_recipe_button_pressed.bind(recipes[i]))
+
+	if recipes.size() > 0:
+		_on_recipe_button_pressed(recipes[0])  # Automatically select the first recipe
+
+
+# When a recipe button is pressed, update the required items label
+func _on_recipe_button_pressed(recipe):
 	active_recipe = recipe
-	var recipe_id = recipe["id"]
-	var item_to_craft
-	for item in ItemManager.items:
-		if item["id"] == recipe_id:
-			item_to_craft = item
-	
-	get_node(description).text = item_to_craft["description"]
-	
-	var is_craft_possible = true
-	
-	for required_item in active_recipe["required_resource"]:
-		get_node(required_items).text = required_item + ": " + str(active_recipe["required_resource"][required_item]) + "\n"
-		
-		if !get_node(hud).check_if_resources_are_available(required_item, int(active_recipe["required_resource"][required_item])):
-			is_craft_possible = false
-	
-	if is_craft_possible:
-		get_node(start_crafting_button).text = "Craft!"
-		get_node(start_crafting_button).disabled = false
-	else:
-		get_node(start_crafting_button).text = "Not enough resources!"
-		get_node(start_crafting_button).disabled = true
-	
+	for element in required_items.get_children():
+		required_items.remove_child(element)
+		element.queue_free()  # Properly free the node to avoid memory leaks
+
+	for resource in recipe.get("required_resources", []):
+		var item_id = resource["id"]
+		var amount = resource["amount"]
+		var resource_container = HBoxContainer.new()
+		var item_data = Gamedata.get_data_by_id(Gamedata.data.items,item_id)
+		var item_name: String = item_data["name"]
+		required_items.add_child(resource_container)
+
+		var item_icon_texture = Gamedata.get_sprite_by_id(Gamedata.data.items, item_id)
+		if item_icon_texture:
+			var icon = TextureRect.new()
+			icon.texture = item_icon_texture
+			icon.custom_minimum_size = Vector2(32, 32)  # Set a fixed size for icons
+			resource_container.add_child(icon)
+
+		var label = Label.new()
+		label.text = " %s: %d" % [item_name, amount]
+		resource_container.add_child(label)
 
 
 func _on_start_crafting_button_pressed():
-	start_craft.emit(active_recipe)
+	start_craft.emit(active_item, active_recipe)

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -653,6 +653,7 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 			for item in dropped_data:
 				# Transfer the item to the current inventory
 				item_inventory.transfer_automerge(item, myInventory)
+				Helper.signal_broker.item_changed_inventory.emit(item)
 
 
 # When the user requests a reload trough the inventory context menu

--- a/Scripts/Helper/json_helper.gd
+++ b/Scripts/Helper/json_helper.gd
@@ -169,3 +169,19 @@ func delete_json_file(path: String):
 			print_debug("File deleted successfully: " + path)
 		else:
 			print_debug("An error occurred when trying to delete the file: " + path)
+
+
+# Returns the value from the given property from the given dictionary
+# mydata = any dictionary with properties
+# path = a dot-separated string properties.
+# Usage example: Helper.json_helper.get_nested_data(furniture_data, "Function.container.itemgroup")
+# The example will return the value of itemgroup from the furniture_data
+func get_nested_data(mydata: Dictionary, path: String) -> Variant:
+	var parts = path.split(".")
+	var current = mydata
+	for part in parts:
+		if current.has(part):
+			current = current[part]
+		else:
+			return null
+	return current

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -31,6 +31,18 @@ signal item_was_equipped(heldItem: InventoryItem, equipmentSlot: Control)
 # When an item slot has cleared out, we forward the signal
 signal item_slot_cleared(heldItem: InventoryItem, equipmentSlot: Control)
 
+# An item has been removed from an inventory (player or proximity) 
+# and cannot be accessed# by the player anymore
+signal item_removed_from_inventory(inventoryItem: InventoryItem)
+
+# The stack size of an item has been changed. If the stack size is 0, Gloot will
+# automatically remove it from the inventory.
+signal item_stack_size_changed(inventoryItem: InventoryItem)
+
+# An item has been moved from one inventory to another
+# May or may not be accessible by the player
+signal item_changed_inventory(inventoryItem: InventoryItem)
+
 
 # We signal to the hud to start a progressbar
 func on_start_timer_progressbar(time_left: float):

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -31,17 +31,11 @@ signal item_was_equipped(heldItem: InventoryItem, equipmentSlot: Control)
 # When an item slot has cleared out, we forward the signal
 signal item_slot_cleared(heldItem: InventoryItem, equipmentSlot: Control)
 
-# An item has been removed from an inventory (player or proximity) 
-# and cannot be accessed# by the player anymore
-signal item_removed_from_inventory(inventoryItem: InventoryItem)
 
-# The stack size of an item has been changed. If the stack size is 0, Gloot will
-# automatically remove it from the inventory.
-signal item_stack_size_changed(inventoryItem: InventoryItem)
-
-# An item has been moved from one inventory to another
-# May or may not be accessible by the player
-signal item_changed_inventory(inventoryItem: InventoryItem)
+# When the player moves and the ItemDetector signals that a container
+# has entered or left the player's proximity
+signal container_entered_proximity(container: Node3D)
+signal container_exited_proximity(container: Node3D)
 
 
 # We signal to the hud to start a progressbar

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -43,6 +43,9 @@ func _ready():
 		RightHandEquipmentSlot.deserialize(General.player_equipment_dict.RightHandEquipmentSlot)
 	# We let the signal broker forward the change in visibility so other nodes can respond
 	visibility_changed.connect(Helper.signal_broker.on_inventory_visibility_changed.bind(self))
+	Helper.signal_broker.container_entered_proximity.connect(_on_container_entered_proximity)
+	Helper.signal_broker.container_exited_proximity.connect(_on_container_exited_proximity)
+
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -103,12 +106,12 @@ func get_equipment_dict() -> Dictionary:
 
 
 # Signal handler for adding a container to the proximity
-func _on_item_detector_add_to_proximity_inventory(container: Node3D):
+func _on_container_entered_proximity(container: Node3D):
 	add_container_to_list(container)
 
 
 # Signal handler for removing a container from the proximity
-func _on_item_detector_remove_from_proximity_inventory(container: Node3D):
+func _on_container_exited_proximity(container: Node3D):
 	remove_container_from_list(container)
 
 

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -79,57 +79,6 @@ func check_if_resources_are_available(item_id, amount_to_spend: int):
 	return false
 
 
-func try_to_spend_item(item_id, amount_to_spend : int):
-	var inventory_node = inventory
-	if inventory_node.get_item_by_id(item_id):
-		var item_total_amount : int = 0
-		var current_amount_to_spend = amount_to_spend
-		var items = inventory_node.get_items_by_id(item_id)
-		
-		for item in items:
-			item_total_amount += InventoryStacked.get_item_stack_size(item)
-		
-		if item_total_amount >= amount_to_spend:
-			merge_items_to_total_amount(items, inventory_node, item_total_amount - current_amount_to_spend)
-			return true
-		else:
-			return false
-	else:
-		return false
-
-
-func merge_items_to_total_amount(items, inventory_node, total_amount : int):
-	var current_total_amount = total_amount
-	for item in items:
-		if inventory_node.get_item_stack_size(item) < current_total_amount:
-			if inventory_node.get_item_stack_size(item) == item.get_property("max_stack_size"):
-				current_total_amount -= inventory_node.get_item_stack_size(item)
-			elif inventory_node.get_item_stack_size(item) < item.get_property("max_stack_size"):
-				current_total_amount -= item.get_property("max_stack_size") - inventory_node.get_item_stack_size(item)
-				inventory_node.set_item_stack_size(item, item.get_property("max_stack_size"))
-
-		elif inventory_node.get_item_stack_size(item) == current_total_amount:
-			current_total_amount = 0
-
-		elif inventory_node.get_item_stack_size(item) > current_total_amount:
-			inventory_node.set_item_stack_size(item, current_total_amount)
-			current_total_amount = 0
-
-			if inventory_node.get_item_stack_size(item) == 0:
-				inventory_node.remove_item(item)
-
-
-func _on_crafting_menu_start_craft(recipe):
-	if recipe:
-		#first we need to use required resources for the recipe
-		for required_item in recipe["required_resource"]:
-			try_to_spend_item(required_item, recipe["required_resource"][required_item])
-		#adding a new item(s) to the inventory based on the recipe
-		var item
-		item = inventory.create_and_add_item(recipe["crafts"])
-		InventoryStacked.set_item_stack_size(item, recipe["craft_amount"])
-
-
 # When an item is added to the player inventory
 # We check where it came from and delete it from that inventory
 # This happens when the player moves an item from $CtrlInventoryGridExProx

--- a/Scripts/ItemDetector.gd
+++ b/Scripts/ItemDetector.gd
@@ -1,16 +1,13 @@
 extends Area3D
 
-signal add_to_proximity_inventory
-signal remove_from_proximity_inventory
-
 
 func _on_area_entered(area):
 	if area.get_owner().is_in_group("Containers"):
-		add_to_proximity_inventory.emit(area.get_owner())
+		Helper.signal_broker.container_entered_proximity.emit(area.get_owner())
 
 
 func _on_area_exited(area):
 	var areaowner = area.get_owner()
 	if areaowner:
 		if areaowner.is_in_group("Containers"):
-			remove_from_proximity_inventory.emit(area.get_owner())
+			Helper.signal_broker.container_exited_proximity.emit(area.get_owner())

--- a/Scripts/crafting_recipes_manager.gd
+++ b/Scripts/crafting_recipes_manager.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var crafting_recipes
+var craftable_items
 
 
 # Called when the node enters the scene tree for the first time.
@@ -8,7 +8,22 @@ func _ready():
 	get_crafting_recipes_from_json()
 
 func get_crafting_recipes_from_json():
-	var file = "res://JSON/crafting_recipes.json"
-	var json_as_text = FileAccess.get_file_as_string(file)
-	var json_as_dict = JSON.parse_string(json_as_text)
-	crafting_recipes = json_as_dict
+	craftable_items = Gamedata.get_items_by_type("Craft")
+
+
+# Function to check if there are enough resources in the inventory to craft a given recipe.
+func can_craft_recipe(recipe: Dictionary) -> bool:
+	# Ensure that the recipe contains the 'required_resources' key.
+	if "required_resources" in recipe:
+		# Loop through each resource required by the recipe.
+		for resource in recipe["required_resources"]:
+			# Check if the inventory has a sufficient amount of each required resource.
+			if not ItemManager.has_sufficient_item_amount(resource.get("id"), resource.get("amount")):
+				print_debug("Not enough", resource.get("id"), "to craft")
+				return false  # Return false immediately if any resource is insufficient.
+	else:
+		print_debug("No required resources specified for recipe")
+		return false  # Return false if the recipe does not specify any required resources.
+	
+	# If all checks are passed, return true indicating that crafting can proceed.
+	return true

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -299,8 +299,8 @@ func get_items_by_type(item_type: String) -> Array:
 # oldlist and newlist are arrays with item id strings in them
 func on_itemgroup_changed(newdata: Dictionary, olddata: Dictionary):
 	var changes_made = false
-	var oldlist: Array = get_nested_data(olddata, "items")
-	var newlist: Array = get_nested_data(newdata, "items")
+	var oldlist: Array = Helper.json_helper.get_nested_data(olddata, "items")
+	var newlist: Array = Helper.json_helper.get_nested_data(newdata, "items")
 	var itemgroup: String = newdata.id
 	# Remove itemgroup from items in the old list that are not in the new list
 	for item_id in oldlist:
@@ -442,18 +442,8 @@ func get_property_by_path(mydata: Dictionary, property_path: String, entity_id: 
 	if entity_data.is_empty():
 		print_debug("Entity with ID", entity_id, "not found.")
 		return null
-	return get_nested_data(entity_data, property_path)
+	return Helper.json_helper.get_nested_data(entity_data, property_path)
 
-
-func get_nested_data(mydata: Dictionary, path: String) -> Variant:
-	var parts = path.split(".")
-	var current = mydata
-	for part in parts:
-		if current.has(part):
-			current = current[part]
-		else:
-			return null
-	return current
 
 
 # A mob has been changed.
@@ -488,8 +478,8 @@ func on_mob_changed(newdata: Dictionary, olddata: Dictionary):
 # Some furniture has been changed
 # We need to update the relation between the furniture and the itemgroup
 func on_furniture_changed(newdata: Dictionary, olddata: Dictionary):
-	var old_group = get_nested_data(olddata, "Function.container.itemgroup")
-	var new_group = get_nested_data(newdata, "Function.container.itemgroup")
+	var old_group = Helper.json_helper.get_nested_data(olddata, "Function.container.itemgroup")
+	var new_group = Helper.json_helper.get_nested_data(newdata, "Function.container.itemgroup")
 	var furniture_id: String = newdata.id
 	# Exit if old_group and new_group are the same
 	if old_group == new_group:
@@ -587,7 +577,7 @@ func on_furniture_deleted(furniture_id: String):
 	itemgroup, furniture_id) or changes_made
 	
 	# Check if the furniture has references to maps and remove it from those maps
-	var maps = get_nested_data(furniture_data,"references.core.maps")
+	var maps = Helper.json_helper.get_nested_data(furniture_data,"references.core.maps")
 	for map_id in maps:
 		remove_entity_from_map(map_id, "furniture", furniture_id)
 
@@ -613,7 +603,7 @@ func on_mob_deleted(mob_id: String):
 	loot_group, mob_id) or changes_made
 	
 	# Check if the mob has references to maps and remove it from those maps
-	var maps = get_nested_data(mob_data,"references.core.maps")
+	var maps = Helper.json_helper.get_nested_data(mob_data,"references.core.maps")
 	for map_id in maps:
 		remove_entity_from_map(map_id, "mob", mob_id)
 
@@ -635,7 +625,7 @@ func on_tile_deleted(tile_id: String):
 	# Check if the tile has references to maps and remove it from those maps
 	var modules = tile_data.get("references", [])
 	for mod in modules:
-		var maps = get_nested_data(tile_data,"references."+mod+".maps")
+		var maps = Helper.json_helper.get_nested_data(tile_data,"references."+mod+".maps")
 		for map_id in maps:
 			remove_entity_from_map(map_id, "tile", tile_id)
 

--- a/Scripts/general.gd
+++ b/Scripts/general.gd
@@ -18,7 +18,19 @@ func _ready():
 	add_child(action_timer)
 	start_timer_progressbar.connect(Helper.signal_broker.on_start_timer_progressbar)
 
+
 # Function to start an action
+# Usage example: 
+	# This example will call the 'reload_weapon" functoin in self after the timer is complete
+	# var reload_callable = Callable(self, "reload_weapon").bind(item, specific_magazine)
+	# General.start_action(reload_time, reload_callable)
+# Usage example using an inline callable:
+	# This example will call the 'myfunc' callable after the start_action timer runs out
+	# var myfunc: Callable = func (itemgroup_id):
+	#	var itemlist: Array = get_property_by_path(Gamedata.data.itemgroups, "items", itemgroup_id)
+	#	if item_id in itemlist:
+	#		itemlist.erase(item_id)
+	# General.start_action(reload_time, myfunc)
 func start_action(duration: float, callback: Callable):
 	if not is_action_in_progress:
 		is_action_in_progress = true

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -153,19 +153,6 @@ func merge_items_to_total_amount(items, inventory, total_amount : int):
 				inventory.remove_item(item)
 
 
-func _on_crafting_menu_start_craft(recipe):
-	
-	if recipe:
-		#first we need to use required resources for the recipe
-		for required_item in recipe["required_resource"]:
-			try_to_spend_item(required_item, recipe["required_resource"][required_item])
-			
-		#adding a new item(s) to the inventory based on the recipe
-		var item
-		item = inventoryWindow.get_inventory().create_and_add_item(recipe["crafts"])
-		inventoryWindow.get_inventory().set_item_stack_size(item, recipe["craft_amount"])
-
-
 func start_progress_bar(time : float):
 	get_node(progress_bar).visible = true
 	get_node(progress_bar_timer).wait_time = time

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -100,59 +100,6 @@ func _on_concrete_button_down():
 	construction_chosen.emit("concrete_wall")
 
 
-func check_if_resources_are_available(item_id, amount_to_spend: int):
-	var inventory_node: InventoryStacked = inventoryWindow.get_inventory()
-	print("checking if we have the item id in inv")
-	if inventory_node.get_item_by_id(item_id):
-		print("we have the item id")
-		var item_total_amount : int = 0
-		var current_amount_to_spend = amount_to_spend
-		var items = inventory_node.get_items_by_id(item_id)
-		for item in items:
-			item_total_amount += InventoryStacked.get_item_stack_size(item)
-		if item_total_amount >= current_amount_to_spend:
-			return true
-	return false
-
-func try_to_spend_item(item_id, amount_to_spend : int):
-	var inventory_node = inventoryWindow.get_inventory()
-	if inventory_node.get_item_by_id(item_id):
-		var item_total_amount : int = 0
-		var current_amount_to_spend = amount_to_spend
-		var items = inventory_node.get_items_by_id(item_id)
-		
-		for item in items:
-			item_total_amount += inventory_node.get_item_stack_size(item)
-		
-		if item_total_amount >= amount_to_spend:
-			merge_items_to_total_amount(items, inventory_node, item_total_amount - current_amount_to_spend)
-			return true
-		else:
-			return false
-	else:
-		return false
-
-func merge_items_to_total_amount(items, inventory, total_amount : int):
-	var current_total_amount = total_amount
-	for item in items:
-		if inventory.get_item_stack_size(item) < current_total_amount:
-			if inventory.get_item_stack_size(item) == item.get_property("max_stack_size"):
-				current_total_amount -= inventory.get_item_stack_size(item)
-			elif inventory.get_item_stack_size(item) < item.get_property("max_stack_size"):
-				current_total_amount -= item.get_property("max_stack_size") - inventory.get_item_stack_size(item)
-				inventory.set_item_stack_size(item, item.get_property("max_stack_size"))
-
-		elif inventory.get_item_stack_size(item) == current_total_amount:
-			current_total_amount = 0
-
-		elif inventory.get_item_stack_size(item) > current_total_amount:
-			inventory.set_item_stack_size(item, current_total_amount)
-			current_total_amount = 0
-
-			if inventory.get_item_stack_size(item) == 0:
-				inventory.remove_item(item)
-
-
 func start_progress_bar(time : float):
 	get_node(progress_bar).visible = true
 	get_node(progress_bar_timer).wait_time = time

--- a/hud.tscn
+++ b/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://clhj525tmme3k"]
+[gd_scene load_steps=18 format=3 uid="uid://clhj525tmme3k"]
 
 [ext_resource type="FontFile" uid="uid://chm7lbcdeyo0h" path="res://Roboto-Bold.ttf" id="1_pxloi"]
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
@@ -12,9 +12,7 @@
 [ext_resource type="Texture2D" uid="uid://1alnt17qsyd7" path="res://Textures/rightarm.png" id="7_td8gu"]
 [ext_resource type="Texture2D" uid="uid://t7ny2gtgqll8" path="res://Textures/head.png" id="8_vb8fm"]
 [ext_resource type="Texture2D" uid="uid://c1begynwustlp" path="res://Textures/torso.png" id="9_4u4ej"]
-[ext_resource type="Script" path="res://Scripts/CraftingMenu.gd" id="14_g3fif"]
-[ext_resource type="PackedScene" uid="uid://cpcn3qq8okj12" path="res://item_craft_button.tscn" id="15_otw1a"]
-[ext_resource type="ButtonGroup" uid="uid://bcjuavqvre6mk" path="res://crafting_recipes_button_group.tres" id="16_2oloe"]
+[ext_resource type="PackedScene" uid="uid://bxyvtsslfr7kt" path="res://Scenes/UI/CraftingMenu.tscn" id="13_wjtvq"]
 [ext_resource type="PackedScene" uid="uid://bgswuol251m3u" path="res://Scenes/Overmap/Overmap.tscn" id="19_oomhy"]
 [ext_resource type="PackedScene" uid="uid://e0ebcv1n8jnq" path="res://Scenes/InventoryWindow.tscn" id="20_0l505"]
 [ext_resource type="PackedScene" uid="uid://ckuh2s0nvwg0x" path="res://Scenes/GameOver.tscn" id="20_jlthm"]
@@ -22,9 +20,6 @@
 [sub_resource type="Theme" id="Theme_xn5t2"]
 default_font = ExtResource("1_pxloi")
 default_font_size = 0
-
-[sub_resource type="StyleBoxLine" id="StyleBoxLine_xekk0"]
-color = Color(1, 1, 1, 1)
 
 [node name="HUD" type="CanvasLayer" node_paths=PackedStringArray("inventoryWindow", "overmap")]
 script = ExtResource("1_s3xoj")
@@ -220,114 +215,8 @@ columns = 4
 layout_mode = 2
 text = "Concrete"
 
-[node name="CraftingMenu" type="Panel" parent="." groups=["CraftingMenu"]]
+[node name="CraftingMenu" parent="." instance=ExtResource("13_wjtvq")]
 visible = false
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -250.0
-offset_top = -321.0
-offset_right = 370.0
-offset_bottom = 323.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-script = ExtResource("14_g3fif")
-button_container = NodePath("CraftingList/VBoxContainer")
-item_craft_button = ExtResource("15_otw1a")
-button_group = ExtResource("16_2oloe")
-description = NodePath("Panel/Description")
-required_items = NodePath("Panel/RequiredItems")
-start_crafting_button = NodePath("Panel/StartCraftingButton")
-hud = NodePath("..")
-
-[node name="CraftingList" type="ScrollContainer" parent="CraftingMenu"]
-layout_mode = 1
-anchors_preset = 9
-anchor_bottom = 1.0
-offset_right = 246.0
-grow_vertical = 2
-horizontal_scroll_mode = 0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="CraftingMenu/CraftingList"]
-custom_minimum_size = Vector2(100, 50)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="Panel" type="Panel" parent="CraftingMenu"]
-layout_mode = 1
-anchors_preset = 11
-anchor_left = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -371.0
-grow_horizontal = 0
-grow_vertical = 2
-
-[node name="StartCraftingButton" type="Button" parent="CraftingMenu/Panel"]
-layout_mode = 1
-anchors_preset = 12
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_top = -31.0
-grow_horizontal = 2
-grow_vertical = 0
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-theme_override_fonts/font = ExtResource("1_pxloi")
-theme_override_font_sizes/font_size = 20
-text = "Craft!"
-
-[node name="Description" type="Label" parent="CraftingMenu/Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 13.0
-offset_right = -13.0
-offset_bottom = -322.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-theme_override_fonts/font = ExtResource("1_pxloi")
-theme_override_font_sizes/font_size = 20
-text = "Description
-"
-autowrap_mode = 3
-
-[node name="HSeparator" type="HSeparator" parent="CraftingMenu/Panel"]
-layout_mode = 0
-offset_left = 3.0
-offset_top = 316.0
-offset_right = 360.0
-offset_bottom = 323.0
-theme_override_constants/separation = 1
-theme_override_styles/separator = SubResource("StyleBoxLine_xekk0")
-
-[node name="RequiredItems" type="Label" parent="CraftingMenu/Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 11.0
-offset_top = 323.0
-offset_right = -15.0
-offset_bottom = -33.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-theme_override_fonts/font = ExtResource("1_pxloi")
-theme_override_font_sizes/font_size = 20
-text = "Required items
-"
-autowrap_mode = 3
 
 [node name="Overmap" parent="." instance=ExtResource("19_oomhy")]
 visible = false
@@ -347,6 +236,4 @@ visible = false
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_exited"]
 [connection signal="button_down" from="BuildingMenu/Concrete" to="." method="_on_concrete_button_down"]
-[connection signal="start_craft" from="CraftingMenu" to="." method="_on_crafting_menu_start_craft"]
-[connection signal="pressed" from="CraftingMenu/Panel/StartCraftingButton" to="CraftingMenu" method="_on_start_crafting_button_pressed"]
 [connection signal="change_level_pressed" from="Overmap" to="." method="_on_overmap_change_level_pressed"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -234,8 +234,6 @@ transform = Transform3D(-0.946576, 0, -0.32248, 0, 1, 0, 0.32248, 0, -0.946576, 
 [connection signal="ammo_changed" from="TacticalMap/Entities/Player/Sprite3D2/EquippedLeft" to="HUD" method="_on_shooting_ammo_changed"]
 [connection signal="timeout" from="TacticalMap/Entities/Player/Shooting/Left_attack_cooldown" to="TacticalMap/Entities/Player/Sprite3D2/EquippedLeft" method="_on_left_attack_cooldown_timeout"]
 [connection signal="timeout" from="TacticalMap/Entities/Player/Shooting/Right_attack_cooldown" to="TacticalMap/Entities/Player/Sprite3D2/EquippedRight" method="_on_right_attack_cooldown_timeout"]
-[connection signal="add_to_proximity_inventory" from="TacticalMap/Entities/Player/ItemDetector" to="HUD" method="_on_item_detector_add_to_proximity_inventory"]
 [connection signal="area_entered" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_area_entered"]
 [connection signal="area_exited" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_area_exited"]
-[connection signal="remove_from_proximity_inventory" from="TacticalMap/Entities/Player/ItemDetector" to="HUD" method="_on_item_detector_remove_from_proximity_inventory"]
 [connection signal="construction_chosen" from="HUD" to="TacticalMap/BuildManager" method="_on_hud_construction_chosen"]


### PR DESCRIPTION
Khaligufzel had already implemented crafting early in the game. I made adjustments to the crafting window to make it work again after I broke it.

- Crafting recipes are read from items that have the 'Craft' property
- Currently all items that can be crafted are added to the crafting menu
- Since one item can have multiple recipes, the selection is two-fold; first select the item from the list and then select the recipe you want to craft. The first recipe will be automatically selected, so you only need to switch if there is more then one recipe.
- The item buttons will turn red if the player is unable to craft the item and green if the player is able to craft the item.
- When crafting, items in the player's inventory and in containers close to the player are considered. Accessing items in multiple containers at once can only happen in the crafting window. The inventory window can still open only one container at a time.
- A change in inventory (stepping out of range of containers or adding/removing items from the inventory) will trigger a re-fresh of the crafting recipes where it is evaluated what can be crafted and what not. This will not happen for all recipes. What actually happens is that we determine what items were added or removed. Then, we look at what item recipes reference the added/removed item. Next, we only update the referenced recipes.


You can see the update of the craft menu when the player is close to the storage cabinets:
https://github.com/Khaligufzel/CataX/assets/50166150/d0aca341-abc3-4a44-b8b9-c3211380a8ff


More work needs to be done on limits and constraints, and the crafting ui can be improved by specifying how many more of a resource is needed for a recipe. Also, crafting does not cost any time, so we should add some delay while crafting.
