### PR TITLE
Melee attack hits furniture

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cllbo1owveorj"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 
@@ -281,7 +281,8 @@ json_data = "[
 	},
 	{
 		\"Melee\": {
-			\"damage\": 25
+			\"damage\": 25,
+			\"reach\": 1
 		},
 		\"description\": \"A sharp blade with a handle for excellent control\",
 		\"id\": \"machete\",

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -275,7 +275,8 @@
 	},
 	{
 		"Melee": {
-			"damage": 25
+			"damage": 25,
+			"reach": 1
 		},
 		"description": "A sharp blade with a handle for excellent control",
 		"id": "machete",

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://Scripts/ItemMeleeEditor.gd" id="1_pg18d"]
 
-[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("DamageSpinBox")]
+[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("DamageSpinBox", "ReachSpinBox")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,6 +11,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_pg18d")
 DamageSpinBox = NodePath("Melee/DamageSpinbox")
+ReachSpinBox = NodePath("Melee/ReachSpinbox")
 
 [node name="Melee" type="GridContainer" parent="."]
 layout_mode = 0
@@ -23,3 +24,14 @@ text = "Damage"
 
 [node name="DamageSpinbox" type="SpinBox" parent="Melee"]
 layout_mode = 2
+tooltip_text = "The damage that the target will receive when it get's hit by this weapon"
+
+[node name="ReachLabel" type="Label" parent="Melee"]
+layout_mode = 2
+text = "Reach"
+
+[node name="ReachSpinbox" type="SpinBox" parent="Melee"]
+layout_mode = 2
+tooltip_text = "The melee range of the weapon in meters. A larger number means the wielder can attack over a larger distance."
+step = 0.1
+value = 1.0

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -11,7 +11,7 @@ var sprite: Sprite3D = null
 var last_rotation: int
 var current_chunk: Chunk
 
-
+var is_animating_hit: bool = false # flag to prevent multiple blink actions
 var corpse_scene: PackedScene = preload("res://Defaults/Mobs/mob_corpse.tscn")
 var current_health: float = 10.0
 
@@ -34,14 +34,12 @@ func _physics_process(_delta):
 
 
 func get_hit(damage):
-	#3d
-#	tween = create_tween()
-#	tween.tween_property(get_node(sprite), "scale", get_node(sprite).scale * 1.35, 0.1)
-#	tween.tween_property(get_node(sprite), "scale", original_scale, 0.1)
-	
 	current_health -= damage
 	if current_health <= 0:
 		_die()
+	else:
+		if not is_animating_hit:
+			animate_hit()
 
 
 func _die():
@@ -153,3 +151,22 @@ func get_data() -> Dictionary:
 		"global_position_z": furnitureposition.z,
 		"rotation": last_rotation
 	}
+
+
+# The furniture will move 0.2 meters in a random direction to indicate that it's hit
+# Then it will return to its original position
+func animate_hit():
+	is_animating_hit = true
+
+	var directions = [Vector3(0.1, 0, 0), Vector3(-0.1, 0, 0), Vector3(0, 0, 0.1), Vector3(0, 0, -0.1)]
+	var random_direction = directions[randi() % directions.size()]
+
+	var tween = create_tween()
+	tween.tween_property(sprite, "position", sprite.position + random_direction, 0.1).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
+	tween.tween_property(sprite, "position", Vector3(0,0,0), 0.1).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT).set_delay(0.1)
+
+	tween.finished.connect(_on_tween_finished)
+
+# The furniture is done blinking so we reset the relevant variables
+func _on_tween_finished():
+	is_animating_hit = false

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -1,10 +1,11 @@
 extends Control
 
 # This scene is intended to be used inside the item editor
-# It is supposed to edit exactly one type of melee wearon
+# It is supposed to edit exactly one type of melee weapon
 
 # Form elements
 @export var DamageSpinBox: SpinBox = null
+@export var ReachSpinBox: SpinBox = null
 
 
 func _ready():
@@ -13,10 +14,13 @@ func _ready():
 
 func get_properties() -> Dictionary:
 	return {
-		"damage": DamageSpinBox.value
+		"damage": DamageSpinBox.value,
+		"reach": ReachSpinBox.value
 	}
 
 
 func set_properties(properties: Dictionary) -> void:
 	if properties.has("damage"):
 		DamageSpinBox.value = properties["damage"]
