### PR TITLE
Slopes have sides

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -726,8 +726,8 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array
 	# Append UV coordinates for the side faces (6 vertices)
 	# The UV coordinates are not quire right but close enough
 	var side_uvs = PackedVector2Array([
-		top_face_uv[0], top_face_uv[1], top_face_uv[2],  # North face UVs
-		top_face_uv[0], top_face_uv[1], top_face_uv[2]   # South face UVs
+		top_face_uv[0], top_face_uv[1], top_face_uv[2],  # Right face UVs
+		top_face_uv[0], top_face_uv[1], top_face_uv[2]   # Left face UVs
 	])
 	uvs.append_array(side_uvs)
 	
@@ -745,15 +745,15 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array
 	indices.append_array([
 		base_index, base_index + 1, base_index + 2,  # Top face triangle 1
 		base_index, base_index + 2, base_index + 3,  # Top face triangle 2
-		base_index + 4, base_index + 5, base_index + 6,  # North face
-		base_index + 7, base_index + 8, base_index + 9   # South face
+		base_index + 4, base_index + 5, base_index + 6,  # First side face
+		base_index + 7, base_index + 8, base_index + 9   # Second side face
 	])
 
 
 # Gets the normals of the sides of the slope, based on rotation
-func get_slope_side_normals(rotation: int) -> Array:
+func get_slope_side_normals(sloperotation: int) -> Array:
 	var side_normals = []
-	match rotation:
+	match sloperotation:
 		90: # North
 			side_normals.append(Vector3(-1, 0, 0))  # West normal
 			side_normals.append(Vector3(1, 0, 0))   # East normal
@@ -807,7 +807,6 @@ func get_slope_vertices_north(half_block: float, slopeposition: Vector3) -> Pack
 	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
 	
 	return vertices
-
 
 
 # Function to get slope vertices facing west
@@ -881,18 +880,6 @@ func get_slope_vertices_east(half_block: float, slopeposition: Vector3) -> Packe
 	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
 	
 	return vertices
-
-
-# Function to add normals and indices for slopes
-func add_slope_normals_and_indices(verts, normals, indices):
-	var normal = Vector3(0, 1, 0)
-	for _i in range(4):
-		normals.append(normal)
-	var base_index = verts.size() - 4
-	indices.append_array([
-		base_index, base_index + 1, base_index + 2,
-		base_index, base_index + 2, base_index + 3
-	])
 
 
 # Coroutine for creating colliders with non-blocking delays

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -711,14 +711,61 @@ func find_blocks_at_y_level(y_level: int) -> Array:
 			})
 	return blocks_at_same_y
 
-
-# Setup the slope mesh based on it's position and rotation.
-func setup_slope(pos: Vector3, block_data: Dictionary, verts, uvs, normals, indices, top_face_uv):
+func setup_slope1(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array, uvs: PackedVector2Array, normals: PackedVector3Array, indices: PackedInt32Array, top_face_uv: PackedVector2Array):
 	var block_rotation = block_data.get("rotation", 0)
 	var slope_vertices = calculate_slope_vertices(block_rotation, pos)
+	
+	# Add the vertices for the slope
 	verts.append_array(slope_vertices)
+	
+	# Add UV coordinates for each vertex
+	var uv_count = slope_vertices.size()
+	for _i in range(uv_count):
+		uvs.append_array(top_face_uv)
+	
+	# Add normals for each vertex
+	var normal = Vector3(0, 1, 0)  # Assuming a simple upward normal; adjust as needed
+	for _i in range(uv_count):
+		normals.append(normal)
+	
+	# Add indices for the top face and side faces
+	var base_index = verts.size() - uv_count
+	for i in range(0, uv_count, 3):
+		indices.append(base_index + i)
+		indices.append(base_index + i + 1)
+		indices.append(base_index + i + 2)
+
+
+func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array, uvs: PackedVector2Array, normals: PackedVector3Array, indices: PackedInt32Array, top_face_uv: PackedVector2Array):
+	var block_rotation = block_data.get("rotation", 0)
+	var slope_vertices = calculate_slope_vertices(block_rotation, pos)
+	
+	# Add the vertices for the slope
+	verts.append_array(slope_vertices)
+	
+	# Append the top face UV coordinates
 	uvs.append_array(top_face_uv)
