### PR TITLE
Prevent transfer to default prox

### DIFF
--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -243,6 +243,11 @@ func equip_item(items: Array[InventoryItem], itemSlot: Control) -> void:
 
 
 func _on_transfer_all_left_button_button_up():
+	# Check if the current proximity inventory is the default set in the ItemManager
+	if proximity_inventory_control.get_inventory() == ItemManager.proximityInventory:
+		print_debug("Attempt to transfer to default proximity inventory aborted.")
+		return  # Exit the function early if the condition is met
+
 	Helper.signal_broker.inventory_operation_started.emit()
 	var items_to_transfer = inventory.get_items()
 	var favorite_items = []
@@ -292,6 +297,11 @@ func _on_transfer_all_right_button_button_up():
 
 # Items are transferred from the right list to the left list
 func _on_transfer_left_button_button_up():
+	# Check if the current proximity inventory is the default set in the ItemManager
+	if proximity_inventory_control.get_inventory() == ItemManager.proximityInventory:
+		print_debug("Attempt to transfer to default proximity inventory aborted.")
+		return  # Exit the function early if the condition is met
+
 	var selected_inventory_items: Array[InventoryItem] = inventory_control.get_selected_inventory_items()
 	for item in selected_inventory_items:
 		if inventory.transfer_autosplitmerge(item, proximity_inventory_control.get_inventory()):


### PR DESCRIPTION
Fixes #109 
Requires #120

The proximity inventory control has a default proximity inventory. It uses this if there are no containers in proximity. With the inventory window buttons, you can transfer items to the inventory even if it's not visible, making the items disappear.

The solution for now is to check if the proximity inventory is the same as ItemManager.proximity_inventory and cancel the transfer if true. Maybe a better solution would be to set the proximity inventory to null and check for that? Maybe we can find a use case for the hidden inventory in the future. For example hidden tools or quest items.