### PR TITLE
Reference the tacticalmap for maps that are included in it

### DIFF
--- a/Mods/Core/Maps/Generichouse.json
+++ b/Mods/Core/Maps/Generichouse.json
@@ -35099,5 +35099,12 @@
 		[]
 	],
 	"mapheight": 32,
-	"mapwidth": 32
+	"mapwidth": 32,
+	"references": {
+		"core": {
+			"tacticalmaps": [
+				"./Mods/Core/TacticalMaps/DefaultTacticalMap.json"
+			]
+		}
+	}
 }

--- a/Mods/Core/Maps/Generichouse.json
+++ b/Mods/Core/Maps/Generichouse.json
@@ -35103,7 +35103,7 @@
 	"references": {
 		"core": {
 			"tacticalmaps": [
-				"./Mods/Core/TacticalMaps/DefaultTacticalMap.json"
+				"DefaultTacticalMap.json"
 			]
 		}
 	}

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -37879,7 +37879,7 @@
 	"references": {
 		"core": {
 			"tacticalmaps": [
-				"./Mods/Core/TacticalMaps/DefaultTacticalMap.json"
+				"DefaultTacticalMap.json"
 			]
 		}
 	}

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -37875,5 +37875,12 @@
 		[]
 	],
 	"mapheight": 32,
-	"mapwidth": 32
+	"mapwidth": 32,
+	"references": {
+		"core": {
+			"tacticalmaps": [
+				"./Mods/Core/TacticalMaps/DefaultTacticalMap.json"
+			]
+		}
+	}
 }

--- a/Mods/Core/Maps/RockyHill_NE.json
+++ b/Mods/Core/Maps/RockyHill_NE.json
@@ -27739,7 +27739,7 @@
 	"references": {
 		"core": {
 			"tacticalmaps": [
-				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+				"RockyHill_00.json"
 			]
 		}
 	}

--- a/Mods/Core/Maps/RockyHill_NE.json
+++ b/Mods/Core/Maps/RockyHill_NE.json
@@ -27735,5 +27735,12 @@
 		[]
 	],
 	"mapheight": 32,
-	"mapwidth": 32
+	"mapwidth": 32,
+	"references": {
+		"core": {
+			"tacticalmaps": [
+				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+			]
+		}
+	}
 }

--- a/Mods/Core/Maps/RockyHill_NW.json
+++ b/Mods/Core/Maps/RockyHill_NW.json
@@ -27739,7 +27739,7 @@
 	"references": {
 		"core": {
 			"tacticalmaps": [
-				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+				"RockyHill_00.json"
 			]
 		}
 	}

--- a/Mods/Core/Maps/RockyHill_NW.json
+++ b/Mods/Core/Maps/RockyHill_NW.json
@@ -27735,5 +27735,12 @@
 		[]
 	],
 	"mapheight": 32,
-	"mapwidth": 32
+	"mapwidth": 32,
+	"references": {
+		"core": {
+			"tacticalmaps": [
+				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+			]
+		}
+	}
 }

--- a/Mods/Core/Maps/RockyHill_SE.json
+++ b/Mods/Core/Maps/RockyHill_SE.json
@@ -27731,7 +27731,7 @@
 	"references": {
 		"core": {
 			"tacticalmaps": [
-				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+				"RockyHill_00.json"
 			]
 		}
 	}

--- a/Mods/Core/Maps/RockyHill_SE.json
+++ b/Mods/Core/Maps/RockyHill_SE.json
@@ -27727,5 +27727,12 @@
 		[]
 	],
 	"mapheight": 32,
-	"mapwidth": 32
+	"mapwidth": 32,
+	"references": {
+		"core": {
+			"tacticalmaps": [
+				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+			]
+		}
+	}
 }

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -27773,7 +27773,7 @@
 	"references": {
 		"core": {
 			"tacticalmaps": [
-				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+				"RockyHill_00.json"
 			]
 		}
 	}

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -27769,5 +27769,12 @@
 		[]
 	],
 	"mapheight": 32,
-	"mapwidth": 32
+	"mapwidth": 32,
+	"references": {
+		"core": {
+			"tacticalmaps": [
+				"./Mods/Core/TacticalMaps/RockyHill_00.json"
+			]
+		}
+	}
 }

