### PR TITLE
Mod maintenance script to delete a property

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cllbo1owveorj"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cllbo1owveorj"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 
@@ -7,7 +7,6 @@ script = ExtResource("1_o35lu")
 json_data = "[
 	{
 		\"description\": \"A wooden plank that could be used for all kinds of crafting and construction\",
-		\"height\": \"2\",
 		\"id\": \"plank_2x4\",
 		\"image\": \"./Mods/Core/Items/plank.png\",
 		\"max_stack_size\": \"3\",
@@ -23,12 +22,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"300\",
-		\"weight\": \"2\",
-		\"width\": \"4\"
+		\"weight\": \"2\"
 	},
 	{
 		\"description\": \"Some metal bits and pieces. Useful for something, right?\",
-		\"height\": \"2\",
 		\"id\": \"steel_scrap\",
 		\"image\": \"./Mods/Core/Items/steel_scrap.png\",
 		\"max_stack_size\": \"100\",
@@ -49,15 +46,13 @@ json_data = "[
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
 		\"volume\": \"15\",
-		\"weight\": \"0.25\",
-		\"width\": \"2\"
+		\"weight\": \"0.25\"
 	},
 	{
 		\"Ammo\": {
 			\"damage\": \"25\"
 		},
 		\"description\": \"Standard type of ammunition. Very common.\",
-		\"height\": \"1\",
 		\"id\": \"bullet_9mm\",
 		\"image\": \"./Mods/Core/Items/9mm.png\",
 		\"max_stack_size\": \"100\",
@@ -77,8 +72,7 @@ json_data = "[
 		\"stack_size\": \"20\",
 		\"two_handed\": false,
 		\"volume\": \"0.1\",
-		\"weight\": \"0.01\",
-		\"width\": \"1\"
+		\"weight\": \"0.01\"
 	},
 	{
 		\"Craft\": [
@@ -106,7 +100,6 @@ json_data = "[
 			\"used_ammo\": \"bullet_9mm\"
 		},
 		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
-		\"height\": \"1\",
 		\"id\": \"pistol_magazine\",
 		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
 		\"max_stack_size\": \"1\",
@@ -123,8 +116,7 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"10\",
-		\"weight\": \"0.25\",
-		\"width\": \"1\"
+		\"weight\": \"0.25\"
 	},
 	{
 		\"Ranged\": {
@@ -139,7 +131,6 @@ json_data = "[
 			\"used_skill\": \"short_guns\"
 		},
 		\"description\": \"A standard issue pistol that uses 9mm ammunition\",
-		\"height\": \"2\",
 		\"id\": \"pistol_9mm\",
 		\"image\": \"./Mods/Core/Items/pistol_32.png\",
 		\"max_stack_size\": \"1\",
@@ -155,8 +146,7 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"150\",
-		\"weight\": \"2\",
-		\"width\": \"2\"
+		\"weight\": \"2\"
 	},
 	{
 		\"Ranged\": {
@@ -171,7 +161,6 @@ json_data = "[
 			\"used_skill\": \"short_guns\"
 		},
 		\"description\": \"A standard issue rifle that uses 9mm ammunition\",
-		\"height\": \"2\",
 		\"id\": \"rifle_m4a1\",
 		\"image\": \"./Mods/Core/Items/rifle_64_32.png\",
 		\"max_stack_size\": \"1\",
@@ -180,8 +169,7 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": true,
 		\"volume\": \"300\",
-		\"weight\": \"4\",
-		\"width\": \"4\"
+		\"weight\": \"4\"
 	},
 	{
 		\"Ranged\": {
@@ -196,7 +184,6 @@ json_data = "[
 			\"used_skill\": \"short_guns\"
 		},
 		\"description\": \"Chugun in Russian is for cast steel, MPAP is \\\"Multi Purpose Automatic Pistol\\\"\",
-		\"height\": \"2\",
 		\"id\": \"chugunov_mpap\",
 		\"image\": \"./Mods/Core/Items/chugunov_mpap_32_28.png\",
 		\"max_stack_size\": \"1\",
@@ -205,8 +192,7 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": true,
 		\"volume\": \"150\",
-		\"weight\": \"3\",
-		\"width\": \"4\"
+		\"weight\": \"3\"
 	},
 	{
 		\"Magazine\": {
@@ -215,7 +201,6 @@ json_data = "[
 			\"used_ammo\": \"bullet_7.62x26\"
 		},
 		\"description\": \"A magazine to be loaded into a Chuganov MPAP\",
-		\"height\": \"1\",
 		\"id\": \"chugunov_mpap_magazine\",
 		\"image\": \"./Mods/Core/Items/chugunov_mpap_magazine_16_32.png\",
 		\"max_stack_size\": \"1\",
@@ -224,12 +209,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"10\",
-		\"weight\": \"0.25\",
-		\"width\": \"1\"
+		\"weight\": \"0.25\"
 	},
 	{
 		\"description\": \"This plastic bottle only contains air\",
-		\"height\": \"2\",
 		\"id\": \"bottle_plastic_empty\",
 		\"image\": \"./Mods/Core/Items/bottle_empty_32.png\",
 		\"max_stack_size\": \"10\",
@@ -248,15 +231,13 @@ json_data = "[
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
 		\"volume\": \"15\",
-		\"weight\": \"0.1\",
-		\"width\": \"2\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"Food\": {
 			\"health\": \"5\"
 		},
 		\"description\": \"This plastic bottle is filled with water\",
-		\"height\": \"2\",
 		\"id\": \"bottle_plastic_water\",
 		\"image\": \"./Mods/Core/Items/bottle_water_32.png\",
 		\"max_stack_size\": \"10\",
@@ -273,12 +254,10 @@ json_data = "[
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
 		\"volume\": \"15\",
-		\"weight\": \"0.25\",
-		\"width\": \"2\"
+		\"weight\": \"0.25\"
 	},
 	{
 		\"description\": \"The contents will satisfy your hunger\",
-		\"height\": \"2\",
 		\"id\": \"canned_food\",
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
 		\"max_stack_size\": \"5\",
@@ -294,12 +273,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"30\",
-		\"weight\": \"0.25\",
-		\"width\": \"2\"
+		\"weight\": \"0.25\"
 	},
 	{
 		\"description\": \"A sharp blade with a handle for excellent control\",
-		\"height\": \"1\",
 		\"id\": \"machete\",
 		\"image\": \"./Mods/Core/Items/machete_32.png\",
 		\"max_stack_size\": \"1\",
@@ -308,12 +285,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"4\",
-		\"width\": \"1\"
+		\"weight\": \"4\"
 	},
 	{
 		\"description\": \"Anyone is able to craft this simple arrow\",
-		\"height\": \"1\",
 		\"id\": \"wood_arrow_basic\",
 		\"image\": \"./Mods/Core/Items/arrow_basic_32.png\",
 		\"max_stack_size\": \"20\",
@@ -322,13 +297,10 @@ json_data = "[
 		\"stack_size\": \"5\",
 		\"two_handed\": false,
 		\"volume\": \"1\",
-		\"weight\": \"0.1\",
-		\"width\": \"1\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A stick with a block of steel on it. It is used to apply force to objects like nails\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"hammer\",
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
 		\"max_stack_size\": \"1\",
@@ -344,8 +316,7 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"50\",
-		\"weight\": \"2\",
-		\"width\": \"4\"
+		\"weight\": \"2\"
 	},
 	{
 		\"Craft\": [
@@ -368,7 +339,6 @@ json_data = "[
 			}
 		],
 		\"description\": \"A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects\",
