### PR TITLE
Itemgroup probability and amount

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -220,8 +220,7 @@ json_data = "[
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"kitchen_cupboard\",
-					\"cabinet_general\"
+					\"kitchen_cupboard\"
 				],
 				\"items\": [
 					\"screwdriver\"
@@ -246,8 +245,8 @@ json_data = "[
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"cabinet_general\",
-					\"kitchen_cupboard\"
+					\"kitchen_cupboard\",
+					\"cabinet_general\"
 				]
 			}
 		},

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -220,7 +220,8 @@ json_data = "[
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"kitchen_cupboard\"
+					\"kitchen_cupboard\",
+					\"cabinet_general\"
 				],
 				\"items\": [
 					\"screwdriver\"

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -3,15 +3,56 @@
 		"description": "Anything you can find in a kitchen cupboard",
 		"id": "kitchen_cupboard",
 		"items": [
-			"canned_food",
-			"bottle_plastic_water",
-			"bottle_plastic_empty",
-			"screwdriver",
-			"bandage_basic",
-			"bottle_antibiotics",
-			"can_beer",
-			"bottle_disinfectant"
+			{
+				"id": "canned_food",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bottle_plastic_water",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bottle_plastic_empty",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "screwdriver",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bandage_basic",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bottle_antibiotics",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "can_beer",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bottle_disinfectant",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			}
 		],
+		"mode": "Collection",
 		"name": "Kitchen cupboard",
 		"references": {
 			"core": {
@@ -29,11 +70,32 @@
 		"description": "Loot that's dropped by a mob",
 		"id": "mob_loot",
 		"items": [
-			"bullet_9mm",
-			"pistol_magazine",
-			"steel_scrap",
-			"plank_2x4"
+			{
+				"id": "bullet_9mm",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "pistol_magazine",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "steel_scrap",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "plank_2x4",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			}
 		],
+		"mode": "Collection",
 		"name": "Mob loot",
 		"sprite": "machete_32.png"
 	},
@@ -41,20 +103,86 @@
 		"description": "What you would find in a cabinet in a house, for example in the living room",
 		"id": "cabinet_general",
 		"items": [
-			"steel_scrap",
-			"bullet_9mm",
-			"pistol_magazine",
-			"pistol_9mm",
-			"bottle_plastic_water",
-			"hammer",
-			"screwdriver",
-			"bandage_basic",
-			"boots",
-			"can_oil",
-			"flashlight_basic",
-			"battery_small",
-			"book_novel"
+			{
+				"id": "steel_scrap",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bullet_9mm",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "pistol_magazine",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "pistol_9mm",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bottle_plastic_water",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "hammer",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "screwdriver",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "bandage_basic",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "boots",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "can_oil",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "flashlight_basic",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "battery_small",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "book_novel",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			}
 		],
+		"mode": "Collection",
 		"name": "General cabinet contents",
 		"references": {
 			"core": {

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -239,8 +239,8 @@
 		"references": {
 			"core": {
 				"itemgroups": [
-					"cabinet_general",
-					"kitchen_cupboard"
+					"kitchen_cupboard",
+					"cabinet_general"
 				]
 			}
 		},

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -5,6 +5,10 @@
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="4_tvfec"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_i82vb"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
 
 [node name="ItemgroupEditor" type="Control" node_paths=PackedStringArray("itemgroupImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemgroupSelector", "imageNameStringLabel", "modeOptionButton", "itemListContainer")]
 layout_mode = 3

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -95,7 +95,7 @@ layout_mode = 2
 text = "Description"
 
 [node name="DescriptionTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
-custom_minimum_size = Vector2(0, 100)
+custom_minimum_size = Vector2(300, 100)
 layout_mode = 2
 size_flags_stretch_ratio = 0.9
 tooltip_text = "Enter the description of this itemgroup"
@@ -125,7 +125,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
-columns = 4
+columns = 6
 
 [node name="Sprite_selector" parent="." instance=ExtResource("4_tvfec")]
 visible = false
@@ -133,5 +133,4 @@ visible = false
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="gui_input" from="VBoxContainer/FormGrid/ItemgroupImageDisplay" to="." method="_on_itemgroup_image_display_gui_input"]
-[connection signal="button_up" from="VBoxContainer/FormGrid/GroupTypeOptionButton" to="." method="_on_remove_item_button_button_up"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemgroupEditor.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=4 format=3 uid="uid://bw61ihylsl1p7"]
+[gd_scene load_steps=5 format=3 uid="uid://bw61ihylsl1p7"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd" id="1_ulsfi"]
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_fq8lh"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="4_tvfec"]
 
-[node name="ItemgroupEditor" type="Control" node_paths=PackedStringArray("itemgroupImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemgroupSelector", "imageNameStringLabel", "selectedItemNameDisplay", "itemList")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_i82vb"]
+
+[node name="ItemgroupEditor" type="Control" node_paths=PackedStringArray("itemgroupImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemgroupSelector", "imageNameStringLabel", "modeOptionButton", "itemListContainer")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -18,8 +20,8 @@ NameTextEdit = NodePath("VBoxContainer/FormGrid/NameTextEdit")
 DescriptionTextEdit = NodePath("VBoxContainer/FormGrid/DescriptionTextEdit")
 itemgroupSelector = NodePath("Sprite_selector")
 imageNameStringLabel = NodePath("VBoxContainer/FormGrid/ImageNameStringLabel")
-selectedItemNameDisplay = NodePath("VBoxContainer/FormGrid/SelectedItemControls/SelectedItemNameDisplay")
-itemList = NodePath("VBoxContainer/FormGrid/ItemList")
+modeOptionButton = NodePath("VBoxContainer/FormGrid/GroupTypeOptionButton")
+itemListContainer = NodePath("VBoxContainer/FormGrid/PanelContainer/ItemList")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -74,7 +76,6 @@ text = "ID:"
 [node name="IDTextLabel" type="Label" parent="VBoxContainer/FormGrid"]
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
-size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 
 [node name="NameLabel" type="Label" parent="VBoxContainer/FormGrid"]
@@ -84,7 +85,6 @@ text = "Name"
 [node name="NameTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
-size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 tooltip_text = "Enter the name of this itemgroup"
 focus_next = NodePath("../DescriptionTextEdit")
@@ -97,41 +97,35 @@ text = "Description"
 [node name="DescriptionTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
-size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.9
 tooltip_text = "Enter the description of this itemgroup"
 focus_previous = NodePath("../NameTextEdit")
 wrap_mode = 1
 
-[node name="SelectedItemLabel" type="Label" parent="VBoxContainer/FormGrid"]
+[node name="GroupTypeLabel" type="Label" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
-text = "Selected item"
+text = "Group type"
 
-[node name="SelectedItemControls" type="HBoxContainer" parent="VBoxContainer/FormGrid"]
-layout_mode = 2
-
-[node name="SelectedItemName" type="Label" parent="VBoxContainer/FormGrid/SelectedItemControls"]
-layout_mode = 2
-
-[node name="SelectedItemNameDisplay" type="Label" parent="VBoxContainer/FormGrid/SelectedItemControls"]
-layout_mode = 2
-
-[node name="RemoveItemButton" type="Button" parent="VBoxContainer/FormGrid/SelectedItemControls"]
+[node name="GroupTypeOptionButton" type="OptionButton" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
 tooltip_text = "Removes the selected item from the list"
-text = "Remove"
 
 [node name="ItemsLabel" type="Label" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
 text = "Items"
 
-[node name="ItemList" type="ItemList" parent="VBoxContainer/FormGrid"]
-custom_minimum_size = Vector2(0, 200)
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_i82vb")
+
+[node name="ItemList" type="GridContainer" parent="VBoxContainer/FormGrid/PanelContainer"]
+custom_minimum_size = Vector2(200, 200)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
-mouse_filter = 1
+columns = 4
 
 [node name="Sprite_selector" parent="." instance=ExtResource("4_tvfec")]
 visible = false
@@ -139,7 +133,5 @@ visible = false
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="gui_input" from="VBoxContainer/FormGrid/ItemgroupImageDisplay" to="." method="_on_itemgroup_image_display_gui_input"]
-[connection signal="button_up" from="VBoxContainer/FormGrid/SelectedItemControls/RemoveItemButton" to="." method="_on_remove_item_button_button_up"]
-[connection signal="empty_clicked" from="VBoxContainer/FormGrid/ItemList" to="." method="_on_item_list_empty_clicked"]
-[connection signal="item_selected" from="VBoxContainer/FormGrid/ItemList" to="." method="_on_item_list_item_selected"]
+[connection signal="button_up" from="VBoxContainer/FormGrid/GroupTypeOptionButton" to="." method="_on_remove_item_button_button_up"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -41,6 +41,7 @@ func _ready():
 	modeOptionButton.selected = 0  # Default to Collection
 
 
+# Refreshes the itemlist based on the contentdata
 func update_item_list_with_probabilities():
 	# Remove all children from the existing container
 	while itemListContainer.get_child_count() > 0:
@@ -53,6 +54,7 @@ func update_item_list_with_probabilities():
 		add_item_entry(item)
 
 
+# Adds a new item and controls to the itemlist
 func add_item_entry(item):
 	var item_icon = TextureRect.new()
 	var item_sprite = Gamedata.get_sprite_by_id(Gamedata.data.items, item.get("id"))
@@ -104,6 +106,8 @@ func add_item_entry(item):
 	itemListContainer.add_child(delete_button)
 
 
+# The user has pressed the delete button next to an item in the itemlist
+# Remove the entire row of the item
 func _on_delete_item_button_pressed(item_id):
 	var num_columns = itemListContainer.columns  # Make sure this matches the number of elements per item in your grid
 	var children_to_remove = []
@@ -125,7 +129,7 @@ func _on_delete_item_button_pressed(item_id):
 		child.queue_free()
 
 
-
+# Loads the data into the editor. contentData describes exactly one itemgroup
 func load_itemgroup_data():
 	if itemgroupImageDisplay and contentData.has("sprite") and not contentData["sprite"].is_empty():
 		itemgroupImageDisplay.texture = Gamedata.data.itemgroups.sprites[contentData["sprite"]]
@@ -214,6 +218,7 @@ func _on_itemgroup_image_display_gui_input(event):
 		itemgroupSelector.show()
 
 
+# Sets the sprite in the editor based on what sprite the user has selected
 func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	var itemgroupTexture: Resource = clicked_sprite.get_texture()
 	itemgroupImageDisplay.texture = itemgroupTexture
@@ -275,6 +280,7 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 		print_debug("Dropped data does not contain an 'id' key.")
 
 
+# Adds a header to the itemlist
 func add_header_row():
 	# Define a common style for all header labels
 	var header_style = StyleBoxFlat.new()

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -11,8 +11,8 @@ extends Control
 @export var DescriptionTextEdit: TextEdit = null
 @export var itemgroupSelector: Popup = null
 @export var imageNameStringLabel: Label = null
-@export var selectedItemNameDisplay: Label = null
-@export var itemList: ItemList = null
+@export var modeOptionButton: OptionButton
+@export var itemListContainer: GridContainer
 # For controlling the focus when the tab button is pressed
 var control_elements: Array = []
 
@@ -36,6 +36,60 @@ var contentData: Dictionary = {}:
 func _ready():
 	control_elements = [itemgroupImageDisplay,NameTextEdit,DescriptionTextEdit]
 	data_changed.connect(Gamedata.on_data_changed)
+	modeOptionButton.add_item("Collection")
+	modeOptionButton.add_item("Distribution")
+	modeOptionButton.selected = 0  # Default to Collection
+
+
+func update_item_list_with_probabilities():
+	# Remove all children from the existing container
+	while itemListContainer.get_child_count() > 0:
+		var child = itemListContainer.get_child(0)
+		itemListContainer.remove_child(child)
+		child.queue_free()
+
+	# Populate the container with new data
+	for item in contentData.get("items", []):
+		add_item_entry(item)
+
+
+func add_item_entry(item):
+	var item_icon = TextureRect.new()
+	var item_sprite = Gamedata.get_sprite_by_id(Gamedata.data.items, item.get("id"))
+	item_icon.texture = item_sprite
+	item_icon.custom_minimum_size = Vector2(16, 16)  # Customize as needed
+
+	var item_label = Label.new()
+	item_label.text = item.get("id")
+
+	var probability_spinbox = SpinBox.new()
+	probability_spinbox.min_value = 0.0
+	probability_spinbox.max_value = 100.0
+	probability_spinbox.value = item.get("probability", 20)
+	probability_spinbox.step = 1
+
+	var delete_button = Button.new()
+	delete_button.text = "Delete"
+	delete_button.button_up.connect(_on_delete_item_button_pressed.bind(item.get("id")))
+
+	# Add components to GridContainer
+	itemListContainer.add_child(item_icon)
+	itemListContainer.add_child(item_label)
+	itemListContainer.add_child(probability_spinbox)
+	itemListContainer.add_child(delete_button)
+
+
+func _on_delete_item_button_pressed(item_id):
+	for i in range(itemListContainer.get_child_count()):
+		var child = itemListContainer.get_child(i)
+		if child is Label and child.text == item_id:
+			var index = itemListContainer.get_index(child)
+			# Remove each element of the row
+			for offset in range(4):
+				var child_to_remove = itemListContainer.get_child(index - (index % 4))
+				itemListContainer.remove_child(child_to_remove)
+				child_to_remove.queue_free()
+			break
 
 
 func load_itemgroup_data():
@@ -48,16 +102,11 @@ func load_itemgroup_data():
 		NameTextEdit.text = contentData["name"]
 	if DescriptionTextEdit and contentData.has("description"):
 		DescriptionTextEdit.text = contentData["description"]
-	# Load the items into the itemList
-	itemList.clear()  # Clear the list before populating
-	if contentData.has("items"):
-		for item_id in contentData["items"]:
-			# Get item data and sprite from the game data
-			var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
-			if not item_data.is_empty():
-				var item_sprite = Gamedata.get_sprite_by_id(Gamedata.data.items, item_id)
-				var item_index = itemList.add_item(item_data.get("name", "Unnamed Item"), item_sprite)
-				itemList.set_item_metadata(item_index, item_id)
+	# Set the mode from contentData
+	if contentData.has("mode"):
+		select_option_by_string(modeOptionButton, contentData["mode"])
+
+	update_item_list_with_probabilities()
 
 
 # This function will select the option in the option_button that matches the given string.
@@ -84,17 +133,19 @@ func _on_save_button_button_up():
 	contentData["sprite"] = imageNameStringLabel.text
 	contentData["name"] = NameTextEdit.text
 	contentData["description"] = DescriptionTextEdit.text
+	contentData["mode"] = modeOptionButton.get_item_text(modeOptionButton.selected)
 	
-	# Collect all item IDs from the itemList and update the contentData accordingly
-	var newlist: Array[String] = []
-	for i in range(itemList.get_item_count()):
-		var item_id = itemList.get_item_metadata(i)  # Assuming metadata holds the item ID
-		newlist.append(item_id)
+	var new_items = []
+	var num_children = itemListContainer.get_child_count()
+	var num_columns = itemListContainer.columns
 	
-	if newlist.size() > 0:
-		contentData["items"] = newlist
-	elif contentData.has("items"):
-		contentData.erase("items")  # Delete the "items" property if the list is empty
+	# Iterate through each row based on the number of columns
+	for i in range(0, num_children, num_columns):
+		var item_id = itemListContainer.get_child(i + 1).text  # +1 because the second child in the sequence is the label
+		var probability = itemListContainer.get_child(i + 2).get_value()  # +2 because the third child in the sequence is the SpinBox
+		new_items.append({"id": item_id, "probability": probability})
+	
+	contentData["items"] = new_items
 	
 	data_changed.emit(Gamedata.data.itemgroups, contentData, olddata)
 	olddata = contentData.duplicate(true)
@@ -133,15 +184,17 @@ func _can_drop_data(_newpos, data) -> bool:
 	if not data or not data.has("id"):
 		return false
 	
-	# Fetch item data by ID from the Gamedata to ensure it exists and is valid
+	# Fetch item data by ID from Gamedata to ensure it exists and is valid
 	var item_data = Gamedata.get_data_by_id(Gamedata.data.items, data["id"])
 	if item_data.is_empty():
 		return false
 
-	# Check if the ID of the dragged item already exists in the itemList
-	for i in range(itemList.get_item_count()):
-		if itemList.get_item_metadata(i) == data["id"]:
-			return false
+	# Check if the ID of the dragged item already exists in the itemListContainer
+	for child in itemListContainer.get_children():
+		if child is HBoxContainer:
+			var label = child.get_child(1)  # Assuming the ID label is the second child
+			if label.text == data["id"]:
+				return false  # The item is already in the list
 
 	# If all checks pass, return true
 	return true
@@ -157,7 +210,6 @@ func _drop_data(newpos, data) -> void:
 # We have to check the dropped_data for the id property
 # Then we have to get the item data from Gamedata.get_data_by_id(Gamedata.data.items, id)
 # Then we have to get the sprite using Gamedata.get_sprite_by_id(Gamedata.data.items, id)
-# Then we have to create a new item in itemList using the id as the text and the sprite as the icon
 func _handle_item_drop(dropped_data, _newpos) -> void:
 	# Assuming dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
@@ -166,44 +218,16 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 		if item_data.is_empty():
 			print_debug("No item data found for ID: " + item_id)
 			return
-		
-		# Retrieve the sprite for the item
-		var item_sprite = Gamedata.get_sprite_by_id(Gamedata.data.items, item_id)
-		if item_sprite:
-			# Add the item to the itemList with the retrieved sprite as an icon
-			var item_index = itemList.add_item(item_id, item_sprite)
-			itemList.set_item_metadata(item_index, item_id)  # Store the item ID as metadata
-		else:
-			print_debug("No sprite found for item with ID: " + item_id)
+
+		# Check if the item already exists in the itemListContainer to avoid duplicates
+		for child in itemListContainer.get_children():
+			if child is HBoxContainer:
+				var label = child.get_child(1)  # Assuming the ID label is the second child
+				if label.text == item_id:
+					print_debug("Item already exists in the list: " + item_id)
+					return
+
+		# If item is not already in the list, add it
+		add_item_entry({"id": item_id, "probability": 20})  # Default probability if not specified
 	else:
 		print_debug("Dropped data does not contain an 'id' key.")
-
-
-# The user clicked in the list, but not on any of the items
-# Deselect all items and reset the selectedItemNameDisplay label
-func _on_item_list_empty_clicked(_at_position, _mouse_button_index):
-	itemList.deselect_all()  # Deselect any selected items
-	selectedItemNameDisplay.text = "No item selected"  # Reset the display label
-
-
-# The user has selected an item from the list
-# Update the selectedItemNameDisplay label to show the selected item's text
-func _on_item_list_item_selected(index):
-	var item_text = itemList.get_item_text(index)  # Get the text of the selected item
-	selectedItemNameDisplay.text = item_text  # Display the text in the label
-
-
-# The user has released the remove item button after pressing it
-# We have to check if an item is selected in the itemList
-# If an item is selected, we remove it from the list and update the selectedItemNameDisplay label
-# If no item is selected, we do nothing
-func _on_remove_item_button_button_up():
-	var selected_index = itemList.get_selected_items()
-	if selected_index.size() > 0:
-		# Get the first selected item index (since multiple selections might be disabled, this is safe)
-		selected_index = selected_index[0]
-		itemList.remove_item(selected_index)
-		selectedItemNameDisplay.text = "No item selected"  # Update the display label after removing an item
-		print_debug("Item removed at index: " + str(selected_index))
-	else:
-		print_debug("No item selected to remove")

--- a/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
@@ -80,6 +80,8 @@ func get_type_data() -> Variant:
 		return Gamedata.data.items
 	elif selected_type == "Furniture":
 		return Gamedata.data.furniture
+	elif selected_type == "Itemgroup":
+		return Gamedata.data.itemgroups
 	elif selected_type == "Mob":
 		return Gamedata.data.mobs
 	return null

--- a/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
@@ -49,14 +49,16 @@ text = "Selected type:"
 
 [node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2
-item_count = 3
+item_count = 4
 selected = 0
 popup/item_0/text = "Item"
 popup/item_0/id = 0
 popup/item_1/text = "Furniture"
 popup/item_1/id = 1
-popup/item_2/text = "Mob"
-popup/item_2/id = 2
+popup/item_2/text = "Itemgroup"
+popup/item_2/id = 3
+popup/item_3/text = "Mob"
+popup/item_3/id = 2
 
 [node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -22,27 +22,37 @@ func _ready():
 # Only new furniture will have an itemgroup assigned, not previously saved furniture.
 func create_loot():
 	# Check if the inventory is not already populated
-	if inventory.get_items() == []:
+	if inventory.get_items().is_empty():
 		# Attempt to retrieve the itemgroup data from Gamedata
 		var itemgroup_data = Gamedata.get_data_by_id(Gamedata.data.itemgroups, itemgroup)
 		
 		# Check if the itemgroup data exists and has items
 		if itemgroup_data and "items" in itemgroup_data:
-			# Loop over each item ID in the itemgroup's 'items' property
-			for item_id in itemgroup_data["items"]:
+			# Loop over each item object in the itemgroup's 'items' property
+			for item_object in itemgroup_data["items"]:
+				# Each item_object is expected to be a dictionary with id, probability, min, max
+				var item_id = item_object["id"]
+				var item_min = item_object["min"]
+				var item_max = item_object["max"]
+				var item_probability = item_object["probability"]  # This could be used for determining spawn chance
+
 				# Fetch the individual item data for verification
 				var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
 				
 				# Check if the item data is valid before adding
 				if item_data and not item_data.is_empty():
-					# Create and add the item to the inventory deferred to ensure all properties are set
-					inventory.create_and_add_item.call_deferred(item_id)
+					# Check probability to decide if item should be added
+					if randi_range(0, 100) <= item_probability:
+						# Determine quantity to add based on min and max
+						var quantity = randi_range(item_min, item_max)
+						for i in range(quantity):
+							# Create and add the item to the inventory
+							inventory.create_and_add_item.call_deferred(item_id)
 				else:
 					print_debug("No valid data found for item ID: " + str(item_id))
 		else:
 			# Fallback if no valid itemgroup data found or the itemgroup is empty
 			print_debug("Invalid or empty itemgroup data for itemgroup ID: " + str(itemgroup))
-			# Optional: add fallback items if needed, or handle the case accordingly
 
 
 func create_inventory():


### PR DESCRIPTION
Requires #111 

Instead of spawning all items in an itemgroup, each item is spawned based on a chance.
- Based on https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/ITEM_SPAWN.md
- Users can set 'collection' and 'distribution' in the itemgroup editor
- Users can set a probability and min/max amount per item
- The game spawns the items based on their chance and amount

![image](https://github.com/Khaligufzel/CataX/assets/50166150/234f7137-5ce6-43de-8e42-385e1d74ab6d)