--- a/Mods/Core/TacticalMaps/DefaultTacticalMap.json
+++ b/Mods/Core/TacticalMaps/DefaultTacticalMap.json
@@ -1,14 +1,12 @@
 {
-	"mapheight": 1,
 	"chunks": [
 		{
-			"id": "Generichouse.json",
-			"rotation": 0
+			"id": "Generichouse.json"
 		},
 		{
-			"id": "Generichouse_00.json",
-			"rotation": 0
+			"id": "Generichouse_00.json"
 		}
 	],
+	"mapheight": 1,
 	"mapwidth": 2
 }

--- a/Mods/Core/TacticalMaps/RockyHill_00.json
+++ b/Mods/Core/TacticalMaps/RockyHill_00.json
@@ -1,22 +1,18 @@
 {
-	"mapheight": 2,
 	"chunks": [
 		{
-			"id": "RockyHill_NW.json",
-			"rotation": 0
+			"id": "RockyHill_NW.json"
 		},
 		{
-			"id": "RockyHill_NE.json",
-			"rotation": 0
+			"id": "RockyHill_NE.json"
 		},
 		{
-			"id": "RockyHill_SW.json",
-			"rotation": 0
+			"id": "RockyHill_SW.json"
 		},
 		{
-			"id": "RockyHill_SE.json",
-			"rotation": 0
+			"id": "RockyHill_SE.json"
 		}
 	],
+	"mapheight": 2,
 	"mapwidth": 2
 }

--- a/Scripts/Helper/json_helper.gd
+++ b/Scripts/Helper/json_helper.gd
@@ -21,9 +21,7 @@ func load_json_array_file(source: String) -> Array:
 		print_debug("Unable to load file: " + source)
 	return data_json
 	
-#This function takes the path to a json file and returns its contents as an array
-#It should check if the contents is an array or not. If it is not an array, 
-#it should return an empty array
+#This function takes the path to a json file and returns its contents as an dictionary
 func load_json_dictionary_file(source: String) -> Dictionary:
 	var data_json: Dictionary = {}
 	var file = FileAccess.open(source, FileAccess.READ)

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -449,6 +449,8 @@ func remove_references_of_deleted_id(contentData: Dictionary, id: String):
 		on_furniture_deleted(id)
 	if contentData == Gamedata.data.maps:
 		on_map_deleted(id)
+	if contentData == Gamedata.data.tacticalmaps:
+		on_tacticalmap_deleted(id)
 	if contentData == Gamedata.data.mobs:
 		on_mob_deleted(id)
 	if contentData == Gamedata.data.tiles:
@@ -761,6 +763,23 @@ func on_map_deleted(map_id: String):
 		save_data_to_file(Gamedata.data.tiles)
 		save_data_to_file(Gamedata.data.furniture)
 		save_data_to_file(Gamedata.data.mobs)
+
+
+# A map is being deleted. Remove all references to this map
+func on_tacticalmap_deleted(tacticalmap_id: String):
+	var file = Gamedata.data.tacticalmaps.dataPath + tacticalmap_id + ".json"
+	var tacticalmapdata: Dictionary = Helper.json_helper.load_json_dictionary_file(file)
+	if not tacticalmapdata.has("chunks"):
+		print("Tacticalmap data does not contain 'chunks'.")
+		return
+
+	for i in range(tacticalmapdata["chunks"].size()):
+		var chunk = tacticalmapdata["chunks"][i]
+		# If the chunk has the target id, remove the reference from the map
+		if chunk.has("id"):
+			var chunkid = chunk["id"]
+			remove_reference(Gamedata.data.maps, "core", "tacticalmaps", \
+				chunk["id"], tacticalmap_id + ".json")
 
 
 # Function to collect unique entities from each level in newdata and olddata

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -724,7 +724,7 @@ func on_map_deleted(map_id: String):
 
 	# This callable will remove this map from every tacticalmap that references this itemgroup.
 	var myfunc: Callable = func (tmap_id):
-		var tfile = Gamedata.data.tacticalmaps.dataPath + tmap_id + ".json"
+		var tfile = Gamedata.data.tacticalmaps.dataPath + tmap_id
 		var tmapdata: Dictionary = Helper.json_helper.load_json_dictionary_file(tfile)
 		# Check if the "chunks" key exists and is an array
 		if tmapdata.has("chunks") and tmapdata["chunks"] is Array:
@@ -732,7 +732,7 @@ func on_map_deleted(map_id: String):
 			for i in range(tmapdata["chunks"].size()):
 				var chunk = tmapdata["chunks"][i]
 				# If the chunk has the target id, remove it from the array