-		\"height\": \"2\",
 		\"id\": \"screwdriver\",
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
 		\"max_stack_size\": \"1\",
@@ -385,12 +355,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"20\",
-		\"weight\": \"0.5\",
-		\"width\": \"4\"
+		\"weight\": \"0.5\"
 	},
 	{
 		\"description\": \"A basic bandage that will help to heal a wound\",
-		\"height\": \"2\",
 		\"id\": \"bandage_basic\",
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
 		\"max_stack_size\": \"20\",
@@ -407,12 +375,10 @@ json_data = "[
 		\"stack_size\": \"3\",
 		\"two_handed\": false,
 		\"volume\": \"1\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A small bottle that contains antibiotics. It helps to recover from disease.\",
-		\"height\": \"2\",
 		\"id\": \"bottle_antibiotics\",
 		\"image\": \"./Mods/Core/Items/antibiotics_32.png\",
 		\"max_stack_size\": \"5\",
@@ -428,13 +394,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"5\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A piece of clothing to wear on the torso. It will keep you warm and offers a bit of protection.\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"jacket\",
 		\"image\": \"./Mods/Core/Items/jacket_32.png\",
 		\"max_stack_size\": \"1\",
@@ -443,13 +406,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"1\",
-		\"width\": \"4\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"Comfortable footwear to keep your feet safe\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"boots\",
 		\"image\": \"./Mods/Core/Items/boots_32.png\",
 		\"max_stack_size\": \"1\",
@@ -465,13 +425,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"1\",
-		\"width\": \"4\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A large container that holds gasoline\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"jerrycan_gasoline\",
 		\"image\": \"./Mods/Core/Items/jerrycan_gas_32.png\",
 		\"max_stack_size\": \"1\",
@@ -480,13 +437,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"400\",
-		\"weight\": \"10\",
-		\"width\": \"4\"
+		\"weight\": \"10\"
 	},
 	{
 		\"description\": \"It's a can that contains oil. It has a spout that allows you to pour it out.\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"can_oil\",
 		\"image\": \"./Mods/Core/Items/can_oil_32.png\",
 		\"max_stack_size\": \"1\",
@@ -502,12 +456,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"2\",
-		\"width\": \"4\"
+		\"weight\": \"2\"
 	},
 	{
 		\"description\": \"A small radio that can be powered by batteries or an electical cord.\",
-		\"height\": \"2\",
 		\"id\": \"radio_handheld\",
 		\"image\": \"./Mods/Core/Items/battery_powered_radio_32.png\",
 		\"max_stack_size\": \"1\",
@@ -516,12 +468,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"1\",
-		\"width\": \"4\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A basic battery powered flashlight. It will shine a beam of light when it is turned on\",
-		\"height\": \"2\",
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
 		\"max_stack_size\": \"1\",
@@ -537,13 +487,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"0.5\",
-		\"width\": \"4\"
+		\"weight\": \"0.5\"
 	},
 	{
 		\"description\": \"It's a can that contains beer. Don't drink a lot of it or you will get drunk\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"can_beer\",
 		\"image\": \"./Mods/Core/Items/can_beer_32.png\",
 		\"max_stack_size\": \"5\",
@@ -559,12 +506,10 @@ json_data = "[
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
 		\"volume\": \"50\",
-		\"weight\": \"0.5\",
-		\"width\": \"4\"
+		\"weight\": \"0.5\"
 	},
 	{
 		\"description\": \"It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking\",
-		\"height\": \"2\",
 		\"id\": \"pack_sigarrettes\",
 		\"image\": \"./Mods/Core/Items/sigarrette_pack_32.png\",
 		\"max_stack_size\": \"5\",
@@ -573,12 +518,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"10\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A piece of clothing that offers protection from environmental hazards\",
-		\"height\": \"2\",
 		\"id\": \"gas_mask\",
 		\"image\": \"./Mods/Core/Items/gasmask_32.png\",
 		\"max_stack_size\": \"1\",
@@ -587,13 +530,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"80\",
-		\"weight\": \"1\",
-		\"width\": \"4\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A piece of clothing that offers protection from ballistic forces\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"vest_ballistic\",
 		\"image\": \"./Mods/Core/Items/vest_ballistic_32.png\",
 		\"max_stack_size\": \"1\",
@@ -602,13 +542,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"150\",
-		\"weight\": \"4\",
-		\"width\": \"4\"
+		\"weight\": \"4\"
 	},
 	{
 		\"description\": \"A device that shows your orientation relative to the earth's poles\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"compass\",
 		\"image\": \"./Mods/Core/Items/compass_32.png\",
 		\"max_stack_size\": \"1\",
@@ -617,12 +554,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"6\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A very common type of battery that fits most battery-powered devices\",
-		\"height\": \"2\",
 		\"id\": \"battery_small\",
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
 		\"max_stack_size\": \"20\",
@@ -638,13 +573,10 @@ json_data = "[
 		\"stack_size\": \"2\",
 		\"two_handed\": false,
 		\"volume\": \"0.1\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A large panel that draws power from the sun\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"solar_panel\",
 		\"image\": \"./Mods/Core/Items/solar_panel_32.png\",
 		\"max_stack_size\": \"1\",
@@ -653,13 +585,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"1000\",
-		\"weight\": \"10\",
-		\"width\": \"4\"
+		\"weight\": \"10\"
 	},
 	{
 		\"description\": \"A large piece of paper that visualizes the area around you\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"map_paper\",
 		\"image\": \"./Mods/Core/Items/map_paper_32.png\",
 		\"max_stack_size\": \"1\",
@@ -668,13 +597,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"5\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A piece of fabric and some strings. You can deploy it to get some shelter from the weather\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"tarp\",
 		\"image\": \"./Mods/Core/Items/tarp_32.png\",
 		\"max_stack_size\": \"1\",
@@ -683,13 +609,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"150\",
-		\"weight\": \"3\",
-		\"width\": \"4\"
+		\"weight\": \"3\"
 	},
 	{
 		\"description\": \"A piece of fabric and some strings. You can deploy it to get some shelter from the weather. It is currently folded to save space.\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"tent\",
 		\"image\": \"./Mods/Core/Items/tent_32.png\",
 		\"max_stack_size\": \"1\",
@@ -698,13 +621,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"600\",
-		\"weight\": \"9\",
-		\"width\": \"4\"
+		\"weight\": \"9\"
 	},
 	{
 		\"description\": \"A small book explaining the very basics of survival\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"guide_survival_basic\",
 		\"image\": \"./Mods/Core/Items/survival_guide_32.png\",
 		\"max_stack_size\": \"5\",
@@ -713,13 +633,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"10\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A book containing an entertaining story\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"book_novel\",
 		\"image\": \"./Mods/Core/Items/book_novel_32.png\",
 		\"max_stack_size\": \"5\",
@@ -735,12 +652,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"10\",
-		\"weight\": \"0.4\",
-		\"width\": \"4\"
+		\"weight\": \"0.4\"
 	},
 	{
 		\"description\": \"A small bottle that contains disinfectant. It helps to disinfect wounds\",
-		\"height\": \"2\",
 		\"id\": \"bottle_disinfectant\",
 		\"image\": \"./Mods/Core/Items/bottle_disinfectant_32.png\",
 		\"max_stack_size\": \"5\",
@@ -756,12 +671,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"5\",
-		\"weight\": \"0.1\",
-		\"width\": \"4\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A small radio that allows you to communicate with someone over a large distance\",
-		\"height\": \"2\",
 		\"id\": \"radio_two_way\",
 		\"image\": \"./Mods/Core/Items/radio_two_way_32.png\",
 		\"max_stack_size\": \"1\",
@@ -770,13 +683,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"50\",
-		\"weight\": \"1\",
-		\"width\": \"4\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A small device that provides a spark that can be used to light a fire. No power or fuel required.\",
-		\"height\": \"2\",
-		\"iamge\": \"res://Textures/plank.png\",
 		\"id\": \"firestarter_basic\",
 		\"image\": \"./Mods/Core/Items/firestarter_32.png\",
 		\"max_stack_size\": \"1\",
@@ -785,12 +695,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"10\",
-		\"weight\": \"0.2\",
-		\"width\": \"4\"
+		\"weight\": \"0.2\"
 	},
 	{
 		\"description\": \"\\n    A true survival fishing kit in a very small, lightweight package!\\n    Contains 118 foot line and winder\\n    2 lures, 2 hooks\\n    2 swivels, 2 weghts\\n    Comes in a strong durable heavy duty resealable plastic bag\",
-		\"height\": \"2\",
 		\"id\": \"kit_fishing_small\",
 		\"image\": \"./Mods/Core/Items/kit_fishing_small_32.png\",
 		\"max_stack_size\": \"1\",
@@ -799,12 +707,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"50\",
-		\"weight\": \"0.4\",
-		\"width\": \"4\"
+		\"weight\": \"0.4\"
 	},
 	{
 		\"description\": \"A versatile kitchen tool, essential for slicing, dicing, and chopping food.\",
-		\"height\": \"1\",
 		\"id\": \"kitchen_knife\",
 		\"image\": \"./Mods/Core/Items/kitchen_knife_64_32.png\",
 		\"max_stack_size\": \"1\",
@@ -813,12 +719,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"0.4\",
-		\"width\": \"1\"
+		\"weight\": \"0.4\"
 	},
 	{
 		\"description\": \"A compact and portable stove, perfect for cooking meals during survival situations.\",
-		\"height\": \"3\",
 		\"id\": \"portable_stove\",
 		\"image\": \"./Mods/Core/Items/portable_stove_64_32.png\",
 		\"max_stack_size\": \"1\",
@@ -827,12 +731,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"200\",
-		\"weight\": \"3\",
-		\"width\": \"3\"
+		\"weight\": \"3\"
 	},
 	{
 		\"description\": \"A durable cooking pot, essential for boiling water and preparing meals.\",
-		\"height\": \"4\",
 		\"id\": \"cooking_pot\",
 		\"image\": \"./Mods/Core/Items/cooking_pot_32.png\",
 		\"max_stack_size\": \"1\",
@@ -841,12 +743,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"350\",
-		\"weight\": \"3\",
-		\"width\": \"4\"
+		\"weight\": \"3\"
 	},
 	{
 		\"description\": \"A small tool crucial for opening canned food, an essential for survival.\",
-		\"height\": \"1\",
 		\"id\": \"can_opener\",
 		\"image\": \"./Mods/Core/Items/can_opener_64_32.png\",
 		\"max_stack_size\": \"1\",
@@ -855,12 +755,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"60\",
-		\"weight\": \"0.2\",
-		\"width\": \"1\"
+		\"weight\": \"0.2\"
 	},
 	{
 		\"description\": \"A sturdy cutting board, ideal for preparing food safely and efficiently.\",
-		\"height\": \"2\",
 		\"id\": \"cutting_board\",
 		\"image\": \"./Mods/Core/Items/cutting_board_64_32.png\",
 		\"max_stack_size\": \"1\",
@@ -869,12 +767,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"200\",
-		\"weight\": \"1\",
-		\"width\": \"3\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A large bowl used for mixing ingredients, indispensable for any cooking or baking tasks.\",
-		\"height\": \"3\",
 		\"id\": \"mixing_bowl\",
 		\"image\": \"./Mods/Core/Items/mixing_bowl_32.png\",
 		\"max_stack_size\": \"1\",
@@ -883,12 +779,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"250\",
-		\"weight\": \"0.5\",
-		\"width\": \"3\"
+		\"weight\": \"0.5\"
 	},
 	{
 		\"description\": \"A metal kettle perfect for boiling water to make tea or instant meals.\",
-		\"height\": \"3\",
 		\"id\": \"tea_kettle\",
 		\"image\": \"./Mods/Core/Items/tea_kettle_32.png\",
 		\"max_stack_size\": \"1\",
@@ -897,12 +791,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"200\",
-		\"weight\": \"1\",
-		\"width\": \"3\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A small rack containing various spices to enhance the flavor of food.\",
-		\"height\": \"2\",
 		\"id\": \"spice_rack\",
 		\"image\": \"./Mods/Core/Items/spice_rack_32.png\",
 		\"max_stack_size\": \"1\",
@@ -911,12 +803,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"150\",
-		\"weight\": \"1\",
-		\"width\": \"4\"
+		\"weight\": \"1\"
 	},
 	{
 		\"description\": \"A measuring cup, essential for precisely measuring ingredients for recipes.\",
-		\"height\": \"1\",
 		\"id\": \"measuring_cup\",
 		\"image\": \"./Mods/Core/Items/measuring_cup_32.png\",
 		\"max_stack_size\": \"1\",
@@ -925,12 +815,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"100\",
-		\"weight\": \"0.3\",
-		\"width\": \"2\"
+		\"weight\": \"0.3\"
 	},
 	{
 		\"description\": \"A wooden rolling pin, essential for flattening dough for baking.\",
-		\"height\": \"1\",
 		\"id\": \"rolling_pin\",
 		\"image\": \"./Mods/Core/Items/rolling_pin_64_32.png\",
 		\"max_stack_size\": \"1\",
@@ -939,12 +827,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"150\",
-		\"weight\": \"0.5\",
-		\"width\": \"3\"
+		\"weight\": \"0.5\"
 	},
 	{
 		\"description\": \"A heavy-duty frying pan, perfect for cooking everything from eggs to stir-fry.\",
-		\"height\": \"2\",
 		\"id\": \"frying_pan\",
 		\"image\": \"./Mods/Core/Items/frying_pan_32.png\",
 		\"max_stack_size\": \"1\",
@@ -953,12 +839,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"200\",
-		\"weight\": \"2\",
-		\"width\": \"4\"
+		\"weight\": \"2\"
 	},
 	{
 		\"description\": \"A metal colander, ideal for draining pasta or washing vegetables.\",
-		\"height\": \"3\",
 		\"id\": \"steel_colander\",
 		\"image\": \"./Mods/Core/Items/steel_colander_32.png\",
 		\"max_stack_size\": \"1\",
@@ -967,12 +851,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"200\",
-		\"weight\": \"0.7\",
-		\"width\": \"3\"
+		\"weight\": \"0.7\"
 	},
 	{
 		\"description\": \"A handy peeler, perfect for skinning vegetables and fruits with ease.\",
-		\"height\": \"1\",
 		\"id\": \"peeler\",
 		\"image\": \"./Mods/Core/Items/peeler_32.png\",
 		\"max_stack_size\": \"1\",
@@ -981,12 +863,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"50\",
-		\"weight\": \"0.1\",
-		\"width\": \"1\"
+		\"weight\": \"0.1\"
 	},
 	{
 		\"description\": \"A metal grater, essential for shredding cheese, vegetables, and more.\",
-		\"height\": \"2\",
 		\"id\": \"grater\",
 		\"image\": \"./Mods/Core/Items/grater_32.png\",
 		\"max_stack_size\": \"1\",
@@ -995,12 +875,10 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"50\",
-		\"weight\": \"0.3\",
-		\"width\": \"2\"
+		\"weight\": \"0.3\"
 	},
 	{
 		\"description\": \"A compact electric toaster, ideal for toasting bread quickly.\",
-		\"height\": \"2\",
 		\"id\": \"toaster\",
 		\"image\": \"./Mods/Core/Items/toaster_32.png\",
 		\"max_stack_size\": \"1\",
@@ -1009,8 +887,7 @@ json_data = "[
 		\"stack_size\": \"1\",
 		\"two_handed\": false,
 		\"volume\": \"300\",
-		\"weight\": \"1.5\",
-		\"width\": \"2\"
+		\"weight\": \"1.5\"
 	},
 	{
 		\"description\": \"An electric blender, perfect for making smoothies, soups, and other blended concoctions.\",

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -1,7 +1,6 @@
 [
 	{
 		"description": "A wooden plank that could be used for all kinds of crafting and construction",
-		"height": "2",
 		"id": "plank_2x4",
 		"image": "./Mods/Core/Items/plank.png",
 		"max_stack_size": "3",
@@ -17,12 +16,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "300",
-		"weight": "2",
-		"width": "4"
+		"weight": "2"
 	},
 	{
 		"description": "Some metal bits and pieces. Useful for something, right?",
-		"height": "2",
 		"id": "steel_scrap",
 		"image": "./Mods/Core/Items/steel_scrap.png",
 		"max_stack_size": "100",
@@ -43,15 +40,13 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "0.25",
-		"width": "2"
+		"weight": "0.25"
 	},
 	{
 		"Ammo": {
 			"damage": "25"
 		},
 		"description": "Standard type of ammunition. Very common.",
-		"height": "1",
 		"id": "bullet_9mm",
 		"image": "./Mods/Core/Items/9mm.png",
 		"max_stack_size": "100",
@@ -71,8 +66,7 @@
 		"stack_size": "20",
 		"two_handed": false,
 		"volume": "0.1",
-		"weight": "0.01",
-		"width": "1"
+		"weight": "0.01"
 	},
 	{
 		"Craft": [
@@ -100,7 +94,6 @@
 			"used_ammo": "bullet_9mm"
 		},
 		"description": "In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets",
-		"height": "1",
 		"id": "pistol_magazine",
 		"image": "./Mods/Core/Items/pistol_magazine.png",
 		"max_stack_size": "1",
@@ -117,8 +110,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.25",
-		"width": "1"
+		"weight": "0.25"
 	},
 	{
 		"Ranged": {
@@ -133,7 +125,6 @@
 			"used_skill": "short_guns"
 		},
 		"description": "A standard issue pistol that uses 9mm ammunition",
-		"height": "2",
 		"id": "pistol_9mm",
 		"image": "./Mods/Core/Items/pistol_32.png",
 		"max_stack_size": "1",
@@ -149,8 +140,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "2",
-		"width": "2"
+		"weight": "2"
 	},
 	{
 		"Ranged": {
@@ -165,7 +155,6 @@
 			"used_skill": "short_guns"
 		},
 		"description": "A standard issue rifle that uses 9mm ammunition",
-		"height": "2",
 		"id": "rifle_m4a1",
 		"image": "./Mods/Core/Items/rifle_64_32.png",
 		"max_stack_size": "1",
@@ -174,8 +163,7 @@
 		"stack_size": "1",
 		"two_handed": true,
 		"volume": "300",
-		"weight": "4",
-		"width": "4"
+		"weight": "4"
 	},
 	{
 		"Ranged": {
@@ -190,7 +178,6 @@
 			"used_skill": "short_guns"
 		},
 		"description": "Chugun in Russian is for cast steel, MPAP is \"Multi Purpose Automatic Pistol\"",
-		"height": "2",
 		"id": "chugunov_mpap",
 		"image": "./Mods/Core/Items/chugunov_mpap_32_28.png",
 		"max_stack_size": "1",
@@ -199,8 +186,7 @@
 		"stack_size": "1",
 		"two_handed": true,
 		"volume": "150",
-		"weight": "3",
-		"width": "4"
+		"weight": "3"
 	},
 	{
 		"Magazine": {
@@ -209,7 +195,6 @@
 			"used_ammo": "bullet_7.62x26"
 		},
 		"description": "A magazine to be loaded into a Chuganov MPAP",
-		"height": "1",
 		"id": "chugunov_mpap_magazine",
 		"image": "./Mods/Core/Items/chugunov_mpap_magazine_16_32.png",
 		"max_stack_size": "1",
@@ -218,12 +203,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.25",
-		"width": "1"
+		"weight": "0.25"
 	},
 	{
 		"description": "This plastic bottle only contains air",
-		"height": "2",
 		"id": "bottle_plastic_empty",
 		"image": "./Mods/Core/Items/bottle_empty_32.png",
 		"max_stack_size": "10",
@@ -242,15 +225,13 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "0.1",
-		"width": "2"
+		"weight": "0.1"
 	},
 	{
 		"Food": {
 			"health": "5"
 		},
 		"description": "This plastic bottle is filled with water",
-		"height": "2",
 		"id": "bottle_plastic_water",
 		"image": "./Mods/Core/Items/bottle_water_32.png",
 		"max_stack_size": "10",
@@ -267,12 +248,10 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "0.25",
-		"width": "2"
+		"weight": "0.25"
 	},
 	{
 		"description": "The contents will satisfy your hunger",
-		"height": "2",
 		"id": "canned_food",
 		"image": "./Mods/Core/Items/canned_food_32.png",
 		"max_stack_size": "5",
@@ -288,12 +267,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "30",
-		"weight": "0.25",
-		"width": "2"
+		"weight": "0.25"
 	},
 	{
 		"description": "A sharp blade with a handle for excellent control",
-		"height": "1",
 		"id": "machete",
 		"image": "./Mods/Core/Items/machete_32.png",
 		"max_stack_size": "1",
@@ -302,12 +279,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "4",
-		"width": "1"
+		"weight": "4"
 	},
 	{
 		"description": "Anyone is able to craft this simple arrow",
-		"height": "1",
 		"id": "wood_arrow_basic",
 		"image": "./Mods/Core/Items/arrow_basic_32.png",
 		"max_stack_size": "20",
@@ -316,13 +291,10 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "1",
-		"weight": "0.1",
-		"width": "1"
+		"weight": "0.1"
 	},
 	{
 		"description": "A stick with a block of steel on it. It is used to apply force to objects like nails",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "hammer",
 		"image": "./Mods/Core/Items/hammer_32.png",
 		"max_stack_size": "1",
@@ -338,8 +310,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "2",
-		"width": "4"
+		"weight": "2"
 	},
 	{
 		"Craft": [
@@ -362,7 +333,6 @@
 			}
 		],
 		"description": "A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects",
-		"height": "2",
 		"id": "screwdriver",
 		"image": "./Mods/Core/Items/screwdriver_32.png",
 		"max_stack_size": "1",
@@ -379,12 +349,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "20",
-		"weight": "0.5",
-		"width": "4"
+		"weight": "0.5"
 	},
 	{
 		"description": "A basic bandage that will help to heal a wound",
-		"height": "2",
 		"id": "bandage_basic",
 		"image": "./Mods/Core/Items/bandage_32.png",
 		"max_stack_size": "20",
@@ -401,12 +369,10 @@
 		"stack_size": "3",
 		"two_handed": false,
 		"volume": "1",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A small bottle that contains antibiotics. It helps to recover from disease.",
-		"height": "2",
 		"id": "bottle_antibiotics",
 		"image": "./Mods/Core/Items/antibiotics_32.png",
 		"max_stack_size": "5",
@@ -422,13 +388,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A piece of clothing to wear on the torso. It will keep you warm and offers a bit of protection.",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "jacket",
 		"image": "./Mods/Core/Items/jacket_32.png",
 		"max_stack_size": "1",
@@ -437,13 +400,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "1",
-		"width": "4"
+		"weight": "1"
 	},
 	{
 		"description": "Comfortable footwear to keep your feet safe",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "boots",
 		"image": "./Mods/Core/Items/boots_32.png",
 		"max_stack_size": "1",
@@ -459,13 +419,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "1",
-		"width": "4"
+		"weight": "1"
 	},
 	{
 		"description": "A large container that holds gasoline",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "jerrycan_gasoline",
 		"image": "./Mods/Core/Items/jerrycan_gas_32.png",
 		"max_stack_size": "1",
@@ -474,13 +431,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "400",
-		"weight": "10",
-		"width": "4"
+		"weight": "10"
 	},
 	{
 		"description": "It's a can that contains oil. It has a spout that allows you to pour it out.",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "can_oil",
 		"image": "./Mods/Core/Items/can_oil_32.png",
 		"max_stack_size": "1",
@@ -496,12 +450,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "2",
-		"width": "4"
+		"weight": "2"
 	},
 	{
 		"description": "A small radio that can be powered by batteries or an electical cord.",
-		"height": "2",
 		"id": "radio_handheld",
 		"image": "./Mods/Core/Items/battery_powered_radio_32.png",
 		"max_stack_size": "1",
@@ -510,12 +462,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "1",
-		"width": "4"
+		"weight": "1"
 	},
 	{
 		"description": "A basic battery powered flashlight. It will shine a beam of light when it is turned on",
-		"height": "2",
 		"id": "flashlight_basic",
 		"image": "./Mods/Core/Items/flashlight_32.png",
 		"max_stack_size": "1",
@@ -531,13 +481,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.5",
-		"width": "4"
+		"weight": "0.5"
 	},
 	{
 		"description": "It's a can that contains beer. Don't drink a lot of it or you will get drunk",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "can_beer",
 		"image": "./Mods/Core/Items/can_beer_32.png",
 		"max_stack_size": "5",
@@ -553,12 +500,10 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.5",
-		"width": "4"
+		"weight": "0.5"
 	},
 	{
 		"description": "It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking",
-		"height": "2",
 		"id": "pack_sigarrettes",
 		"image": "./Mods/Core/Items/sigarrette_pack_32.png",
 		"max_stack_size": "5",
@@ -567,12 +512,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A piece of clothing that offers protection from environmental hazards",
-		"height": "2",
 		"id": "gas_mask",
 		"image": "./Mods/Core/Items/gasmask_32.png",
 		"max_stack_size": "1",
@@ -581,13 +524,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "80",
-		"weight": "1",
-		"width": "4"
+		"weight": "1"
 	},
 	{
 		"description": "A piece of clothing that offers protection from ballistic forces",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "vest_ballistic",
 		"image": "./Mods/Core/Items/vest_ballistic_32.png",
 		"max_stack_size": "1",
@@ -596,13 +536,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "4",
-		"width": "4"
+		"weight": "4"
 	},
 	{
 		"description": "A device that shows your orientation relative to the earth's poles",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "compass",
 		"image": "./Mods/Core/Items/compass_32.png",
 		"max_stack_size": "1",
@@ -611,12 +548,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "6",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A very common type of battery that fits most battery-powered devices",
-		"height": "2",
 		"id": "battery_small",
 		"image": "./Mods/Core/Items/battery_32.png",
 		"max_stack_size": "20",
@@ -632,13 +567,10 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "0.1",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A large panel that draws power from the sun",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "solar_panel",
 		"image": "./Mods/Core/Items/solar_panel_32.png",
 		"max_stack_size": "1",
@@ -647,13 +579,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "1000",
-		"weight": "10",
-		"width": "4"
+		"weight": "10"
 	},
 	{
 		"description": "A large piece of paper that visualizes the area around you",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "map_paper",
 		"image": "./Mods/Core/Items/map_paper_32.png",
 		"max_stack_size": "1",
@@ -662,13 +591,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A piece of fabric and some strings. You can deploy it to get some shelter from the weather",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "tarp",
 		"image": "./Mods/Core/Items/tarp_32.png",
 		"max_stack_size": "1",
@@ -677,13 +603,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "3",
-		"width": "4"
+		"weight": "3"
 	},
 	{
 		"description": "A piece of fabric and some strings. You can deploy it to get some shelter from the weather. It is currently folded to save space.",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "tent",
 		"image": "./Mods/Core/Items/tent_32.png",
 		"max_stack_size": "1",
@@ -692,13 +615,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "600",
-		"weight": "9",
-		"width": "4"
+		"weight": "9"
 	},
 	{
 		"description": "A small book explaining the very basics of survival",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "guide_survival_basic",
 		"image": "./Mods/Core/Items/survival_guide_32.png",
 		"max_stack_size": "5",
@@ -707,13 +627,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A book containing an entertaining story",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "book_novel",
 		"image": "./Mods/Core/Items/book_novel_32.png",
 		"max_stack_size": "5",
@@ -729,12 +646,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.4",
-		"width": "4"
+		"weight": "0.4"
 	},
 	{
 		"description": "A small bottle that contains disinfectant. It helps to disinfect wounds",
-		"height": "2",
 		"id": "bottle_disinfectant",
 		"image": "./Mods/Core/Items/bottle_disinfectant_32.png",
 		"max_stack_size": "5",
@@ -750,12 +665,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1",
-		"width": "4"
+		"weight": "0.1"
 	},
 	{
 		"description": "A small radio that allows you to communicate with someone over a large distance",
-		"height": "2",
 		"id": "radio_two_way",
 		"image": "./Mods/Core/Items/radio_two_way_32.png",
 		"max_stack_size": "1",
@@ -764,13 +677,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "1",
-		"width": "4"
+		"weight": "1"
 	},
 	{
 		"description": "A small device that provides a spark that can be used to light a fire. No power or fuel required.",
-		"height": "2",
-		"iamge": "res://Textures/plank.png",
 		"id": "firestarter_basic",
 		"image": "./Mods/Core/Items/firestarter_32.png",
 		"max_stack_size": "1",
@@ -779,12 +689,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.2",
-		"width": "4"
+		"weight": "0.2"
 	},
 	{
 		"description": "\n    A true survival fishing kit in a very small, lightweight package!\n    Contains 118 foot line and winder\n    2 lures, 2 hooks\n    2 swivels, 2 weghts\n    Comes in a strong durable heavy duty resealable plastic bag",
-		"height": "2",
 		"id": "kit_fishing_small",
 		"image": "./Mods/Core/Items/kit_fishing_small_32.png",
 		"max_stack_size": "1",
@@ -793,12 +701,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.4",
-		"width": "4"
+		"weight": "0.4"
 	},
 	{
 		"description": "A versatile kitchen tool, essential for slicing, dicing, and chopping food.",
-		"height": "1",
 		"id": "kitchen_knife",
 		"image": "./Mods/Core/Items/kitchen_knife_64_32.png",
 		"max_stack_size": "1",
@@ -807,12 +713,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.4",
-		"width": "1"
+		"weight": "0.4"
 	},
 	{
 		"description": "A compact and portable stove, perfect for cooking meals during survival situations.",
-		"height": "3",
 		"id": "portable_stove",
 		"image": "./Mods/Core/Items/portable_stove_64_32.png",
 		"max_stack_size": "1",
@@ -821,12 +725,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "3",
-		"width": "3"
+		"weight": "3"
 	},
 	{
 		"description": "A durable cooking pot, essential for boiling water and preparing meals.",
-		"height": "4",
 		"id": "cooking_pot",
 		"image": "./Mods/Core/Items/cooking_pot_32.png",
 		"max_stack_size": "1",
@@ -835,12 +737,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "350",
-		"weight": "3",
-		"width": "4"
+		"weight": "3"
 	},
 	{
 		"description": "A small tool crucial for opening canned food, an essential for survival.",
-		"height": "1",
 		"id": "can_opener",
 		"image": "./Mods/Core/Items/can_opener_64_32.png",
 		"max_stack_size": "1",
@@ -849,12 +749,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "60",
-		"weight": "0.2",
-		"width": "1"
+		"weight": "0.2"
 	},
 	{
 		"description": "A sturdy cutting board, ideal for preparing food safely and efficiently.",
-		"height": "2",
 		"id": "cutting_board",
 		"image": "./Mods/Core/Items/cutting_board_64_32.png",
 		"max_stack_size": "1",
@@ -863,12 +761,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "1",
-		"width": "3"
+		"weight": "1"
 	},
 	{
 		"description": "A large bowl used for mixing ingredients, indispensable for any cooking or baking tasks.",
-		"height": "3",
 		"id": "mixing_bowl",
 		"image": "./Mods/Core/Items/mixing_bowl_32.png",
 		"max_stack_size": "1",
@@ -877,12 +773,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "250",
-		"weight": "0.5",
-		"width": "3"
+		"weight": "0.5"
 	},
 	{
 		"description": "A metal kettle perfect for boiling water to make tea or instant meals.",
-		"height": "3",
 		"id": "tea_kettle",
 		"image": "./Mods/Core/Items/tea_kettle_32.png",
 		"max_stack_size": "1",
@@ -891,12 +785,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "1",
-		"width": "3"
+		"weight": "1"
 	},
 	{
 		"description": "A small rack containing various spices to enhance the flavor of food.",
-		"height": "2",
 		"id": "spice_rack",
 		"image": "./Mods/Core/Items/spice_rack_32.png",
 		"max_stack_size": "1",
@@ -905,12 +797,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "1",
-		"width": "4"
+		"weight": "1"
 	},
 	{
 		"description": "A measuring cup, essential for precisely measuring ingredients for recipes.",
-		"height": "1",
 		"id": "measuring_cup",
 		"image": "./Mods/Core/Items/measuring_cup_32.png",
 		"max_stack_size": "1",
@@ -919,12 +809,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.3",
-		"width": "2"
+		"weight": "0.3"
 	},
 	{
 		"description": "A wooden rolling pin, essential for flattening dough for baking.",
-		"height": "1",
 		"id": "rolling_pin",
 		"image": "./Mods/Core/Items/rolling_pin_64_32.png",
 		"max_stack_size": "1",
@@ -933,12 +821,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "0.5",
-		"width": "3"
+		"weight": "0.5"
 	},
 	{
 		"description": "A heavy-duty frying pan, perfect for cooking everything from eggs to stir-fry.",
-		"height": "2",
 		"id": "frying_pan",
 		"image": "./Mods/Core/Items/frying_pan_32.png",
 		"max_stack_size": "1",
@@ -947,12 +833,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "2",
-		"width": "4"
+		"weight": "2"
 	},
 	{
 		"description": "A metal colander, ideal for draining pasta or washing vegetables.",
-		"height": "3",
 		"id": "steel_colander",
 		"image": "./Mods/Core/Items/steel_colander_32.png",
 		"max_stack_size": "1",
@@ -961,12 +845,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "0.7",
-		"width": "3"
+		"weight": "0.7"
 	},
 	{
 		"description": "A handy peeler, perfect for skinning vegetables and fruits with ease.",
-		"height": "1",
 		"id": "peeler",
 		"image": "./Mods/Core/Items/peeler_32.png",
 		"max_stack_size": "1",
@@ -975,12 +857,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.1",
-		"width": "1"
+		"weight": "0.1"
 	},
 	{
 		"description": "A metal grater, essential for shredding cheese, vegetables, and more.",
-		"height": "2",
 		"id": "grater",
 		"image": "./Mods/Core/Items/grater_32.png",
 		"max_stack_size": "1",
@@ -989,12 +869,10 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.3",
-		"width": "2"
+		"weight": "0.3"
 	},
 	{
 		"description": "A compact electric toaster, ideal for toasting bread quickly.",
-		"height": "2",
 		"id": "toaster",
 		"image": "./Mods/Core/Items/toaster_32.png",
 		"max_stack_size": "1",
@@ -1003,8 +881,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "300",
-		"weight": "1.5",
-		"width": "2"
+		"weight": "1.5"
 	},
 	{
 		"description": "An electric blender, perfect for making smoothies, soups, and other blended concoctions.",

--- a/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
@@ -1,0 +1,82 @@
+extends Control
+
+# This script is meant to be used with the mod maintenance interface
+# This script allows the user to erase the selected property from the selected type
+
+@export var propertiesOptionButton: OptionButton
+@export var typesOptionButton: OptionButton
+@export var outputTextEdit: TextEdit
+
+
+func _on_back_button_button_up():
+	get_tree().change_scene_to_file("res://scene_selector.tscn")
+
+
+# fills the propertiesOptionButton with all top-level properties of the selected entity type
+# 1. Check if a type has been selected and return if not
+# 2. check if the type_data array contains anything and return if not
+# 3. Loop over all entities in type_data
+# 4. For each yop-level property in the entity's property dictionary, add the property
+# to propertiesOptionButton if it's not already there
+func _on_get_properties_button_button_up():
+	propertiesOptionButton.clear()  # Clear existing items
+	var type_data = get_type_data()
+	if not type_data or type_data.is_empty():
+		outputTextEdit.text = "No data available or type not selected."
+		return
+
+	var properties_set = {}  # Using a dictionary to track unique properties
+	for entity in type_data:
+		for property in entity.keys():
+			properties_set[property] = true
+
+	for property in properties_set.keys():
+		propertiesOptionButton.add_item(property)
+
+	if propertiesOptionButton.get_item_count() == 0:
+		outputTextEdit.text = "No properties found for selected type."
+	else:
+		outputTextEdit.text = "Properties loaded for selected type."
+
+
+# Erases the selected property from all entities of the selected type
+# 1. Check if a type has been selected and return if not
+# 2. Check if a property has been selected and return if not
+# 3. Get the data of the selected type and check if it contains data. Return if not
+# 4. Loop over the entities in the data of the selected type
+# 4.1. For each entity, erase the selected property if it exists
+# 4.2 print the deleted entity id and property to the output
+func _on_erase_properties_button_button_up():
+	if typesOptionButton.selected == -1:
+		outputTextEdit.text = "No type selected."
+		return
+	if propertiesOptionButton.selected == -1:
+		outputTextEdit.text = "No property selected."
+		return
+
+	var type_data = get_type_data()
+	if type_data.is_empty():
+		outputTextEdit.text = "No data available for the selected type."
+		return
+
+	var property_to_erase = propertiesOptionButton.get_item_text(propertiesOptionButton.selected)
+	var changes = []
+	for entity in type_data:
+		if property_to_erase in entity:
+			changes.append("Removed property '" + property_to_erase + "' from " + str(entity.get("id", "Unknown ID")))
+			entity.erase(property_to_erase)
+
+	outputTextEdit.text = "Changes made:\n" + "\n".join(changes)
+	if changes.empty():
+		outputTextEdit.text = "No changes made, property '" + property_to_erase + "' not found in any entities."
+
+
+func get_type_data() -> Variant:
+	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
+	if selected_type == "Item":
+		return Gamedata.data.items
+	elif selected_type == "Furniture":
+		return Gamedata.data.furniture
+	elif selected_type == "Mob":
+		return Gamedata.data.mobs
+	return null

--- a/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
@@ -20,7 +20,8 @@ func _on_back_button_button_up():
 # to propertiesOptionButton if it's not already there
 func _on_get_properties_button_button_up():
 	propertiesOptionButton.clear()  # Clear existing items
-	var type_data = get_type_data()
+	var game_data = get_type_data()
+	var type_data = game_data.data
 	if not type_data or type_data.is_empty():
 		outputTextEdit.text = "No data available or type not selected."
 		return
@@ -54,7 +55,8 @@ func _on_erase_properties_button_button_up():
 		outputTextEdit.text = "No property selected."
 		return
 
-	var type_data = get_type_data()
+	var game_data = get_type_data()
+	var type_data = game_data.data
 	if type_data.is_empty():
 		outputTextEdit.text = "No data available for the selected type."
 		return
@@ -67,16 +69,17 @@ func _on_erase_properties_button_button_up():
 			entity.erase(property_to_erase)
 
 	outputTextEdit.text = "Changes made:\n" + "\n".join(changes)
-	if changes.empty():
+	if changes.is_empty():
 		outputTextEdit.text = "No changes made, property '" + property_to_erase + "' not found in any entities."
+	Gamedata.save_data_to_file(game_data)
 
 
 func get_type_data() -> Variant:
 	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
 	if selected_type == "Item":
-		return Gamedata.data.items.data
+		return Gamedata.data.items
 	elif selected_type == "Furniture":
-		return Gamedata.data.furniture.data
+		return Gamedata.data.furniture
 	elif selected_type == "Mob":
-		return Gamedata.data.mobs.data
+		return Gamedata.data.mobs
 	return null

--- a/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
@@ -74,9 +74,9 @@ func _on_erase_properties_button_button_up():
 func get_type_data() -> Variant:
 	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
 	if selected_type == "Item":
-		return Gamedata.data.items
+		return Gamedata.data.items.data
 	elif selected_type == "Furniture":
-		return Gamedata.data.furniture
+		return Gamedata.data.furniture.data
 	elif selected_type == "Mob":
-		return Gamedata.data.mobs
+		return Gamedata.data.mobs.data
 	return null

--- a/Scenes/ContentManager/ModMaintenance/modmaintenance.tscn
+++ b/Scenes/ContentManager/ModMaintenance/modmaintenance.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=4 format=3 uid="uid://6d7nhwfk088o"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/modmaintenance.gd" id="1_qyerb"]
+[ext_resource type="PackedScene" uid="uid://cycrhylvmdoo1" path="res://Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn" id="2_flc2r"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_avegi"]
+font_size = 42
+
+[node name="modmaintenance" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_qyerb")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HeaderHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="VBoxContainer/HeaderHBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Back"
+
+[node name="modmaintenanceLabel" type="Label" parent="VBoxContainer/HeaderHBoxContainer"]
+layout_mode = 2
+text = "Mod maintenance"
+label_settings = SubResource("LabelSettings_avegi")
+
+[node name="explainationLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "This menu is used for mod maintenance. Select one of the scripts below you want to use to maintain your mod"
+
+[node name="modSelectionLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Selected mod: Core"
+
+[node name="ScriptHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="ScriptLabel" type="Label" parent="VBoxContainer/ScriptHBoxContainer"]
+layout_mode = 2
+text = "Selected script:"
+
+[node name="ScriptOptionButton" type="OptionButton" parent="VBoxContainer/ScriptHBoxContainer"]
+layout_mode = 2
+item_count = 1
+selected = 0
+popup/item_0/text = "Remove property"
+popup/item_0/id = 0
+
+[node name="removeproperty" parent="VBoxContainer" instance=ExtResource("2_flc2r")]
+layout_mode = 2
+
+[connection signal="button_up" from="VBoxContainer/HeaderHBoxContainer/BackButton" to="." method="_on_back_button_button_up"]
+[connection signal="item_selected" from="VBoxContainer/ScriptHBoxContainer/ScriptOptionButton" to="." method="_on_script_option_button_item_selected"]

--- a/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
@@ -5,7 +5,7 @@
 [sub_resource type="LabelSettings" id="LabelSettings_avegi"]
 font_size = 36
 
-[node name="removeproperty" type="Control"]
+[node name="removeproperty" type="Control" node_paths=PackedStringArray("propertiesOptionButton", "typesOptionButton", "outputTextEdit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -15,6 +15,9 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_vgm8i")
+propertiesOptionButton = NodePath("VBoxContainer/PropertiesHBoxContainer/PropertiesOptionButton")
+typesOptionButton = NodePath("VBoxContainer/TypesHBoxContainer/TypesOptionButton")
+outputTextEdit = NodePath("VBoxContainer/OutputTextEdit")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1

--- a/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
@@ -1,0 +1,85 @@
+[gd_scene load_steps=3 format=3 uid="uid://cycrhylvmdoo1"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd" id="1_vgm8i"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_avegi"]
+font_size = 36
+
+[node name="removeproperty" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_vgm8i")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="modmaintenanceLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Remove property"
+label_settings = SubResource("LabelSettings_avegi")
+
+[node name="explainationLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Create a backup before using this script! Removes the selected property from all of the entities of the selected type. All entities
+ of the selected type will be checked for the property and it will be removed if the entity has it.
+1. Select the type of entity you want to remove the property from.
+2. Select the property to be removed
+3. Press remove property to remove the property from all entities of the selected type"
+
+[node name="TypesHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="TypesLabel" type="Label" parent="VBoxContainer/TypesHBoxContainer"]
+layout_mode = 2
+text = "Selected type:"
+
+[node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
+layout_mode = 2
+item_count = 3
+selected = 0
+popup/item_0/text = "Item"
+popup/item_0/id = 0
+popup/item_1/text = "Furniture"
+popup/item_1/id = 1
+popup/item_2/text = "Mob"
+popup/item_2/id = 2
+
+[node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
+layout_mode = 2
+text = "Get properties"
+
+[node name="PropertiesHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="PropertiesLabel" type="Label" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+text = "Selected property:"
+
+[node name="PropertiesOptionButton" type="OptionButton" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+
+[node name="ErasePropertiesButton" type="Button" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+text = "Erase property"
+
+[node name="outputLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Output:"
+
+[node name="OutputTextEdit" type="TextEdit" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[connection signal="button_up" from="VBoxContainer/TypesHBoxContainer/GetPropertiesButton" to="." method="_on_get_properties_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/PropertiesHBoxContainer/ErasePropertiesButton" to="." method="_on_erase_properties_button_button_up"]

--- a/Scenes/ContentManager/Scripts/contentmanager.gd
+++ b/Scenes/ContentManager/Scripts/contentmanager.gd
@@ -7,3 +7,7 @@ func _on_back_button_button_up():
 
 func _on_content_editor_button_button_up():
 	get_tree().change_scene_to_file("res://Scenes/ContentManager/contenteditor.tscn")
+
+
+func _on_mod_manager_button_button_up():
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/modmanager.tscn")

--- a/Scenes/ContentManager/Scripts/modmaintenance.gd
+++ b/Scenes/ContentManager/Scripts/modmaintenance.gd
@@ -1,0 +1,22 @@
+extends Control
+
+# This script is meant to be used with the mod maintenance inteface
+# This script allows the user to erase the selected property from the selected type
+
+
+@export var scriptOptionButton: OptionButton
+@export var removePropertyScript: Control
+
+
+func _on_back_button_button_up():
+	get_tree().change_scene_to_file("res://scene_selector.tscn")
+
+
+func _on_script_option_button_item_selected(index):
+	hide_scripts()
+	if index == 0:
+		removePropertyScript.visible = true
+
+
+func hide_scripts():
+	removePropertyScript.visible = false

--- a/Scenes/ContentManager/Scripts/modmaintenance.gd
+++ b/Scenes/ContentManager/Scripts/modmaintenance.gd
@@ -9,7 +9,7 @@ extends Control
 
 
 func _on_back_button_button_up():
-	get_tree().change_scene_to_file("res://scene_selector.tscn")
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/modmanager.tscn")
 
 
 func _on_script_option_button_item_selected(index):

--- a/Scenes/ContentManager/Scripts/modmanager.gd
+++ b/Scenes/ContentManager/Scripts/modmanager.gd
@@ -2,8 +2,8 @@ extends Control
 
 
 func _on_back_button_button_up():
-	get_tree().change_scene_to_file("res://scene_selector.tscn")
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/contentmanager.tscn")
 
 
 func _on_mod_maintenance_button_button_up():
-	get_tree().change_scene_to_file("res://Scenes/ContentManager/contenteditor.tscn")
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/ModMaintenance/modmaintenance.tscn")

--- a/Scenes/ContentManager/Scripts/modmanager.gd
+++ b/Scenes/ContentManager/Scripts/modmanager.gd
@@ -1,0 +1,9 @@
+extends Control
+
+
+func _on_back_button_button_up():
+	get_tree().change_scene_to_file("res://scene_selector.tscn")
+
+
+func _on_mod_maintenance_button_button_up():
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/contenteditor.tscn")

--- a/Scenes/ContentManager/contentmanager.tscn
+++ b/Scenes/ContentManager/contentmanager.tscn
@@ -40,5 +40,6 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Back"
 
+[connection signal="button_up" from="VBoxContainer/ModManagerButton" to="." method="_on_mod_manager_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/ContentEditorButton" to="." method="_on_content_editor_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/BackButton" to="." method="_on_back_button_button_up"]

--- a/Scenes/ContentManager/modmanager.tscn
+++ b/Scenes/ContentManager/modmanager.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=2 format=3 uid="uid://cis7fd3ko7xfp"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/modmanager.gd" id="1_dmv7g"]
+
+[node name="modmanager" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_dmv7g")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.5
+offset_top = -33.0
+offset_right = 60.5
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="AddRemoveModsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Add/remove mods"
+
+[node name="ModMaintenanceButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Mod maintenance"
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Back"
+
+[connection signal="button_up" from="VBoxContainer/ModMaintenanceButton" to="." method="_on_mod_maintenance_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/BackButton" to="." method="_on_back_button_button_up"]

--- a/project.godot
+++ b/project.godot
@@ -53,6 +53,7 @@ folder_colors={
 "res://Scenes/ContentManager/Custom_Widgets/": "purple",
 "res://Scenes/ContentManager/Custom_Widgets/Scripts/": "green",
 "res://Scenes/ContentManager/Mapeditor/": "blue",
+"res://Scenes/ContentManager/ModMaintenance/Scripts/": "green",
 "res://Scenes/ContentManager/Scripts/": "green",
 "res://Scenes/Overmap/Scripts/": "green",
 "res://Scripts/": "green",


### PR DESCRIPTION
Requires #110 

This adds a new menu to maintain a mod using scripts. The first script I implemented will remove a property from entities in the mod data. Very simple. In the future, I want to expand this to perform bulk operations on the mod data if needed. This will also allow third-party mods to be maintained. In this way, we can help users keep their mod up to date and remove legacy data.

In this instance, I wanted to remove 3 properties that were still lingering in the data:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/44e5ffc0-6768-4550-b25e-213c8c6c4252)


It will output what has been removed:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/58d94ce0-e894-4673-bca8-2fc164e7051b)


I tested the game and made sure it still works.


