### PR TITLE
Melee item editor

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cllbo1owveorj"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -270,6 +270,9 @@
 		"weight": "0.25"
 	},
 	{
+		"Melee": {
+			"damage": 25
+		},
 		"description": "A sharp blade with a handle for excellent control",
 		"id": "machete",
 		"image": "./Mods/Core/Items/machete_32.png",

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dmpomdwta1pgq"]
+[gd_scene load_steps=11 format=3 uid="uid://dmpomdwta1pgq"]
 
 [ext_resource type="Script" path="res://Scripts/ItemEditor.gd" id="1_ef3j7"]
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_ghd7c"]
@@ -9,6 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://cq4t64qb15y27" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemFoodEditor.tscn" id="6_htafc"]
 [ext_resource type="PackedScene" uid="uid://b7jwy5hpj2vyt" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn" id="7_itht2"]
 [ext_resource type="PackedScene" uid="uid://65bjwo1b3je2" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemWearableEditor.tscn" id="8_4bxny"]
+[ext_resource type="PackedScene" uid="uid://duoxs7mpo6x3t" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn" id="9_ucd7w"]
 
 [node name="ItemEditor" type="Control" node_paths=PackedStringArray("tabContainer", "itemImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemSelector", "VolumeNumberBox", "WeightNumberBox", "StackSizeNumberBox", "MaxStackSizeNumberBox", "typesContainer", "TwoHandedCheckBox")]
 layout_mode = 3
@@ -249,6 +250,10 @@ visible = false
 layout_mode = 2
 
 [node name="Wearable" parent="VBoxContainer/TabContainer" instance=ExtResource("8_4bxny")]
+visible = false
+layout_mode = 2
+
+[node name="Melee" parent="VBoxContainer/TabContainer" instance=ExtResource("9_ucd7w")]
 visible = false
 layout_mode = 2
 

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3 uid="uid://duoxs7mpo6x3t"]
+
+[ext_resource type="Script" path="res://Scripts/ItemMeleeEditor.gd" id="1_pg18d"]
+
+[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("DamageSpinBox")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_pg18d")
+DamageSpinBox = NodePath("Melee/DamageSpinbox")
+
+[node name="Melee" type="GridContainer" parent="."]
+layout_mode = 0
+size_flags_vertical = 3
+columns = 2
+
+[node name="DamageLabel" type="Label" parent="Melee"]
+layout_mode = 2
+text = "Damage"
+
+[node name="DamageSpinbox" type="SpinBox" parent="Melee"]
+layout_mode = 2

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemWearableEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemWearableEditor.tscn
@@ -10,16 +10,16 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_o5i08")
-SlotOptionButton = NodePath("Food/SlotOptionButton")
+SlotOptionButton = NodePath("Wearable/SlotOptionButton")
 
-[node name="Food" type="GridContainer" parent="."]
+[node name="Wearable" type="GridContainer" parent="."]
 layout_mode = 0
 size_flags_vertical = 3
 columns = 2
 
-[node name="SlotLabel" type="Label" parent="Food"]
+[node name="SlotLabel" type="Label" parent="Wearable"]
 layout_mode = 2
 text = "Wearable slot"
 
-[node name="SlotOptionButton" type="OptionButton" parent="Food"]
+[node name="SlotOptionButton" type="OptionButton" parent="Wearable"]
 layout_mode = 2

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -1,0 +1,22 @@
+extends Control
+
+# This scene is intended to be used inside the item editor
+# It is supposed to edit exactly one type of melee wearon
+
+# Form elements
+@export var DamageSpinBox: SpinBox = null
+
+
+func _ready():
+	pass
+
+
+func get_properties() -> Dictionary:
+	return {
+		"damage": DamageSpinBox.value
+	}
+
+
+func set_properties(properties: Dictionary) -> void:
+	if properties.has("damage"):
+		DamageSpinBox.value = properties["damage"]


### PR DESCRIPTION
Requires #121 

Adds a simple melee editor to the item editor. Right now it's only some base damage, but we'll probably split it in to blunt, piercing and cutting down the line.
![image](https://github.com/Khaligufzel/CataX/assets/50166150/b08aac00-7462-4ec6-b821-039e3dc1814e)