-				if chunk.has("id") and chunk["id"] == map_id:
+				if chunk.has("id") and chunk["id"] == map_id + ".json":
 					tmapdata["chunks"].remove_at(i)
 			var map_data_json = JSON.stringify(tmapdata.duplicate(), "\t")
 			Helper.json_helper.write_json_file(tfile, map_data_json)
@@ -846,6 +846,7 @@ func on_tacticalmapdata_changed(tacticalmap_id: String, newdata: Dictionary, old
 				ids_dict_new[chunk["id"]] = true
 	unique_new_ids = ids_dict_new.keys()
 
+	tacticalmap_id = tacticalmap_id.get_file()
 	# Add references for new IDs
 	for id in unique_new_ids:
 		add_reference(Gamedata.data.maps, "core", "tacticalmaps", id, tacticalmap_id)

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -349,18 +349,41 @@ func on_itemgroup_changed(newdata: Dictionary, olddata: Dictionary):
 # This example will add the specified furniture from the itemgroup's references
 func add_reference(mydata: Dictionary, module: String, type: String, onid: String, refid: String) -> bool:
 	var changes_made: bool = false
-	if onid != "":
-		var entitydata = get_data_by_id(mydata, onid)
-		if not entitydata.has("references"):
-			entitydata["references"] = {}
-		if not entitydata["references"].has(module):
-			entitydata["references"][module] = {}
-		if not entitydata["references"][module].has(type):
-			entitydata["references"][module][type] = []
-		
-		if refid not in entitydata["references"][module][type]:
-			entitydata["references"][module][type].append(refid)
+
+	# If onid ends with ".json", handle it as a file reference case
+	if onid.ends_with(".json"):
+		var filepath = mydata.dataPath + onid
+		var file_data = Helper.json_helper.load_json_dictionary_file(filepath)
+		if not file_data.has("references"):
+			file_data["references"] = {}
+		if not file_data["references"].has(module):
+			file_data["references"][module] = {}
+		if not file_data["references"][module].has(type):
+			file_data["references"][module][type] = []
+
+		if refid not in file_data["references"][module][type]:
+			file_data["references"][module][type].append(refid)
 			changes_made = true
+
+		# Save the updated data back to the file
+		var data_json = JSON.stringify(file_data.duplicate(), "\t")
+		Helper.json_helper.write_json_file(filepath, data_json)
+
+	# Default behavior for other cases
+	else:
+		if onid != "":
+			var entitydata = get_data_by_id(mydata, onid)
+			if not entitydata.has("references"):
+				entitydata["references"] = {}
+			if not entitydata["references"].has(module):
+				entitydata["references"][module] = {}
+			if not entitydata["references"][module].has(type):
+				entitydata["references"][module][type] = []
+
+			if refid not in entitydata["references"][module][type]:
+				entitydata["references"][module][type].append(refid)
+				changes_made = true
+
 	return changes_made
 
 
@@ -374,20 +397,45 @@ func add_reference(mydata: Dictionary, module: String, type: String, onid: Strin
 # This example will remove the specified furniture from the itemgroup's references
 func remove_reference(mydata: Dictionary, module: String, type: String, fromid: String, refid: String) -> bool:
 	var changes_made: bool = false
-	if fromid != "":
-		var entitydata = get_data_by_id(mydata, fromid)
-		if entitydata.has("references") and entitydata["references"].has(module) and entitydata["references"][module].has(type):
-			var refs = entitydata["references"][module][type]
+	
+	# If fromid ends with ".json", handle it as a file reference case
+	if fromid.ends_with(".json"):
+		var filepath = mydata.dataPath + fromid
+		var file_data = Helper.json_helper.load_json_dictionary_file(filepath)
+		if file_data.has("references") and file_data["references"].has(module) and file_data["references"][module].has(type):
+			var refs = file_data["references"][module][type]
 			if refid in refs:
 				refs.erase(refid)
 				changes_made = true
 				# Clean up if necessary
 				if refs.size() == 0:
-					entitydata["references"][module].erase(type)
-				if entitydata["references"][module].is_empty():
-					entitydata["references"].erase(module)
-				if entitydata["references"].is_empty():
-					entitydata.erase("references")
+					file_data["references"][module].erase(type)
+				if file_data["references"][module].is_empty():
+					file_data["references"].erase(module)
+				if file_data["references"].is_empty():
+					file_data.erase("references")
+
+				# Save the updated data back to the file
+				var data_json = JSON.stringify(file_data.duplicate(), "\t")
+				Helper.json_helper.write_json_file(filepath, data_json)
+
+	# Default behavior for other cases
+	else:
+		if fromid != "":
+			var entitydata = get_data_by_id(mydata, fromid)
+			if entitydata.has("references") and entitydata["references"].has(module) and entitydata["references"][module].has(type):
+				var refs = entitydata["references"][module][type]
+				if refid in refs:
+					refs.erase(refid)
+					changes_made = true
+					# Clean up if necessary
+					if refs.size() == 0:
+						entitydata["references"][module].erase(type)
+					if entitydata["references"][module].is_empty():
+						entitydata["references"].erase(module)
+					if entitydata["references"].is_empty():
+						entitydata.erase("references")
+
 	return changes_made
 
 
@@ -674,6 +722,25 @@ func on_map_deleted(map_id: String):
 		print("Map data does not contain 'levels'.")
 		return
 
+	# This callable will remove this map from every tacticalmap that references this itemgroup.
+	var myfunc: Callable = func (tmap_id):
+		var tfile = Gamedata.data.tacticalmaps.dataPath + tmap_id + ".json"
+		var tmapdata: Dictionary = Helper.json_helper.load_json_dictionary_file(tfile)
+		# Check if the "chunks" key exists and is an array
+		if tmapdata.has("chunks") and tmapdata["chunks"] is Array:
+			# Iterate through the chunks array
+			for i in range(tmapdata["chunks"].size()):
+				var chunk = tmapdata["chunks"][i]
+				# If the chunk has the target id, remove it from the array
+				if chunk.has("id") and chunk["id"] == map_id:
+					tmapdata["chunks"].remove_at(i)
+			var map_data_json = JSON.stringify(tmapdata.duplicate(), "\t")
+			Helper.json_helper.write_json_file(tfile, map_data_json)
+	
+	# Pass the callable to every furniture in the itemgroup's references
+	# It will call myfunc on every furniture in itemgroup_data.references.core.furniture
+	execute_callable_on_references_of_type(mapdata, "core", "tacticalmaps", myfunc)
+	
 	for level_index in range(mapdata["levels"].size()):
 		var old_level = mapdata["levels"][level_index] if mapdata["levels"].size() > level_index else []
 			# Entire level was removed
@@ -758,6 +825,35 @@ func on_mapdata_changed(map_id: String, newdata: Dictionary, olddata: Dictionary
 		save_data_to_file(Gamedata.data.furniture)
 	if new_entities["tiles"].size() > 0 or old_entities["tiles"].size() > 0:
 		save_data_to_file(Gamedata.data.tiles)
+
+
+func on_tacticalmapdata_changed(tacticalmap_id: String, newdata: Dictionary, olddata: Dictionary):
+	# Collect unique IDs from old data
+	var unique_old_ids: Array = []
+	var ids_dict_old: Dictionary = {}
+	if olddata.has("chunks") and olddata["chunks"] is Array:
+		for chunk in olddata["chunks"]:
+			if chunk.has("id"):
+				ids_dict_old[chunk["id"]] = true
+	unique_old_ids = ids_dict_old.keys()
+
+	# Collect unique IDs from new data
+	var unique_new_ids: Array = []
+	var ids_dict_new: Dictionary = {}
+	if newdata.has("chunks") and newdata["chunks"] is Array:
+		for chunk in newdata["chunks"]:
+			if chunk.has("id"):
+				ids_dict_new[chunk["id"]] = true
+	unique_new_ids = ids_dict_new.keys()
+
+	# Add references for new IDs
+	for id in unique_new_ids:
+		add_reference(Gamedata.data.maps, "core", "tacticalmaps", id, tacticalmap_id)
+
+	# Remove references for IDs not present in new data
+	for id in unique_old_ids:
+		if id not in unique_new_ids:
+			remove_reference(Gamedata.data.maps, "core", "tacticalmaps", id, tacticalmap_id)
 
 
 # Some item has been changed


### PR DESCRIPTION
Fixes #145 

This adds a reference to the tacticalmap to maps that are part of the tacticalmap
- When a tacticalmap is saved, the references between it and the maps are updated
- When a map is deleted, it is also removed from the tacticalmap
- When a tacticalmap is deleted, the references are also removed from the maps

When a tacticalmap is loaded in-game that has a map removed from it, the game throws an error, but that should be resolved in the map editor by the map maker.