### PR TITLE
Entities fall quickly

### DIFF
--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -18,10 +18,21 @@ var current_health: float = 10.0
 
 
 func _ready():
-	set_position.call_deferred(furnitureposition)
+	# Add a Timer node so we can wait for the chunk to pawn
+	var timer = Timer.new()
+	timer.wait_time = 2.0
+	timer.one_shot = true
+	add_child(timer)
+	timer.start()
+	timer.timeout.connect(_on_timer_timeout)
+	
+	#set_position.call_deferred(furnitureposition)
 	set_new_rotation(furniturerotation)
 	last_rotation = furniturerotation
 
+func _on_timer_timeout():
+	# After the chunk is (hopefully) spawned, set the position
+	set_position.call_deferred(furnitureposition)
 
 # Keep track of the furniture's position and rotation. It starts at 0,0,0 and the moves to it's
 # assigned position after a timer. Until that has happened, we don't need to keep track of it's position
@@ -97,7 +108,7 @@ func construct_self(furniturepos: Vector3, newFurnitureJSON: Dictionary):
 	
 	furniturerotation = furnitureJSON.get("rotation", 0)
 	# Set the properties we need
-	linear_damp = 59
+	#linear_damp = 59
 	angular_damp = 59
 	axis_lock_angular_x = true
 	axis_lock_angular_z = true

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -51,6 +51,7 @@ var time_since_ready = 0.0
 var delay_before_movement = 2.0  # 2 second delay
 
 @export var sprite : Sprite3D
+@export var collisionDetector : Area3D # Used for detecting collision with furniture
 
 @export var interact_range : float = 10
 
@@ -61,6 +62,10 @@ var delay_before_movement = 2.0  # 2 second delay
 @export var foostep_player : AudioStreamPlayer
 @export var foostep_stream_randomizer : AudioStreamRandomizer
 
+
+# Variables for furniture pushing
+var pushing_furniture = false
+var furniture_body: RigidBody3D = null
 #var progress_bar_timer_max_time : float
 
 #var is_progress_bar_well_progressing_i_guess = false
@@ -71,6 +76,9 @@ func _ready():
 	initialize_stats_and_skills()
 	Helper.save_helper.load_player_state(self)
 	Helper.signal_broker.health_item_used.connect(_on_health_item_used)
+	# Connect signals for collisionDetector to detect furniture
+	collisionDetector.body_entered.connect(_on_body_entered)
+	collisionDetector.body_exited.connect(_on_body_exited)
 
 
 func initialize_health():
@@ -127,8 +135,6 @@ func _process(_delta):
 
 #	if is_progress_bar_well_progressing_i_guess:
 #		get_node(progress_bar_filling).scale.x = lerp(1, 0, get_node(progress_bar_timer).time_left / progress_bar_timer_max_time)
-		
-
 func _physics_process(delta):
 	time_since_ready += delta
 	if time_since_ready < delay_before_movement:
@@ -141,33 +147,48 @@ func _physics_process(delta):
 	velocity.y -= gravity * 12 * delta
 	move_and_slide()
 	
+		
 	if is_alive:
-		if !is_running || current_stamina <= 0:
-			var input_dir = Input.get_vector("left", "right", "up", "down")
-			var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-			velocity = direction * speed
-#			if velocity.length() > 0.1:
-#				get_node(animation_player).play("player_walking")
-#			else:
-#				get_node(animation_player).stop()
-			move_and_slide()
-		elif is_running && current_stamina > 0:
-			var input_dir = Input.get_vector("left", "right", "up", "down")
-			var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-			velocity = direction * speed * run_multiplier
-			
-			if velocity.length() > 0:
-#				get_node(animation_player).play("player_running")
-				current_stamina -= delta * stamina_lost_while_running_persec
-			
-			move_and_slide()
-			
+		var input_dir = Input.get_vector("left", "right", "up", "down")
+		var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+		
+		# Check if the player is pushing furniture
+		if pushing_furniture and furniture_body:
+			# Get the mass of the RigidBody3D
+			var mass = furniture_body.mass
+			# Calculate resistance based on the mass
+			var resistance = 1.0 / mass
+			# Apply resistance to the player's movement
+			velocity = direction * speed * resistance
+		else:
+			if !is_running || current_stamina <= 0:
+				velocity = direction * speed
+			elif is_running and current_stamina > 0:
+				velocity = direction * speed * run_multiplier
+				
+				if velocity.length() > 0:
+					current_stamina -= delta * stamina_lost_while_running_persec
+				
 		if velocity.length() < 0.1:
 			current_stamina += delta * stamina_regen_while_standing_still
 			if current_stamina > stamina:
 				current_stamina = stamina
 
 		update_stamina_HUD.emit(current_stamina)