-	add_slope_normals_and_indices(verts, normals, indices)
+	
+	# Append UV coordinates for the side faces (6 vertices)
+	var side_uvs = PackedVector2Array([
+		Vector2(0, 0), Vector2(1, 0), Vector2(0.5, 1),  # North face UVs
+		Vector2(0, 0), Vector2(1, 0), Vector2(0.5, 1)   # South face UVs
+	])
+	uvs.append_array(side_uvs)
+	
+	# Add normals for each vertex
+	var normal = Vector3(0, 1, 0)  # Assuming a simple upward normal; adjust as needed
+	for _i in range(slope_vertices.size()):
+		normals.append(normal)
+	
+	# Add indices for the top face and side faces
+	var base_index = verts.size() - slope_vertices.size()
+	indices.append_array([
+		base_index, base_index + 1, base_index + 2,  # Top face triangle 1
+		base_index, base_index + 2, base_index + 3,  # Top face triangle 2
+		base_index + 4, base_index + 5, base_index + 6,  # North face
+		base_index + 7, base_index + 8, base_index + 9   # South face
+	])
 
 
 # Function to calculate slope vertices

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -775,16 +775,16 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array
 func get_slope_side_normals(rotation: int) -> Array:
 	var side_normals = []
 	match rotation:
-		90:
-			side_normals.append(Vector3(0, 0, 1))  # West normal
+		90: # North
+			side_normals.append(Vector3(-1, 0, 0))  # West normal
 			side_normals.append(Vector3(1, 0, 0))   # East normal
-		180:
-			side_normals.append(Vector3(0, 0, 1))   # South normal
+		180: # West
 			side_normals.append(Vector3(0, 0, -1))  # North normal
-		270:
+			side_normals.append(Vector3(0, 0, 1))   # South normal
+		270: # South
 			side_normals.append(Vector3(1, 0, 0))   # East normal
 			side_normals.append(Vector3(-1, 0, 0))  # West normal
-		_:
+		_: # East
 			side_normals.append(Vector3(0, 0, -1))  # North normal
 			side_normals.append(Vector3(0, 0, 1))   # South normal
 	return side_normals
@@ -818,8 +818,9 @@ func get_slope_vertices_north(half_block: float, slopeposition: Vector3) -> Pack
 	
 	# West face vertices (triangle)
 	vertices.push_back(Vector3(-half_block, half_block, -half_block) + slopeposition) # Top north-west corner
-	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
 	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	
 	
 	# East face vertices (triangle)
 	vertices.push_back(Vector3(half_block, half_block, -half_block) + slopeposition) # Top north-east corner
@@ -840,10 +841,12 @@ func get_slope_vertices_west(half_block: float, slopeposition: Vector3) -> Packe
 	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition)
 	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition)
 	
+	
 	# North face vertices (triangle)
 	vertices.push_back(Vector3(-half_block, half_block, -half_block) + slopeposition) # Top north-west corner
-	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
 	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
+	
 	
 	# South face vertices (triangle)
 	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition) # Top south-west corner
@@ -869,10 +872,12 @@ func get_slope_vertices_south(half_block: float, slopeposition: Vector3) -> Pack
 	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
 	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
 	
+	
 	# West face vertices (triangle)
 	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition) # Top south-west corner
-	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
 	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	
 	
 	return vertices
 
@@ -892,10 +897,12 @@ func get_slope_vertices_east(half_block: float, slopeposition: Vector3) -> Packe
 	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
 	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
 	
+	
 	# South face vertices (triangle)
 	vertices.push_back(Vector3(half_block, half_block, half_block) + slopeposition) # Top south-east corner
-	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
 	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	
 	
 	return vertices
 

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -714,66 +714,74 @@ func find_blocks_at_y_level(y_level: int) -> Array:
 
 # Setup the slope mesh based on it's position and rotation.
 func setup_slope(pos: Vector3, block_data: Dictionary, verts, uvs, normals, indices, top_face_uv):
-	var block_rotation = block_data.get("rotation", 0)  # Ensure this retrieves the correct rotation
-
-	# Determine the correct vertices based on rotation
+	var block_rotation = block_data.get("rotation", 0)
 	var slope_vertices = calculate_slope_vertices(block_rotation, pos)
 	verts.append_array(slope_vertices)
