### PR TITLE
Containers hide when above player

### DIFF
--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -24,3 +24,8 @@ func update_visibility(player_y: float):
 	for furniture in get_tree().get_nodes_in_group("furniture"):
 		var is_above_player = furniture.global_position.y > player_y
 		furniture.visible = not is_above_player
+
+	# Update container visibility
+	for container in get_tree().get_nodes_in_group("Containers"):
+		var is_above_player = container.global_position.y > player_y
+		container.visible = not is_above_player


### PR DESCRIPTION
Fixes #137 

Implemented the same logic as for furniture and blocks. When the container is higher then the player, it will be hidden.