### PR TITLE
Furniture destruction disassembly

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cllbo1owveorj"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -14,7 +14,9 @@ json_data = "[
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"mob_loot\"
+					\"mob_loot\",
+					\"destroyed_furniture_medium\",
+					\"disassembled_furniture_medium\"
 				]
 			}
 		},
@@ -34,7 +36,9 @@ json_data = "[
 			\"core\": {
 				\"itemgroups\": [
 					\"cabinet_general\",
-					\"mob_loot\"
+					\"mob_loot\",
+					\"destroyed_furniture_medium\",
+					\"disassembled_furniture_medium\"
 				],
 				\"items\": [
 					\"pistol_magazine\",

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -34,6 +34,8 @@
 			"Indoor"
 		],
 		"description": "One of the central pieces of fruniture that make up a kitchen",
+		"destruction_group": "destroyed_furniture_medium",
+		"disassembly_group": "disassembled_furniture_medium",
 		"edgesnapping": "North",
 		"id": "countertop_wood",
 		"moveable": false,

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -192,5 +192,61 @@
 			}
 		},
 		"sprite": "flashlight_32.png"
+	},
+	{
+		"description": "Items that will spawn when medium sized furniture is destroyed, like countertop, table",
+		"id": "destroyed_furniture_medium",
+		"items": [
+			{
+				"id": "plank_2x4",
+				"max": 3,
+				"min": 1,
+				"probability": 100
+			},
+			{
+				"id": "steel_scrap",
+				"max": 1,
+				"min": 0,
+				"probability": 50
+			}
+		],
+		"mode": "Collection",
+		"name": "Medium destroyed furniture",
+		"references": {
+			"core": {
+				"furniture": [
+					"countertop_wood"
+				]
+			}
+		},
+		"sprite": "plank.png"
+	},
+	{
+		"description": "Items that will spawn when medium sized furniture is disassembled, like countertop, table",
+		"id": "disassembled_furniture_medium",
+		"items": [
+			{
+				"id": "plank_2x4",
+				"max": 5,
+				"min": 2,
+				"probability": 100
+			},
+			{
+				"id": "steel_scrap",
+				"max": 2,
+				"min": 1,
+				"probability": 80
+			}
+		],
+		"mode": "Collection",
+		"name": "Medium disassembled furniture",
+		"references": {
+			"core": {
+				"furniture": [
+					"countertop_wood"
+				]
+			}
+		},
+		"sprite": "plank.png"
 	}
 ]

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -8,7 +8,9 @@
 		"references": {
 			"core": {
 				"itemgroups": [
-					"mob_loot"
+					"mob_loot",
+					"destroyed_furniture_medium",
+					"disassembled_furniture_medium"
 				]
 			}
 		},