-
-	# Apply the same UV mapping to all slopes for simplicity
 	uvs.append_array(top_face_uv)
-	
-	# Normals for the slope's top face
-	var normal = Vector3(0, 1, 0)
-	for _i in range(4):
-		normals.append(normal)
+	add_slope_normals_and_indices(verts, normals, indices)
 
-	# Define two triangles for the slope's top face
-	var base_index = verts.size() - slope_vertices.size()
-	indices.append_array([
-		base_index, base_index + 1, base_index + 2,  # Triangle 1
-		base_index, base_index + 2, base_index + 3   # Triangle 2
-	])
-
-
-# Helper function to calculate vertices based on slope direction
+# Function to calculate slope vertices
 func calculate_slope_vertices(sloperotation: int, slopeposition: Vector3) -> PackedVector3Array:
 	var half_block = 0.5
 	var vertices = PackedVector3Array()
 	match sloperotation:
 		90:
-			# Slope facing Facing north
-			vertices = PackedVector3Array([
-				Vector3(-half_block, half_block, -half_block) + slopeposition, # Top front left
-				Vector3(half_block, half_block, -half_block) + slopeposition,   # Top front right
-				Vector3(half_block, -half_block, half_block) + slopeposition,  # Bottom back right
-				Vector3(-half_block, -half_block, half_block) + slopeposition  # Bottom back left
-			])
+			vertices = get_slope_vertices_north(half_block, slopeposition)
 		180:
-			# Slope facing Facing west
-			vertices = PackedVector3Array([
-				Vector3(-half_block, half_block, half_block) + slopeposition, # Top front left
-				Vector3(-half_block, half_block, -half_block) + slopeposition,   # Top front right
-				Vector3(half_block, -half_block, -half_block) + slopeposition,  # Bottom back right
-				Vector3(half_block, -half_block, half_block) + slopeposition  # Bottom back left
-			])
+			vertices = get_slope_vertices_west(half_block, slopeposition)
 		270:
-			# Slope facing Facing south
-			vertices = PackedVector3Array([
-				Vector3(half_block, half_block, half_block) + slopeposition, # Top front left
-				Vector3(-half_block, half_block, half_block) + slopeposition,   # Top front right
-				Vector3(-half_block, -half_block, -half_block) + slopeposition,  # Bottom back right
-				Vector3(half_block, -half_block, -half_block) + slopeposition  # Bottom back left
-			])
+			vertices = get_slope_vertices_south(half_block, slopeposition)
 		_:
-			# Slope facing Facing east
-			vertices = PackedVector3Array([
-				Vector3(half_block, half_block, -half_block) + slopeposition, # Top front left
-				Vector3(half_block, half_block, half_block) + slopeposition,   # Top front right
-				Vector3(-half_block, -half_block, half_block) + slopeposition,  # Bottom back right
-				Vector3(-half_block, -half_block, -half_block) + slopeposition  # Bottom back left
-			])
+			vertices = get_slope_vertices_east(half_block, slopeposition)
 	return vertices
