### PR TITLE
Prevent accessing containers trough obstacles

### DIFF
--- a/Scripts/ItemDetector.gd
+++ b/Scripts/ItemDetector.gd
@@ -1,13 +1,69 @@
 extends Area3D
 
+@export var playernode: CharacterBody3D
+var areas_in_proximity = {}  # Dictionary to track areas and their proximity status
 
+# Called when the node is added to the scene.
+# Enables the processing of the _process function.
+func _ready():
+	set_process(true)  # Enable processing
+
+# Called every frame to continuously check for obstacles between the playernode and the areas in proximity.
+func _process(_delta):
+	for area in areas_in_proximity.keys():
+		if areas_in_proximity[area]:  # If previously in proximity
+			if not is_clear_path_to_area(area):
+				# Obstacle appeared, emit exit proximity signal
+				Helper.signal_broker.container_exited_proximity.emit(area.get_owner())
+				areas_in_proximity[area] = false
+		else:  # If previously not in proximity
+			if is_clear_path_to_area(area):
+				# Path is clear, emit enter proximity signal
+				Helper.signal_broker.container_entered_proximity.emit(area.get_owner())
+				areas_in_proximity[area] = true
+
+# Called when an area enters the Area3D.
+# Adds the area to the dictionary and checks initial proximity status.
 func _on_area_entered(area):
 	if area.get_owner().is_in_group("Containers"):
-		Helper.signal_broker.container_entered_proximity.emit(area.get_owner())
+		# Add area to the dictionary and check initial proximity status
+		areas_in_proximity[area] = is_clear_path_to_area(area)
+		if areas_in_proximity[area]:
+			Helper.signal_broker.container_entered_proximity.emit(area.get_owner())
 
-
+# Called when an area exits the Area3D.
+# Removes the area from the dictionary and emits exit proximity signal if necessary.
 func _on_area_exited(area):
 	var areaowner = area.get_owner()
 	if areaowner:
 		if areaowner.is_in_group("Containers"):
-			Helper.signal_broker.container_exited_proximity.emit(area.get_owner())
+			# Remove area from the dictionary and emit exit proximity signal if necessary
+			if areas_in_proximity.has(area) and areas_in_proximity[area]:
+				Helper.signal_broker.container_exited_proximity.emit(area.get_owner())
+			areas_in_proximity.erase(area)
+
+# Checks if there is a clear path between the playernode and the specified area.
+# Returns true if there is a clear path, false otherwise.
+func is_clear_path_to_area(area) -> bool:
+	var player_position = playernode.global_transform.origin
+	var area_position = area.global_transform.origin
+
+	# Create a PhysicsRayQueryParameters3D object
+	var query = PhysicsRayQueryParameters3D.new()
+	query.from = player_position
+	query.to = area_position
+	query.exclude = [self, playernode, area]  # Exclude the area, playernode, and self from the raycast
+
+	# Perform the raycast
+	var space_state = get_world_3d().direct_space_state
+	var result = space_state.intersect_ray(query)
+
+	if result.size() != 0:  # Check if the result dictionary is not empty
+		# Check if the hit object is an ancestor of the area
+		var collider = result.collider
+		if collider.is_ancestor_of(area):
+			return true
+		return false
+	else:
+		# No hit means there is a clear path
+		return true

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -217,11 +217,12 @@ bus = &"Sounds"
 stream = ExtResource("14_x756n")
 bus = &"Sounds"
 
-[node name="ItemDetector" type="Area3D" parent="TacticalMap/Entities/Player"]
+[node name="ItemDetector" type="Area3D" parent="TacticalMap/Entities/Player" node_paths=PackedStringArray("playernode")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1205, 0)
 collision_layer = 64
 collision_mask = 64
 script = ExtResource("15_r1xed")
+playernode = NodePath("..")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/ItemDetector"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.792087, 0)


### PR DESCRIPTION
Requires #130
Fixes #113

Players can't access containers trough obstacles anymore
- When a ContainerItem node enters the itemdetector's proximity, it will add it to a dictionary of containers in proximity
- When a ContainerItem node exits the itemdetector's proximity, it will be erased from the dictionary
- Every frame, the itemdetector will check if something is between the player and each of the ContainerItems (this can be walls, doors, other furniture)
- If there is something, but it's the ancestor of the ContainerItem, it is considered within proximity
- If there is something but it's not the ancestor of the ContainerItem, it is considered outside of proximity
- This works with the inventorymenu and the craftingmenu, which accesses items in the area

This might need further tweaking. Specifically, should containers be considered an obstacle? If you have 3 storage cabinets next to each other and you stand against the middle one with no space in between, it will block the raycast to the other two storage cabinets. This means you have to position the player just right to access all three. Alternatively, if containers are not an obstacle, you could potentially access a storage cabinets in the back of a hallway that's blocked by 3 other storage cabinets. We'll figure out some middle ground.