### PR TITLE
Favorite functionality in inventory

### DIFF
--- a/Scenes/InventoryWindow.tscn
+++ b/Scenes/InventoryWindow.tscn
@@ -70,6 +70,10 @@ layout_mode = 2
 [node name="TransferUI" type="VBoxContainer" parent="HBoxContainer"]
 layout_mode = 2
 
+[node name="TransferAllRightButton" type="Button" parent="HBoxContainer/TransferUI"]
+layout_mode = 2
+text = "->>"
+
 [node name="TransferRightButton" type="Button" parent="HBoxContainer/TransferUI"]
 layout_mode = 2
 text = "->"
@@ -77,6 +81,10 @@ text = "->"
 [node name="TransferLeftButton" type="Button" parent="HBoxContainer/TransferUI"]
 layout_mode = 2
 text = "<-"
+
+[node name="TransferAllLeftButton" type="Button" parent="HBoxContainer/TransferUI"]
+layout_mode = 2
+text = "<<-"
 
 [node name="PlayerInventoryControl" type="VBoxContainer" parent="HBoxContainer"]
 layout_mode = 2
@@ -176,7 +184,9 @@ autowrap_mode = 3
 
 [connection signal="equip_left" from="HBoxContainer/ProximityInventoryControl/CtrlInventoryStackedCustomProx" to="." method="_on_ctrl_inventory_stacked_custom_equip_left"]
 [connection signal="equip_right" from="HBoxContainer/ProximityInventoryControl/CtrlInventoryStackedCustomProx" to="." method="_on_ctrl_inventory_stacked_custom_equip_right"]
+[connection signal="button_up" from="HBoxContainer/TransferUI/TransferAllRightButton" to="." method="_on_transfer_all_right_button_button_up"]
 [connection signal="button_up" from="HBoxContainer/TransferUI/TransferRightButton" to="." method="_on_transfer_right_button_button_up"]
 [connection signal="button_up" from="HBoxContainer/TransferUI/TransferLeftButton" to="." method="_on_transfer_left_button_button_up"]
+[connection signal="button_up" from="HBoxContainer/TransferUI/TransferAllLeftButton" to="." method="_on_transfer_all_left_button_button_up"]
 [connection signal="equip_left" from="HBoxContainer/PlayerInventoryControl/CtrlInventoryStackedCustom" to="." method="_on_ctrl_inventory_stacked_custom_equip_left"]
 [connection signal="equip_right" from="HBoxContainer/PlayerInventoryControl/CtrlInventoryStackedCustom" to="." method="_on_ctrl_inventory_stacked_custom_equip_right"]

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -45,6 +45,11 @@ signal container_entered_proximity(container: Node3D)
 signal container_exited_proximity(container: Node3D)
 
 
+# Use these signals to control UI updates. UI only needs an update after the operation is complete
+signal inventory_operation_started()
+signal inventory_operation_finished()
+
+
 # We signal to the hud to start a progressbar
 func on_start_timer_progressbar(time_left: float):
 	hud_start_progressbar.emit(time_left)

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -243,6 +243,7 @@ func equip_item(items: Array[InventoryItem], itemSlot: Control) -> void:
 
 
 func _on_transfer_all_left_button_button_up():
+	Helper.signal_broker.inventory_operation_started.emit()
 	var items_to_transfer = inventory.get_items()
 	var favorite_items = []
 	var non_favorite_items = []
@@ -259,6 +260,7 @@ func _on_transfer_all_left_button_button_up():
 		_transfer_items(non_favorite_items)  # Transfer all non-favorite items
 	elif favorite_items.size() > 0:
 		_transfer_items(favorite_items)  # Transfer favorite items if no non-favorites are present
+	Helper.signal_broker.inventory_operation_finished.emit()
 
 
 func _transfer_items(items: Array) -> bool:
@@ -274,6 +276,7 @@ func _transfer_items(items: Array) -> bool:
 
 
 func _on_transfer_all_right_button_button_up():