+
+# Function to get slope vertices facing north
+func get_slope_vertices_north(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
+	return PackedVector3Array([
+		Vector3(-half_block, half_block, -half_block) + slopeposition,
+		Vector3(half_block, half_block, -half_block) + slopeposition,
+		Vector3(half_block, -half_block, half_block) + slopeposition,
+		Vector3(-half_block, -half_block, half_block) + slopeposition
+	])
+
+# Function to get slope vertices facing west
+func get_slope_vertices_west(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
+	return PackedVector3Array([
+		Vector3(-half_block, half_block, half_block) + slopeposition,
+		Vector3(-half_block, half_block, -half_block) + slopeposition,
+		Vector3(half_block, -half_block, -half_block) + slopeposition,
+		Vector3(half_block, -half_block, half_block) + slopeposition
+	])
+
+# Function to get slope vertices facing south
+func get_slope_vertices_south(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
+	return PackedVector3Array([
+		Vector3(half_block, half_block, half_block) + slopeposition,
+		Vector3(-half_block, half_block, half_block) + slopeposition,
+		Vector3(-half_block, -half_block, -half_block) + slopeposition,
+		Vector3(half_block, -half_block, -half_block) + slopeposition
+	])
+
+# Function to get slope vertices facing east
+func get_slope_vertices_east(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
+	return PackedVector3Array([
+		Vector3(half_block, half_block, -half_block) + slopeposition,
+		Vector3(half_block, half_block, half_block) + slopeposition,
+		Vector3(-half_block, -half_block, half_block) + slopeposition,
+		Vector3(-half_block, -half_block, -half_block) + slopeposition
+	])
+
+# Function to add normals and indices for slopes
+func add_slope_normals_and_indices(verts, normals, indices):
+	var normal = Vector3(0, 1, 0)
+	for _i in range(4):
+		normals.append(normal)
+	var base_index = verts.size() - 4
+	indices.append_array([
+		base_index, base_index + 1, base_index + 2,
+		base_index, base_index + 2, base_index + 3
+	])
+
 
 
 # Coroutine for creating colliders with non-blocking delays

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -711,31 +711,8 @@ func find_blocks_at_y_level(y_level: int) -> Array:
 			})
 	return blocks_at_same_y
 
-func setup_slope1(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array, uvs: PackedVector2Array, normals: PackedVector3Array, indices: PackedInt32Array, top_face_uv: PackedVector2Array):
-	var block_rotation = block_data.get("rotation", 0)
-	var slope_vertices = calculate_slope_vertices(block_rotation, pos)
-	
-	# Add the vertices for the slope
-	verts.append_array(slope_vertices)
-	
-	# Add UV coordinates for each vertex
-	var uv_count = slope_vertices.size()
-	for _i in range(uv_count):
-		uvs.append_array(top_face_uv)
-	
-	# Add normals for each vertex
-	var normal = Vector3(0, 1, 0)  # Assuming a simple upward normal; adjust as needed
-	for _i in range(uv_count):
-		normals.append(normal)
-	
-	# Add indices for the top face and side faces
-	var base_index = verts.size() - uv_count
-	for i in range(0, uv_count, 3):
-		indices.append(base_index + i)
-		indices.append(base_index + i + 1)
-		indices.append(base_index + i + 2)
 
-
+# Collects vertices, uvs, normals and indices for a slope based on it's position and rotation
 func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array, uvs: PackedVector2Array, normals: PackedVector3Array, indices: PackedInt32Array, top_face_uv: PackedVector2Array):
 	var block_rotation = block_data.get("rotation", 0)
 	var slope_vertices = calculate_slope_vertices(block_rotation, pos)
@@ -772,6 +749,8 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array
 		base_index + 7, base_index + 8, base_index + 9   # South face
 	])
 
+
+# Gets the normals of the sides of the slope, based on rotation
 func get_slope_side_normals(rotation: int) -> Array:
 	var side_normals = []
 	match rotation:
@@ -806,7 +785,7 @@ func calculate_slope_vertices(sloperotation: int, slopeposition: Vector3) -> Pac
 	return vertices
 
 
-# Function to get slope vertices facing north, west, and east
+# Function to get slope vertices facing north
 func get_slope_vertices_north(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
 	var vertices = PackedVector3Array()
 	
@@ -856,7 +835,6 @@ func get_slope_vertices_west(half_block: float, slopeposition: Vector3) -> Packe
 	return vertices
 
 
-
 # Function to get slope vertices facing south
 func get_slope_vertices_south(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
 	var vertices = PackedVector3Array()
@@ -877,7 +855,6 @@ func get_slope_vertices_south(half_block: float, slopeposition: Vector3) -> Pack
 	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition) # Top south-west corner
 	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
 	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
-	
 	
 	return vertices
 
@@ -903,8 +880,8 @@ func get_slope_vertices_east(half_block: float, slopeposition: Vector3) -> Packe
 	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
 	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
 	
-	
 	return vertices
+
 
 # Function to add normals and indices for slopes
 func add_slope_normals_and_indices(verts, normals, indices):
@@ -916,7 +893,6 @@ func add_slope_normals_and_indices(verts, normals, indices):
 		base_index, base_index + 1, base_index + 2,
 		base_index, base_index + 2, base_index + 3
 	])
-
 
 
 # Coroutine for creating colliders with non-blocking delays

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -720,6 +720,7 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts, uvs, normals, indi
 	uvs.append_array(top_face_uv)
 	add_slope_normals_and_indices(verts, normals, indices)
 
