### PR TITLE
Add furniture weight

### DIFF
--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -13,7 +13,8 @@
 		"id": "table_round_wood",
 		"moveable": true,
 		"name": "Round wooden table",
-		"sprite": "table_64.png"
+		"sprite": "table_64.png",
+		"weight": 10
 	},
 	{
 		"categories": [
@@ -29,7 +30,8 @@
 		"id": "chair_wood",
 		"moveable": true,
 		"name": "Wooden chair",
-		"sprite": "chair_32.png"
+		"sprite": "chair_32.png",
+		"weight": 2
 	},
 	{
 		"Function": {
@@ -153,7 +155,8 @@
 		"id": "plant_pot_00",
 		"moveable": true,
 		"name": "Potted plant",
-		"sprite": "pot_plant_32_32.png"
+		"sprite": "pot_plant_32_32.png",
+		"weight": 1
 	},
 	{
 		"categories": [

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_o3k3a"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="4_fbact"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("furnitureImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "CategoriesList", "furnitureSelector", "imageNameStringLabel", "moveableCheckboxButton", "edgeSnappingOptionButton", "doorOptionButton", "containerCheckBox", "containerTextEdit", "destroyHboxContainer", "canDestroyCheckbox", "destructionTextEdit", "destructionImageDisplay", "destructionSpriteNameLabel", "disassemblyHboxContainer", "canDisassembleCheckbox", "disassemblyTextEdit", "disassemblyImageDisplay", "disassemblySpriteNameLabel")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("furnitureImageDisplay", "IDTextLabel", "NameTextEdit", "DescriptionTextEdit", "CategoriesList", "furnitureSelector", "imageNameStringLabel", "moveableCheckboxButton", "weightLabel", "weightSpinBox", "edgeSnappingOptionButton", "doorOptionButton", "containerCheckBox", "containerTextEdit", "destroyHboxContainer", "canDestroyCheckbox", "destructionTextEdit", "destructionImageDisplay", "destructionSpriteNameLabel", "disassemblyHboxContainer", "canDisassembleCheckbox", "disassemblyTextEdit", "disassemblyImageDisplay", "disassemblySpriteNameLabel")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -21,7 +21,9 @@ DescriptionTextEdit = NodePath("VBoxContainer/FormGrid/DescriptionTextEdit")
 CategoriesList = NodePath("VBoxContainer/FormGrid/Editable_Item_List")
 furnitureSelector = NodePath("Sprite_selector")
 imageNameStringLabel = NodePath("VBoxContainer/FormGrid/ImageNameStringLabel")
-moveableCheckboxButton = NodePath("VBoxContainer/FormGrid/UnmoveableCheckBox")
+moveableCheckboxButton = NodePath("VBoxContainer/FormGrid/MoveableHboxContainer/UnmoveableCheckBox")
+weightLabel = NodePath("VBoxContainer/FormGrid/MoveableHboxContainer/WeightLabel")
+weightSpinBox = NodePath("VBoxContainer/FormGrid/MoveableHboxContainer/WeightSpinBox")
 edgeSnappingOptionButton = NodePath("VBoxContainer/FormGrid/SnappingOptionButton")
 doorOptionButton = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/DoorOptionButton")
 containerCheckBox = NodePath("VBoxContainer/FormGrid/FunctionControlContainer/ContainerCheckBox")
@@ -135,10 +137,27 @@ header = "Categories"
 layout_mode = 2
 text = "Can move"
 
-[node name="UnmoveableCheckBox" type="CheckBox" parent="VBoxContainer/FormGrid"]
+[node name="MoveableHboxContainer" type="HBoxContainer" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+
+[node name="UnmoveableCheckBox" type="CheckBox" parent="VBoxContainer/FormGrid/MoveableHboxContainer"]
 layout_mode = 2
 tooltip_text = "Check this if the furniture should be moveable, like a chair. Leave this unchecked if the furniture should not move, like a fence"
 text = "Moveable"
+
+[node name="WeightLabel" type="Label" parent="VBoxContainer/FormGrid/MoveableHboxContainer"]
+layout_mode = 2
+text = "| Weight"
+
+[node name="WeightSpinBox" type="SpinBox" parent="VBoxContainer/FormGrid/MoveableHboxContainer"]
+layout_mode = 2
+tooltip_text = "Specify the weight in kg for this furniture. A larger number 
+means it will be heavier and harder to push. A smaller 
+number means it will be lighter and easier to push. Only 
+applies to moveable furniture`"
+min_value = 0.1
+step = 0.1
+value = 1.0
 
 [node name="DisassembleLabel" type="Label" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
@@ -154,7 +173,7 @@ text = "Can disassemble"
 
 [node name="DisassembleLootGroupLabel" type="Label" parent="VBoxContainer/FormGrid/DisassembleHboxContainer"]
 layout_mode = 2
-text = "Loot group:"
+text = "| Loot group:"
 
 [node name="DisassemblyTextEdit" parent="VBoxContainer/FormGrid/DisassembleHboxContainer" instance=ExtResource("4_fbact")]
 custom_minimum_size = Vector2(100, 30)
@@ -167,7 +186,7 @@ myplaceholdertext = "Drag an itemgroup from the left to here"
 
 [node name="DisassembleSpriteLabel" type="Label" parent="VBoxContainer/FormGrid/DisassembleHboxContainer"]
 layout_mode = 2
-text = "Disassembled sprite:"
+text = "| Disassembled sprite:"
 
 [node name="DisassembleImageDisplay" type="TextureRect" parent="VBoxContainer/FormGrid/DisassembleHboxContainer"]
 custom_minimum_size = Vector2(32, 32)
@@ -199,7 +218,7 @@ text = "Can destroy"
 
 [node name="DestructionLootGroupLabel" type="Label" parent="VBoxContainer/FormGrid/DestructionHBoxContainer"]
 layout_mode = 2
-text = "Loot group:"
+text = "| Loot group:"
 
 [node name="DestructionTextEdit" parent="VBoxContainer/FormGrid/DestructionHBoxContainer" instance=ExtResource("4_fbact")]
 custom_minimum_size = Vector2(100, 30)
@@ -212,7 +231,7 @@ myplaceholdertext = "Drag an itemgroup from the left to here"
 
 [node name="DestructionSpriteLabel" type="Label" parent="VBoxContainer/FormGrid/DestructionHBoxContainer"]
 layout_mode = 2
-text = "Destroyed sprite:"
+text = "| Destroyed sprite:"
 
 [node name="DestructionImageDisplay" type="TextureRect" parent="VBoxContainer/FormGrid/DestructionHBoxContainer"]
 custom_minimum_size = Vector2(32, 32)

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -13,6 +13,8 @@ extends Control
 @export var furnitureSelector: Popup = null
 @export var imageNameStringLabel: Label = null
 @export var moveableCheckboxButton: CheckBox = null # The player can push it if selected
+@export var weightLabel: Label = null
+@export var weightSpinBox: SpinBox = null # The wight considered when pushing
 @export var edgeSnappingOptionButton: OptionButton = null # Apply edge snapping if selected
 @export var doorOptionButton: OptionButton = null # Maks the furniture as a door
 @export var containerCheckBox: CheckBox = null # Marks the furniture as a container
@@ -58,6 +60,11 @@ func _ready():
 	control_elements = [furnitureImageDisplay,NameTextEdit,DescriptionTextEdit]
 	data_changed.connect(Gamedata.on_data_changed)
 	set_drop_functions()
+	
+	# Connect the toggle signal to the function
+	moveableCheckboxButton.toggled.connect(_on_moveable_checkbox_toggled)
+
+
 
 
 func load_furniture_data():
@@ -76,11 +83,12 @@ func load_furniture_data():
 			CategoriesList.add_item_to_list(category)
 	if moveableCheckboxButton and contentData.has("moveable"):
 		moveableCheckboxButton.button_pressed = contentData["moveable"]
+		_on_moveable_checkbox_toggled(contentData["moveable"])
 	if edgeSnappingOptionButton and contentData.has("edgesnapping"):
 		select_option_by_string(edgeSnappingOptionButton, contentData["edgesnapping"])
 	if doorOptionButton:
 		update_door_option(contentData.get("Function", {}).get("door", "None"))
-		
+
 	if "destruction" in contentData:
 		canDestroyCheckbox.button_pressed = true
 		var destruction_data = contentData["destruction"]
@@ -332,3 +340,9 @@ func _on_can_disassemble_check_box_toggled(toggled_on):
 		disassemblySpriteNameLabel.text = ""
 		disassemblyImageDisplay.texture = load("res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png")
 	set_visibility_for_children(disassemblyHboxContainer, toggled_on)
+
+
+# Function to handle the toggle state of the checkbox
+func _on_moveable_checkbox_toggled(button_pressed):
+	weightLabel.visible = button_pressed
+	weightSpinBox.visible = button_pressed

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -65,8 +65,6 @@ func _ready():
 	moveableCheckboxButton.toggled.connect(_on_moveable_checkbox_toggled)
 
 
-
-
 func load_furniture_data():
 	if furnitureImageDisplay and contentData.has("sprite"):
 		furnitureImageDisplay.texture = Gamedata.data.furniture.sprites[contentData["sprite"]]
@@ -84,6 +82,8 @@ func load_furniture_data():
 	if moveableCheckboxButton and contentData.has("moveable"):
 		moveableCheckboxButton.button_pressed = contentData["moveable"]
 		_on_moveable_checkbox_toggled(contentData["moveable"])
+	if weightSpinBox and contentData.has("weight"):
+		weightSpinBox.value = contentData["weight"]
 	if edgeSnappingOptionButton and contentData.has("edgesnapping"):
 		select_option_by_string(edgeSnappingOptionButton, contentData["edgesnapping"])
 	if doorOptionButton:
@@ -159,16 +159,23 @@ func _on_close_button_button_up():
 	queue_free.call_deferred()
 
 
-# This function takes all data from the form elements stores them in the contentData
-# Since contentData is a reference to an item in Gamedata.data.furniture.data
-# the central array for furnituredata is updated with the changes as well
-# The function will signal to Gamedata that the data has changed and needs to be saved
+# This function takes all data from the form elements and stores them in the contentData.
+# Since contentData is a reference to an item in Gamedata.data.furniture.data,
+# the central array for furnituredata is updated with the changes as well.
+# The function will signal to Gamedata that the data has changed and needs to be saved.
 func _on_save_button_button_up():
 	contentData["sprite"] = imageNameStringLabel.text
 	contentData["name"] = NameTextEdit.text
 	contentData["description"] = DescriptionTextEdit.text
 	contentData["categories"] = CategoriesList.get_items()
 	contentData["moveable"] = moveableCheckboxButton.button_pressed
+	
+	# Save the weight only if moveableCheckboxButton is checked, otherwise erase it.
+	if moveableCheckboxButton.button_pressed:
+		contentData["weight"] = weightSpinBox.value
+	else:
+		contentData.erase("weight")
+
 	contentData["edgesnapping"] = edgeSnappingOptionButton.get_item_text(edgeSnappingOptionButton.selected)
 
 	handle_door_option()
@@ -178,6 +185,7 @@ func _on_save_button_button_up():
 
 	data_changed.emit(Gamedata.data.furniture, contentData, olddata)
 	olddata = contentData.duplicate(true)
+
 
 # If the door function is set, we save the value to contentData
 # Else, if the door state is set to none, we erase the value from contentdata

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -107,6 +107,7 @@ func construct_self(furniturepos: Vector3, newFurnitureJSON: Dictionary):
 	set_sprite(furnitureSprite)
 	
 	furniturerotation = furnitureJSON.get("rotation", 0)
+	mass = furnitureJSONData.get("weight", 1)
 	# Set the properties we need
 	#linear_damp = 59
 	angular_damp = 59


### PR DESCRIPTION
Fixes #162 

Users can define weight in the furniture editor and it will be set in the furniture properties when it its spawned. This makes it harder to push heavy furniture
- Only applies to moveable furniture. Weight is hidden if 'moveable' is not on