+	Helper.signal_broker.inventory_operation_started.emit()
 	# Attempt to transfer each item from the proximity inventory to the inventory until no items are left
 	var items_to_transfer = proximity_inventory_control.get_inventory().get_items()
 	while items_to_transfer.size() > 0:
@@ -284,6 +287,7 @@ func _on_transfer_all_right_button_button_up():
 			print_debug("Failed to transfer item: " + str(item))
 			break # If a transfer fails, break out of the loop to prevent an infinite loop
 		items_to_transfer = proximity_inventory_control.get_inventory().get_items() # Refresh the list of items after the transfer attempt
+	Helper.signal_broker.inventory_operation_finished.emit()
 
 
 # Items are transferred from the right list to the left list

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -219,26 +219,6 @@ func remove_container_from_list(container: Node3D):
 		proximity_inventory_control.visible = false
 
 
-# Items are transferred from the right list to the left list
-func _on_transfer_left_button_button_up():
-	var selected_inventory_items: Array[InventoryItem] = inventory_control.get_selected_inventory_items()
-	for item in selected_inventory_items:
-		if inventory.transfer_autosplitmerge(item, proximity_inventory_control.get_inventory()):
-			print_debug("Transferred item: " + str(item))
-		else:
-			print_debug("Failed to transfer item: " + str(item))
-
-
-# Items are transferred from the left list to the right list
-func _on_transfer_right_button_button_up():
-	var selected_inventory_items: Array[InventoryItem] = proximity_inventory_control.get_selected_inventory_items()
-	for item in selected_inventory_items:
-		if proximity_inventory_control.get_inventory().transfer_autosplitmerge(item, inventory):
-			print_debug("Transferred item: " + str(item))
-		else:
-			print_debug("Failed to transfer item: " + str(item))
-
-
 # Called when the user has pressed a button that will equip the selected item
 func _on_ctrl_inventory_stacked_custom_equip_left(items: Array[InventoryItem]):
 	equip_item(items, LeftHandEquipmentSlot)
@@ -260,3 +240,48 @@ func equip_item(items: Array[InventoryItem], itemSlot: Control) -> void:
 		itemSlot.equip(items[0])
 	else:
 		print_debug("Multiple items selected. Please select only one item to equip.")
+
+
+func _on_transfer_all_left_button_button_up():
+	# Attempt to transfer each item from the inventory to the proximity inventory until no items are left
+	var items_to_transfer = inventory.get_items()
+	while items_to_transfer.size() > 0:
+		var item = items_to_transfer.pop_front() # Get and remove the first item from the list
+		if inventory.transfer_autosplitmerge(item, proximity_inventory_control.get_inventory()):
+			print_debug("Transferred item: " + str(item))
+		else:
+			print_debug("Failed to transfer item: " + str(item))
+			break # If a transfer fails, break out of the loop to prevent an infinite loop
+		items_to_transfer = inventory.get_items() # Refresh the list of items after the transfer attempt
+
+func _on_transfer_all_right_button_button_up():
+	# Attempt to transfer each item from the proximity inventory to the inventory until no items are left
+	var items_to_transfer = proximity_inventory_control.get_inventory().get_items()
+	while items_to_transfer.size() > 0:
+		var item = items_to_transfer.pop_front() # Get and remove the first item from the list
+		if proximity_inventory_control.get_inventory().transfer_autosplitmerge(item, inventory):
+			print_debug("Transferred item: " + str(item))
+		else:
+			print_debug("Failed to transfer item: " + str(item))
+			break # If a transfer fails, break out of the loop to prevent an infinite loop
+		items_to_transfer = proximity_inventory_control.get_inventory().get_items() # Refresh the list of items after the transfer attempt
+
+
+# Items are transferred from the right list to the left list
+func _on_transfer_left_button_button_up():
+	var selected_inventory_items: Array[InventoryItem] = inventory_control.get_selected_inventory_items()
+	for item in selected_inventory_items:
+		if inventory.transfer_autosplitmerge(item, proximity_inventory_control.get_inventory()):
+			print_debug("Transferred item: " + str(item))
+		else:
+			print_debug("Failed to transfer item: " + str(item))
+
+
+# Items are transferred from the left list to the right list
+func _on_transfer_right_button_button_up():
+	var selected_inventory_items: Array[InventoryItem] = proximity_inventory_control.get_selected_inventory_items()
+	for item in selected_inventory_items:
+		if proximity_inventory_control.get_inventory().transfer_autosplitmerge(item, inventory):
+			print_debug("Transferred item: " + str(item))
+		else:
+			print_debug("Failed to transfer item: " + str(item))

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -243,16 +243,35 @@ func equip_item(items: Array[InventoryItem], itemSlot: Control) -> void:
 
 
 func _on_transfer_all_left_button_button_up():