@@ -28,7 +30,9 @@
 			"core": {
 				"itemgroups": [
 					"cabinet_general",
-					"mob_loot"
+					"mob_loot",
+					"destroyed_furniture_medium",
+					"disassembled_furniture_medium"
 				],
 				"items": [
 					"pistol_magazine",

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://cng4m3os6smj8"]
+[gd_scene load_steps=6 format=3 uid="uid://cng4m3os6smj8"]
 
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="1_gm4uu"]
 [ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd" id="1_wqqit"]
 [ext_resource type="PackedScene" uid="uid://b8i6wfk3fngy4" path="res://Scenes/ContentManager/Custom_Widgets/Editable_Item_List.tscn" id="2_ekwf5"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_o3k3a"]
+[ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="4_fbact"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("furnitureImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "CategoriesList", "furnitureSelector", "imageNameStringLabel", "moveableCheckboxButton", "edgeSnappingOptionButton", "doorOptionButton", "containerCheckBox", "containerTextEdit")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("furnitureImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "CategoriesList", "furnitureSelector", "imageNameStringLabel", "moveableCheckboxButton", "edgeSnappingOptionButton", "doorOptionButton", "containerCheckBox", "containerTextEdit", "destructionTextEdit", "disassemblyTextEdit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -25,6 +26,8 @@ edgeSnappingOptionButton = NodePath("VBoxContainer/FormGrid/SnappingOptionButton
 doorOptionButton = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/DoorOptionButton")
 containerCheckBox = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/ContainerCheckBox")
 containerTextEdit = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/ContainerTextEdit")
+destructionTextEdit = NodePath("VBoxContainer/FormGrid/DestructionTextEdit")
+disassemblyTextEdit = NodePath("VBoxContainer/FormGrid/DisassemblyTextEdit")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -129,6 +132,32 @@ layout_mode = 2
 tooltip_text = "Check this if the furniture should be moveable, like a chair. Leave this unchecked if the furniture should not move, like a fence"
 text = "Moveable"
 
+[node name="DisassembleLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Disassembly loot group"
+
+[node name="DisassemblyTextEdit" parent="VBoxContainer/FormGrid" instance=ExtResource("4_fbact")]
+layout_mode = 2
+size_flags_horizontal = 1
+size_flags_vertical = 1
+tooltip_text = "Drag an itemgroup from the left menu onto this field. When this furniture
+is disassembled, items from that itemgroup will spawn. If no itemgroup
+is selected, no items will spawn after disassembly"
+myplaceholdertext = "Drag an itemgroup from the left to here"
+
+[node name="DestructionLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Destruction loot group"
+
+[node name="DestructionTextEdit" parent="VBoxContainer/FormGrid" instance=ExtResource("4_fbact")]
+layout_mode = 2
+size_flags_horizontal = 1
+size_flags_vertical = 1
+tooltip_text = "Drag an itemgroup from the left menu onto this field. When this furniture
+is destroyed, items from that itemgroup will spawn. If no itemgroup
+is selected, no items will spawn after destruction"
+myplaceholdertext = "Drag an itemgroup from the left to here"
+
 [node name="SnappingLabel" type="Label" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
 text = "Edge snapping"
@@ -191,26 +220,14 @@ right. If this is checked off, the furniture
 will not be able to contain items."
 text = "Container"
 
-[node name="ContainerTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid/FunctionControlContainer"]
-custom_minimum_size = Vector2(0, 30)
+[node name="ContainerTextEdit" parent="VBoxContainer/FormGrid/FunctionControlContainer" instance=ExtResource("4_fbact")]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.1
 tooltip_text = "If container is checked on, you can drag an
 itemgroup to this field to fill the container with the
 contents of the itemgroup when it is
 spawned. If container is not checked on, it
 will not act as a container."
-focus_next = NodePath("../../DescriptionTextEdit")
-focus_previous = NodePath("../../FurnitureImageDisplay")
-mouse_filter = 1
-placeholder_text = "Drag an itemgroup from the left to here"
-editable = false
-
-[node name="ClearContainerButton" type="Button" parent="VBoxContainer/FormGrid/FunctionControlContainer"]
-layout_mode = 2
-tooltip_text = "Press this to clear the itemgroup field"
-text = "X"
+myplaceholdertext = "Drag an itemgroup from the left to here"
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_o3k3a")]
 visible = false
@@ -219,5 +236,4 @@ visible = false
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="gui_input" from="VBoxContainer/FormGrid/FurnitureImageDisplay" to="." method="_on_furniture_image_display_gui_input"]
 [connection signal="toggled" from="VBoxContainer/FormGrid/FunctionControlContainer/ContainerCheckBox" to="." method="_on_container_check_box_toggled"]
-[connection signal="button_up" from="VBoxContainer/FormGrid/FunctionControlContainer/ClearContainerButton" to="." method="_on_clear_container_button_button_up"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -81,10 +81,10 @@ func load_furniture_data():
 		if "itemgroup" in container_data:
 			containerTextEdit.set_text(container_data["itemgroup"])  # Set text edit with the itemgroup ID
 		else:
-			containerTextEdit.clear()  # Clear the text edit if no itemgroup is specified
+			containerTextEdit.mytextedit.clear()  # Clear the text edit if no itemgroup is specified
 	else:
 		containerCheckBox.button_pressed = false  # Uncheck the container checkbox
-		containerTextEdit.clear()  # Clear the text edit as no container data is present
+		containerTextEdit.mytextedit.clear()  # Clear the text edit as no container data is present
 
 
 func update_door_option(door_state):
@@ -202,12 +202,12 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 
 func _on_container_check_box_toggled(toggled_on):
 	if not toggled_on:
-		containerTextEdit.clear()
+		containerTextEdit.mytextedit.clear()
 
 
 # Called when the user has successfully dropped data onto the ItemGroupTextEdit
 # We have to check the dropped_data for the id property
-func itemgroup_drop(dropped_data: Dictionary, texteditcontrol: TextEdit) -> void:
+func itemgroup_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
 	# Assuming dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var itemgroup_id = dropped_data["id"]
@@ -215,17 +215,15 @@ func itemgroup_drop(dropped_data: Dictionary, texteditcontrol: TextEdit) -> void
 		if itemgroup_data.is_empty():
 			print_debug("No item data found for ID: " + itemgroup_id)
 			return
-		texteditcontrol.text = itemgroup_id
+		texteditcontrol.set_text(itemgroup_id)
+		# If it's the container group, we always set the container checkbox to true
+		if texteditcontrol == containerTextEdit:
+			containerCheckBox.button_pressed = true
 	else:
 		print_debug("Dropped data does not contain an 'id' key.")
 
 
-func can_itemgroup_drop(dropped_data: Dictionary, texteditcontrol: TextEdit):
-	# Check if the containerCheckBox is checked; if not, return false
-	# Only applies to containerTextEdit
-	if texteditcontrol == containerTextEdit and not containerCheckBox.is_pressed():
-		return false
-
+func can_itemgroup_drop(dropped_data: Dictionary):
 	# Check if the data dictionary has the 'id' property
 	if not dropped_data or not dropped_data.has("id"):
 		return false
@@ -240,9 +238,9 @@ func can_itemgroup_drop(dropped_data: Dictionary, texteditcontrol: TextEdit):
 
 
 func set_drop_functions():
-	containerTextEdit.drop_function = itemgroup_drop.bind(containerTextEdit.mytextedit)
-	containerTextEdit.can_drop_function = can_itemgroup_drop.bind(containerTextEdit.mytextedit)
-	disassemblyTextEdit.drop_function = itemgroup_drop.bind(disassemblyTextEdit.mytextedit)
-	disassemblyTextEdit.can_drop_function = can_itemgroup_drop.bind(disassemblyTextEdit.mytextedit)
-	destructionTextEdit.drop_function = itemgroup_drop.bind(destructionTextEdit.mytextedit)
-	destructionTextEdit.can_drop_function = can_itemgroup_drop.bind(destructionTextEdit.mytextedit)
+	containerTextEdit.drop_function = itemgroup_drop.bind(containerTextEdit)
+	containerTextEdit.can_drop_function = can_itemgroup_drop
+	disassemblyTextEdit.drop_function = itemgroup_drop.bind(disassemblyTextEdit)
+	disassemblyTextEdit.can_drop_function = can_itemgroup_drop
+	destructionTextEdit.drop_function = itemgroup_drop.bind(destructionTextEdit)
+	destructionTextEdit.can_drop_function = can_itemgroup_drop

--- a/Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn
+++ b/Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=2 format=3 uid="uid://dsax7il2yggw8"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Widgets/Scripts/DropEnabledTextEdit.gd" id="1_abx0d"]
+
+[node name="DropEnabledTextEdit" type="HBoxContainer" node_paths=PackedStringArray("mytextedit")]
+custom_minimum_size = Vector2(0, 30)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_abx0d")
+mytextedit = NodePath("TextEdit")
+
+[node name="TextEdit" type="TextEdit" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+mouse_filter = 1
+editable = false
+
+[node name="Button" type="Button" parent="."]
+layout_mode = 2
+text = "X"
+
+[connection signal="button_up" from="Button" to="." method="_on_button_button_up"]

--- a/Scenes/ContentManager/Custom_Widgets/Scripts/DropEnabledTextEdit.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/DropEnabledTextEdit.gd
@@ -1,0 +1,78 @@
+extends HBoxContainer
+
+# This is a standalone widget that provides a read-only textedit in a hboxcontainer and 
+# a button to clear the contents of the textedit. You can drop data on it to set the content
+# of the textedit. 
+
+# To use this widget, instance it as a child node in your form and assign it to a variable like so:
+# @export var mydroppableTextEdit: HBoxContainer = null
+# 
+# On the _ready function (or anywhere) in your script, call
+# mydroppableTextEdit.drop_function = mydropfunction
+# mydroppableTextEdit.can_drop_function = mycandropfunction
+#
+# Example mydropfunction:
+# func mydropfunction(dropped_data: Dictionary):
+# 	print("my dropped data has id" + dropped_data["id"])
+# 
+# Example mycandropfunction:
+# func mycandropfunction(dropped_data: Dictionary):
+# 	return dropped_data.has("id")
+#
+#
+#
+# If you want a function with extra arguments, you can use this in the ready function:
+# mydroppableTextEdit.drop_function = mydropfunction.bind("pistol_9mm")
+# mydroppableTextEdit.can_drop_function = mycandropfunction.bind("pistol_9mm")
+# The dropped_data will always be passed, and every argumen you bind will be the second,
+# third and so on argument
+#
+# Example mydropfunction with one extra argument:
+# func mydropfunction(dropped_data: Dictionary, item_id: String):
+# 	print("my dropped data has id" + dropped_data["id"])
+# 	print("The data id " + dropped_data["id"] + " matches the item_id " + item_id)
+# 
+# Example mycandropfunction with one extra argument:
+# func mycandropfunction(dropped_data: Dictionary, item_id: String):
+# 	return dropped_data.has("id") and dropped_data["id"] == item_id
+
+
+var can_drop_function: Callable
+var drop_function: Callable
+
+@export var mytextedit: TextEdit
+@export var myplaceholdertext: String = "drop your data here"
+
+func _ready():
+	mytextedit.placeholder_text = myplaceholdertext
+
+
+# This function should return true if the dragged data can be dropped here
+func _can_drop_data(_newpos, data) -> bool:
+	if can_drop_function and can_drop_function.is_valid():
+		return can_drop_function.call(data)
+	return false  # Default to false if no valid callable is set
+
+
+# This function handles the data being dropped
+func _drop_data(newpos, data) -> void:
+	if _can_drop_data(newpos, data):
+		_handle_item_drop(data, newpos)
+
+
+# Called when the user has successfully dropped data onto the TextEdit
+func _handle_item_drop(dropped_data, _newpos) -> void:
+	if drop_function and drop_function.is_valid():
+		drop_function.call(dropped_data)
+
+
+func _on_button_button_up():
+	mytextedit.clear()
+
+
+func set_text(newtext: String):
+	mytextedit.text = newtext
+
+
+func get_text():
+	return mytextedit.text

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -629,8 +629,23 @@ func on_itemgroup_deleted(itemgroup_id: String):
 
 	# This callable will remove this itemgroups from every furniture that reference this itemgroup.
 	var myfunc: Callable = func (furn_id):
-		if erase_property_by_path(Gamedata.data.furniture, furn_id, "Function.container.itemgroup"):
-			changes_made = true
+		var furniture_data = Gamedata.get_data_by_id(Gamedata.data.furniture, furn_id)
+		var container_group = furniture_data.get("Function", {}).get("container", {}).get("itemgroup", "")
+		var disassembly_group = furniture_data.get("disassembly_group", "")
+		var destruction_group = furniture_data.get("destruction_group", "")
+
+		if container_group == itemgroup_id:
+			if erase_property_by_path(Gamedata.data.furniture, furn_id, "Function.container.itemgroup"):
+				changes_made = true
+
+		if disassembly_group == itemgroup_id:
+			if erase_property_by_path(Gamedata.data.furniture, furn_id, "disassembly_group"):
+				changes_made = true
+
+		if destruction_group == itemgroup_id:
+			if erase_property_by_path(Gamedata.data.furniture, furn_id, "destruction_group"):
+				changes_made = true
+
 	# Pass the callable to every furniture in the itemgroup's references
 	# It will call myfunc on every furniture in itemgroup_data.references.core.furniture
 	execute_callable_on_references_of_type(itemgroup_data, "core", "furniture", myfunc)


### PR DESCRIPTION
Requires #126

Adds destruction_group and disassembly_group to the furniture editor
- Added a new custom widget for dropping some text onto a textedit. i needed this because there wasn't really a way to target a specific textedit field when dropping data onto the form
- Itemgroups will add a reference to the furniture when it's used in destruction or disassembly
- The destruction and disassembly fields are cleared if the itemgroup that was in there is deleted
- Updated the container logic. Previously you could not drop an itemgroup in the container field if the container function was off. Now if the container function is off, you can drop an itemgroup into the container field and it will switch the container function checkbox on.
- Added two simple itemgroups for destruction and disassembly of medium furniture

![image](https://github.com/Khaligufzel/CataX/assets/50166150/b0560081-fd54-4f52-b5d7-bbb2fda18b71)


Disassembling and destroying furniture still needs to be implemented (also ties into #116)