+
 # Function to calculate slope vertices
 func calculate_slope_vertices(sloperotation: int, slopeposition: Vector3) -> PackedVector3Array:
 	var half_block = 0.5
@@ -735,41 +736,99 @@ func calculate_slope_vertices(sloperotation: int, slopeposition: Vector3) -> Pac
 			vertices = get_slope_vertices_east(half_block, slopeposition)
 	return vertices
 
-# Function to get slope vertices facing north
+
+# Function to get slope vertices facing north, west, and east
 func get_slope_vertices_north(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
-	return PackedVector3Array([
-		Vector3(-half_block, half_block, -half_block) + slopeposition,
-		Vector3(half_block, half_block, -half_block) + slopeposition,
-		Vector3(half_block, -half_block, half_block) + slopeposition,
-		Vector3(-half_block, -half_block, half_block) + slopeposition
-	])
+	var vertices = PackedVector3Array()
+	
+	# Top face vertices
+	vertices.push_back(Vector3(-half_block, half_block, -half_block) + slopeposition)
+	vertices.push_back(Vector3(half_block, half_block, -half_block) + slopeposition)
+	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition)
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition)
+	
+	# West face vertices (triangle)
+	vertices.push_back(Vector3(-half_block, half_block, -half_block) + slopeposition) # Top north-west corner
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	
+	# East face vertices (triangle)
+	vertices.push_back(Vector3(half_block, half_block, -half_block) + slopeposition) # Top north-east corner
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
+	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
+	
+	return vertices
+
+
 
 # Function to get slope vertices facing west
 func get_slope_vertices_west(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
-	return PackedVector3Array([
-		Vector3(-half_block, half_block, half_block) + slopeposition,
-		Vector3(-half_block, half_block, -half_block) + slopeposition,
-		Vector3(half_block, -half_block, -half_block) + slopeposition,
-		Vector3(half_block, -half_block, half_block) + slopeposition
-	])
+	var vertices = PackedVector3Array()
+	
+	# Top face vertices
+	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition)
+	vertices.push_back(Vector3(-half_block, half_block, -half_block) + slopeposition)
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition)
+	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition)
+	
+	# North face vertices (triangle)
+	vertices.push_back(Vector3(-half_block, half_block, -half_block) + slopeposition) # Top north-west corner
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	
+	# South face vertices (triangle)
+	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition) # Top south-west corner
+	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	
+	return vertices
+
+
 
 # Function to get slope vertices facing south
 func get_slope_vertices_south(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
-	return PackedVector3Array([
-		Vector3(half_block, half_block, half_block) + slopeposition,
-		Vector3(-half_block, half_block, half_block) + slopeposition,
-		Vector3(-half_block, -half_block, -half_block) + slopeposition,
-		Vector3(half_block, -half_block, -half_block) + slopeposition
-	])
+	var vertices = PackedVector3Array()
+	
+	# Top face vertices
+	vertices.push_back(Vector3(half_block, half_block, half_block) + slopeposition)
+	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition)
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition)
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition)
+	
+	# East face vertices (triangle)
+	vertices.push_back(Vector3(half_block, half_block, half_block) + slopeposition) # Top south-east corner
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
+	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
+	
+	# West face vertices (triangle)
+	vertices.push_back(Vector3(-half_block, half_block, half_block) + slopeposition) # Top south-west corner
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	
+	return vertices
+
 
 # Function to get slope vertices facing east
 func get_slope_vertices_east(half_block: float, slopeposition: Vector3) -> PackedVector3Array:
-	return PackedVector3Array([
-		Vector3(half_block, half_block, -half_block) + slopeposition,
-		Vector3(half_block, half_block, half_block) + slopeposition,
-		Vector3(-half_block, -half_block, half_block) + slopeposition,
-		Vector3(-half_block, -half_block, -half_block) + slopeposition
-	])
+	var vertices = PackedVector3Array()
+	
+	# Top face vertices
+	vertices.push_back(Vector3(half_block, half_block, -half_block) + slopeposition)
+	vertices.push_back(Vector3(half_block, half_block, half_block) + slopeposition)
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition)
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition)
+	
+	# North face vertices (triangle)
+	vertices.push_back(Vector3(half_block, half_block, -half_block) + slopeposition) # Top north-east corner
+	vertices.push_back(Vector3(-half_block, -half_block, -half_block) + slopeposition) # Bottom north-west corner
+	vertices.push_back(Vector3(half_block, -half_block, -half_block) + slopeposition) # Bottom north-east corner
+	
+	# South face vertices (triangle)
+	vertices.push_back(Vector3(half_block, half_block, half_block) + slopeposition) # Top south-east corner
+	vertices.push_back(Vector3(-half_block, -half_block, half_block) + slopeposition) # Bottom south-west corner
+	vertices.push_back(Vector3(half_block, -half_block, half_block) + slopeposition) # Bottom south-east corner
+	
+	return vertices
 
 # Function to add normals and indices for slopes
 func add_slope_normals_and_indices(verts, normals, indices):
@@ -1038,8 +1097,6 @@ func setup_cube(pos: Vector3, block_data: Dictionary, verts, uvs, normals, indic
 
 	# Always process the top face as it's never excluded
 	process_face("top", pos, block_data, verts, uvs, normals, indices, top_face_uv)
-
-
 
 
 func process_face(direction: String, pos: Vector3, block_data: Dictionary, verts, uvs, normals, indices, top_face_uv):

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -747,16 +747,21 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array
 	uvs.append_array(top_face_uv)
 	
 	# Append UV coordinates for the side faces (6 vertices)
+	# The UV coordinates are not quire right but close enough
 	var side_uvs = PackedVector2Array([
-		Vector2(0, 0), Vector2(1, 0), Vector2(0.5, 1),  # North face UVs
-		Vector2(0, 0), Vector2(1, 0), Vector2(0.5, 1)   # South face UVs
+		top_face_uv[0], top_face_uv[1], top_face_uv[2],  # North face UVs
+		top_face_uv[0], top_face_uv[1], top_face_uv[2]   # South face UVs
 	])
 	uvs.append_array(side_uvs)
 	
 	# Add normals for each vertex
-	var normal = Vector3(0, 1, 0)  # Assuming a simple upward normal; adjust as needed
-	for _i in range(slope_vertices.size()):
-		normals.append(normal)
+	var top_normal = Vector3(0, 1, 0)
+	var side_normals = get_slope_side_normals(block_rotation)
+	normals.append_array([
+		top_normal, top_normal, top_normal, top_normal,  # Top face normals
+		side_normals[0], side_normals[0], side_normals[0],  # First side face normals
+		side_normals[1], side_normals[1], side_normals[1]   # Second side face normals
+	])
 	
 	# Add indices for the top face and side faces
 	var base_index = verts.size() - slope_vertices.size()
@@ -766,6 +771,23 @@ func setup_slope(pos: Vector3, block_data: Dictionary, verts: PackedVector3Array
 		base_index + 4, base_index + 5, base_index + 6,  # North face
 		base_index + 7, base_index + 8, base_index + 9   # South face
 	])
+
+func get_slope_side_normals(rotation: int) -> Array:
+	var side_normals = []
+	match rotation:
+		90:
+			side_normals.append(Vector3(0, 0, 1))  # West normal
+			side_normals.append(Vector3(1, 0, 0))   # East normal
+		180:
+			side_normals.append(Vector3(0, 0, 1))   # South normal
+			side_normals.append(Vector3(0, 0, -1))  # North normal
+		270:
+			side_normals.append(Vector3(1, 0, 0))   # East normal
+			side_normals.append(Vector3(-1, 0, 0))  # West normal
+		_:
+			side_normals.append(Vector3(0, 0, -1))  # North normal
+			side_normals.append(Vector3(0, 0, 1))   # South normal
+	return side_normals
 
 
 # Function to calculate slope vertices


### PR DESCRIPTION
Fixes #165 

Slopes now have visible sides. The texture is visible and the lighting is okay. 
I only did the side faces because the front face will rest against a block almost always, at least until we can construct slopes and break blocks.
The only problem is the UV coordinates. Some line up pretty well but other sides show the texture in the wrong direction, leading to a distorted view. Still, it's not very noticeable so it will do for now. 


![image](https://github.com/Khaligufzel/CataX/assets/50166150/dca734d8-ca95-42d9-adac-649755defadc)