+		
+		move_and_slide()
+
+
+func _on_body_entered(body):
+	if body is RigidBody3D:
+		pushing_furniture = true
+		furniture_body = body
+
+
+func _on_body_exited(body):
+	if body is RigidBody3D:
+		pushing_furniture = false
+		furniture_body = null
 
 
 func _input(event):

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -47,6 +47,9 @@ var current_pain = 0
 var stats = {}
 var skills = {}
 
+var time_since_ready = 0.0
+var delay_before_movement = 2.0  # 2 second delay
+
 @export var sprite : Sprite3D
 
 @export var interact_range : float = 10
@@ -127,9 +130,15 @@ func _process(_delta):
 		
 
 func _physics_process(delta):
+	time_since_ready += delta
+	if time_since_ready < delay_before_movement:
+		# Skip movement updates during the delay period. Otherwise the player 
+		# will fall into the ground because the ground is still being spawned.
+		return
 
-	var gravity = 9.8
-	velocity.y += -gravity * delta
+	# Added an arbitrary multiplier because without it, the player will fall slowly
+	var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
+	velocity.y -= gravity * 12 * delta
 	move_and_slide()
 	
 	if is_alive:

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -103,13 +103,14 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.4043, 0, -8.78679)
 
 [node name="Projectiles" type="Node3D" parent="TacticalMap/Entities"]
 
-[node name="Player" type="CharacterBody3D" parent="TacticalMap/Entities" node_paths=PackedStringArray("sprite") groups=["Players"]]
+[node name="Player" type="CharacterBody3D" parent="TacticalMap/Entities" node_paths=PackedStringArray("sprite", "collisionDetector") groups=["Players"]]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 15)
 collision_mask = 22
 floor_constant_speed = true
 floor_max_angle = 0.872665
 script = ExtResource("8_gposs")
 sprite = NodePath("Sprite3D2")
+collisionDetector = NodePath("Sprite3D2/CollisionDetector")
 
 [node name="Camera3D" type="Camera3D" parent="TacticalMap/Entities/Player" groups=["Camera"]]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 19, 0)
@@ -191,6 +192,14 @@ collision_mask = 14
 [node name="MeleeCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/Sprite3D2/MeleeRange"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
 shape = SubResource("ConvexPolygonShape3D_ra623")
+
+[node name="CollisionDetector" type="Area3D" parent="TacticalMap/Entities/Player/Sprite3D2"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.00202602)
+collision_mask = 8
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/Sprite3D2/CollisionDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.179206, 0)
+shape = SubResource("ConvexPolygonShape3D_drnhn")
 
 [node name="Shooting" type="Node3D" parent="TacticalMap/Entities/Player" node_paths=PackedStringArray("left_hand_item", "right_hand_item")]
 script = ExtResource("11_6i2sa")


### PR DESCRIPTION
Fixes #138 

- Removed linear dampening from furniturephysics. this causes it to fall normally. I had to put a timer on it's initial position, because otherwise it would fall below the chunk that's still being spawned
- Added an arbitrary multiplier to the player gravity calculations. This is needed because the player is a Characterbody3d and is not affected by physics. Although I did look around in the Godot Discord and no one else uses an arbitrary multiplier for some reason.
- Added some basic pushing calculations and an area3d that has the same shape as the collisionshape of the player. This area3d detects only moveable furniture. If the furniture has more mass, more resistance is applied, slowing the movement of the player down.
- Running and pushing is not possible at the same time
- I did not change anything about mobs because it's basically impossible for them to fall because they follow navigation.


There are still issues with this:
- We should have the furniture initialize it's position based on a signal when the chunk is done loading. Same for the player position
- All furniture has the same mass, so the calculations do nothing at the moment. We should add a weight property to the moveable furniture so heavy furniture is heavy
- All moveable furniture has a sphereshape as a collisionshape and they all have the same size. We could change it to be a rectangle that fits the sprite exactly, but a rectangle is harder to push then a sphere, especially up and down slopes.


Video of the push mechanics, and see the player fall:
https://github.com/Khaligufzel/CataX/assets/50166150/a8cedae9-22f2-4f07-ba90-e980031f2df2