-	# Attempt to transfer each item from the inventory to the proximity inventory until no items are left
 	var items_to_transfer = inventory.get_items()
-	while items_to_transfer.size() > 0:
-		var item = items_to_transfer.pop_front() # Get and remove the first item from the list
-		if inventory.transfer_autosplitmerge(item, proximity_inventory_control.get_inventory()):
-			print_debug("Transferred item: " + str(item))
+	var favorite_items = []
+	var non_favorite_items = []
+
+	# Separate items into favorite and non-favorite lists
+	for item in items_to_transfer:
+		if item.get_property("favorite", false):
+			favorite_items.append(item)
 		else:
+			non_favorite_items.append(item)
+
+	# Decide on the transfer strategy based on the content of the lists
+	if non_favorite_items.size() > 0:
+		_transfer_items(non_favorite_items)  # Transfer all non-favorite items
+	elif favorite_items.size() > 0:
+		_transfer_items(favorite_items)  # Transfer favorite items if no non-favorites are present
+
+
+func _transfer_items(items: Array) -> bool:
+	# Transfers items and returns true if all were successfully transferred, false otherwise
+	var all_transferred = true
+	while items.size() > 0:
+		var item = items.pop_front()  # Get and remove the first item from the list
+		if not inventory.transfer_autosplitmerge(item, proximity_inventory_control.get_inventory()):
 			print_debug("Failed to transfer item: " + str(item))
-			break # If a transfer fails, break out of the loop to prevent an infinite loop
-		items_to_transfer = inventory.get_items() # Refresh the list of items after the transfer attempt
+			all_transferred = false
+			break  # Stop transferring if any transfer fails
+	return all_transferred
+
 
 func _on_transfer_all_right_button_button_up():
 	# Attempt to transfer each item from the proximity inventory to the inventory until no items are left

--- a/Scripts/crafting_recipes_manager.gd
+++ b/Scripts/crafting_recipes_manager.gd
@@ -19,7 +19,6 @@ func can_craft_recipe(recipe: Dictionary) -> bool:
 		for resource in recipe["required_resources"]:
 			# Check if the inventory has a sufficient amount of each required resource.
 			if not ItemManager.has_sufficient_item_amount(resource.get("id"), resource.get("amount")):
-				print_debug("Not enough", resource.get("id"), "to craft")
 				return false  # Return false immediately if any resource is insufficient.
 	else:
 		print_debug("No required resources specified for recipe")


### PR DESCRIPTION
Requires #114 

This PR adds a QoL feature to control favorite items in the inventory, much like in CDDA.
- By clicking on the cell below the favorite column, you can toggle the item as favorite
- Favorite items will have a * in the favorite column
- When clicking "transfer all" (the button with <<- in them), it will not drop the favorited items unless the inventory only contains favorited items
- If favorited items are in a container, they will still be picked up by the transfer all (->>) button
- You can also sort the favorite column, so you could simplify a manual selection using that.
- Disabled UI updates during item transfer for bulk operations in this instance.


I highlighted the relevant UI elements for this PR:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/81add0bf-f230-427a-ab5c-34fc2b3e8303)