+	if properties.has("reach"):
+		ReachSpinBox.value = properties["reach"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=28 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
@@ -48,6 +48,9 @@ stream_0/weight = 1.0
 [sub_resource type="AudioStreamRandomizer" id="AudioStreamRandomizer_n8kat"]
 playback_mode = 1
 random_pitch = 1.2
+
+[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_ra623"]
+points = PackedVector3Array(0, 0, 0.325, -1, -1, 0.325, -1, 1, 0.325, 0, 0, -0.325, -1, -1, -0.325, -1, 1, -0.325)
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_caadj"]
 height = 1.0
@@ -146,7 +149,7 @@ transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.
 pixel_size = 0.002
 texture = ExtResource("10_ghgoh")
 
-[node name="EquippedRight" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "shoot_audio_player", "reload_audio_player")]
+[node name="EquippedRight" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "playerSprite", "shoot_audio_player", "reload_audio_player")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.190849, -0.123334, 0)
 pixel_size = 0.002
 texture = ExtResource("10_3jjqt")
@@ -156,13 +159,16 @@ bullet_speed = 50.0
 bullet_damage = 25.0
 bullet_scene = ExtResource("12_8xasb")
 attack_cooldown_timer = NodePath("../../Shooting/Right_attack_cooldown")
+melee_attack_area = NodePath("../MeleeRange")
+melee_collision_shape = NodePath("../MeleeRange/MeleeCollisionShape3D")
 player = NodePath("../..")
+playerSprite = NodePath("..")
 hud = NodePath("../../../../../HUD")
 shoot_audio_player = NodePath("../../Shooting/ShootAudio")
 shoot_audio_randomizer = SubResource("AudioStreamRandomizer_jdgh6")
 reload_audio_player = NodePath("../../Shooting/ReloadAudio")
 
-[node name="EquippedLeft" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "shoot_audio_player", "reload_audio_player")]
+[node name="EquippedLeft" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "playerSprite", "shoot_audio_player", "reload_audio_player")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.194626, 0.116675, 0)
 pixel_size = 0.002
 texture = ExtResource("11_4n80n")
@@ -172,12 +178,23 @@ bullet_speed = 50.0
 bullet_damage = 25.0
 bullet_scene = ExtResource("12_8xasb")
 attack_cooldown_timer = NodePath("../../Shooting/Left_attack_cooldown")
+melee_attack_area = NodePath("../MeleeRange")
+melee_collision_shape = NodePath("../MeleeRange/MeleeCollisionShape3D")
 player = NodePath("../..")
+playerSprite = NodePath("..")
 hud = NodePath("../../../../../HUD")
 equipped_left = true
 shoot_audio_player = NodePath("../../Shooting/ShootAudio")
 shoot_audio_randomizer = SubResource("AudioStreamRandomizer_n8kat")
 reload_audio_player = NodePath("../../Shooting/ReloadAudio")
+
+[node name="MeleeRange" type="Area3D" parent="TacticalMap/Entities/Player/Sprite3D2"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)
+collision_mask = 2
+
+[node name="MeleeCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/Sprite3D2/MeleeRange"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
+shape = SubResource("ConvexPolygonShape3D_ra623")
 
 [node name="Shooting" type="Node3D" parent="TacticalMap/Entities/Player" node_paths=PackedStringArray("left_hand_item", "right_hand_item")]
 script = ExtResource("11_6i2sa")

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -190,7 +190,7 @@ reload_audio_player = NodePath("../../Shooting/ReloadAudio")
 
 [node name="MeleeRange" type="Area3D" parent="TacticalMap/Entities/Player/Sprite3D2"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)
-collision_mask = 2
+collision_mask = 14
 
 [node name="MeleeCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/Sprite3D2/MeleeRange"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)


### PR DESCRIPTION
Requires #128
Fixes #129

Melee attacks now hit furniture in addition to mobs.
- Mobs will blink white when hit (melee or ranged)
- The sprite of the furniture will slightly move in a random direction when hit (melee or ranged)
- The player can hit entities with a melee attack if they are in a cone in front of him (before it was an entire circle around the player)
- Added 'reach' property to melee weapons. Reach is some amount of meters that the player can attack from. If the number increases, so does the cone in front of the player, allowing for longer attacks.

This does not account for obstacles between the player and the entity.

This image shows the cone in front of the player and the mob blinking. I painted the border of the cone blue for clarity
![image](https://github.com/Khaligufzel/CataX/assets/50166150/22f97d43-bd5d-4fee-b905-872cc0aa71da)


This mp4 shows melee hits on furniture:

https://github.com/Khaligufzel/CataX/assets/50166150/01db57cb-270f-4865-a42e-7aa573e99216



