### PR TITLE
Fix tile rotation

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -843,19 +843,19 @@ func get_block_rotation(shape: String, tilerotation: int = 0) -> int:
 	var myRotation: int = tilerotation + defaultRotation
 	if myRotation == 0:
 		# Only the block will match this case, not the slope. The block points north
-		return myRotation+180
+		return myRotation+0
 	elif myRotation == 90:
 		# A block will point east
 		# A slope will point north
-		return myRotation+0
+		return myRotation+180
 	elif myRotation == 180:
 		# A block will point south
 		# A slope will point east
-		return myRotation-180
+		return myRotation-0
 	elif myRotation == 270:
 		# A block will point west
 		# A slope will point south
-		return myRotation+0
+		return myRotation-180
 	elif myRotation == 360:
 		# Only a slope can match this case if it's rotation is 270 and it gets 90 rotation by default
 		return myRotation-180


### PR DESCRIPTION
Fix #149 

Changed some numbers in chunk.gd. I'd like to get rid of the get_block_rotation function some day because if we have better standards we don't need it. Why are slopes rotated by 90 degrees? Well, that's because of their shape. It works now, but I'd like to see improvements in this area in the future