### PR TITLE
Containers no longer show on top of the player

### DIFF
--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -143,11 +143,13 @@ spot_angle_attenuation = 3.60501
 [node name="Sprite3D2" type="Sprite3D" parent="TacticalMap/Entities/Player"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
 pixel_size = 0.003
+render_priority = 15
 texture = ExtResource("7_jr4x1")
 
 [node name="EquippedRight" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "playerSprite", "shoot_audio_player", "reload_audio_player")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.190849, -0.123334, 0)
 pixel_size = 0.002
+render_priority = 15
 texture = ExtResource("10_3jjqt")
 script = ExtResource("12_xwnuw")
 projectiles = NodePath("../../../Projectiles")
@@ -167,6 +169,7 @@ reload_audio_player = NodePath("../../Shooting/ReloadAudio")
 [node name="EquippedLeft" type="Sprite3D" parent="TacticalMap/Entities/Player/Sprite3D2" node_paths=PackedStringArray("projectiles", "attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "playerSprite", "shoot_audio_player", "reload_audio_player")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.194626, 0.116675, 0)
 pixel_size = 0.002
+render_priority = 15
 texture = ExtResource("11_4n80n")
 script = ExtResource("12_xwnuw")
 projectiles = NodePath("../../../Projectiles")


### PR DESCRIPTION
Fixes #115 

Increased the render priority on the player and his equipment sprites. The player now shows above the containers. I tested the game and the player does not show above blocks or anything, but the weapon may overlap with a table for example but it does not look odd.

Container is below the player:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/4b21e87f-3e8f-4324-a932-f4eae068f096)
