### PR TITLE
Add tacticalmap brush label

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/EntitiesContainer.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/EntitiesContainer.gd
@@ -15,7 +15,7 @@ func _ready():
 	loadMaps()
 
 
-# this function will read all files in Gamedata.data.tiles.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
+# this function will read all files in Gamedata.data.maps.data and creates tilebrushes for each tile in the list. 
 func loadMaps():
 	var mapsList: Array = Gamedata.data.maps.data
 	var newTilesList: Control = scrolling_Flow_Container.instantiate()
@@ -31,6 +31,7 @@ func loadMaps():
 			if mySprite:
 				# Create a TextureRect node
 				var brushInstance = tileBrush.instantiate()
+				brushInstance.set_label(base_name)
 				# Assign the texture to the TextureRect
 				brushInstance.set_tile_texture(mySprite)
 				# Since the map editor needs to knw what tile ID is used,

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
@@ -4,17 +4,31 @@ signal tilebrush_clicked(clicked_tile: Control)
 var mapID: String = ""
 var selected: bool = false
 var entityType: String = "tile"
+@export var tile_sprite: TextureRect
+@export var label: Label
+
+
+# Update the label size based on text and ensure tile_sprite resizes accordingly
+func _ready():
+	label.minimum_size_changed.connect(_on_label_minimum_size_changed)
+	# Ensure there is enough horizontal spacing between tile brushes
+	offset_left = 10
+	offset_left = 10
+
 
 #When the event was a left mouse button press, adjust the modulate property of the $TileSprite to be 3aa2c1
 func _on_texture_rect_gui_input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		tilebrush_clicked.emit(self)
 
+
 func set_tile_texture(res: Resource) -> void:
-	$TileSprite.texture = res
+	tile_sprite.texture = res
+
 
 func get_texture() -> Resource:
-	return $TileSprite.texture
+	return tile_sprite.texture
+
 
 #Mark the clicked tilebrush as selected
 func set_selected(is_selected: bool) -> void:
@@ -23,3 +37,57 @@ func set_selected(is_selected: bool) -> void:
 		modulate = Color(0.227, 0.635, 0.757)
 	else:
 		modulate = Color(1,1,1)
+
+
+# Update the minimum size of the parent container
+func update_label_minimum_size():
+	var total_height = 64 + label.custom_minimum_size.y
+	custom_minimum_size = Vector2(custom_minimum_size.x, total_height)
+
+
+
+# Set the label text and adjust the size of the label and the tile sprite accordingly
+func set_label(text: String):
+	label.text = text
+	label.custom_minimum_size = Vector2(64, 12)  # Ensure the label has a minimum size of 64x12
+
+	# Resize the label to fit its text within 64 pixels width by wrapping text and/or reducing font size
+	#var font_size = label.font_size
+	var font_size = label.get_theme_font_size("font_size")
+	while label.get_minimum_size().x > 64 and font_size > 1:
+		font_size -= 1
+		label.add_theme_font_override("font", FontFile.new())
+		label.add_theme_font_size_override("font", font_size)
+
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART  # Enable word wrapping
+	label.size_flags_horizontal = Control.SIZE_FILL
+	label.size_flags_vertical = Control.SIZE_SHRINK_END
+	label.custom_minimum_size = Vector2(64, label.get_minimum_size().y)  # Ensure the height remains
+
+	# Adjust the size of the tile sprite to fit the label if needed
+	var label_width = label.get_minimum_size().x
+	if label_width > 64:
+		tile_sprite.custom_minimum_size = Vector2(label_width, 64)
+	else:
+		tile_sprite.custom_minimum_size = Vector2(64, 64)
+
+	# Update the minimum size of the parent container
+	update_minimum_size()
+
+
+func _on_label_minimum_size_changed():
+	# Adjust the tile_sprite size based on the label's new size
+	var label_width = label.custom_minimum_size.x
+	if label_width > 64:
+		tile_sprite.custom_minimum_size = Vector2(label_width, 64)
+	else:
+		tile_sprite.custom_minimum_size = Vector2(64, 64)
+
+	# Update the minimum size of the parent container
+	update_min_size()
+
+
+# Update the minimum size of the parent container
+func update_min_size():
+	var total_height = 64 + label.custom_minimum_size.y
+	custom_minimum_size = Vector2(custom_minimum_size.x, total_height)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
@@ -7,13 +7,9 @@ var entityType: String = "tile"
 @export var tile_sprite: TextureRect
 @export var label: Label
 
-
 # Update the label size based on text and ensure tile_sprite resizes accordingly
 func _ready():
 	label.minimum_size_changed.connect(_on_label_minimum_size_changed)
-	# Ensure there is enough horizontal spacing between tile brushes
-	offset_left = 10
-	offset_left = 10
 
 
 #When the event was a left mouse button press, adjust the modulate property of the $TileSprite to be 3aa2c1
@@ -39,50 +35,21 @@ func set_selected(is_selected: bool) -> void:
 		modulate = Color(1,1,1)
 
 
-# Update the minimum size of the parent container
-func update_label_minimum_size():
-	var total_height = 64 + label.custom_minimum_size.y
-	custom_minimum_size = Vector2(custom_minimum_size.x, total_height)
-
-
-
 # Set the label text and adjust the size of the label and the tile sprite accordingly
 func set_label(text: String):
 	label.text = text
-	label.custom_minimum_size = Vector2(64, 12)  # Ensure the label has a minimum size of 64x12
-
-	# Resize the label to fit its text within 64 pixels width by wrapping text and/or reducing font size
-	#var font_size = label.font_size
-	var font_size = label.get_theme_font_size("font_size")
-	while label.get_minimum_size().x > 64 and font_size > 1:
-		font_size -= 1
-		label.add_theme_font_override("font", FontFile.new())
-		label.add_theme_font_size_override("font", font_size)
+	label.custom_minimum_size = Vector2(64, 12)
 
 	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART  # Enable word wrapping
 	label.size_flags_horizontal = Control.SIZE_FILL
 	label.size_flags_vertical = Control.SIZE_SHRINK_END
-	label.custom_minimum_size = Vector2(64, label.get_minimum_size().y)  # Ensure the height remains
-
-	# Adjust the size of the tile sprite to fit the label if needed
-	var label_width = label.get_minimum_size().x
-	if label_width > 64:
-		tile_sprite.custom_minimum_size = Vector2(label_width, 64)
-	else:
-		tile_sprite.custom_minimum_size = Vector2(64, 64)
+	label.custom_minimum_size = Vector2(64, label.get_minimum_size().y)
 
 	# Update the minimum size of the parent container
-	update_minimum_size()
+	update_min_size()
 
 
 func _on_label_minimum_size_changed():
-	# Adjust the tile_sprite size based on the label's new size
-	var label_width = label.custom_minimum_size.x
-	if label_width > 64:
-		tile_sprite.custom_minimum_size = Vector2(label_width, 64)
-	else:
-		tile_sprite.custom_minimum_size = Vector2(64, 64)
-
 	# Update the minimum size of the parent container
 	update_min_size()
 
@@ -90,4 +57,4 @@ func _on_label_minimum_size_changed():
 # Update the minimum size of the parent container
 func update_min_size():
 	var total_height = 64 + label.custom_minimum_size.y
-	custom_minimum_size = Vector2(custom_minimum_size.x, total_height)
+	custom_minimum_size = Vector2(custom_minimum_size.x, total_height+20)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
@@ -4,6 +4,7 @@ signal tilebrush_clicked(clicked_tile: Control)
 var mapID: String = ""
 var selected: bool = false
 var entityType: String = "tile"
+const DEFAULT_WIDTH = 64
 @export var tile_sprite: TextureRect
 @export var label: Label
 
@@ -38,12 +39,12 @@ func set_selected(is_selected: bool) -> void:
 # Set the label text and adjust the size of the label and the tile sprite accordingly
 func set_label(text: String):
 	label.text = text
-	label.custom_minimum_size = Vector2(64, 12)
+	label.custom_minimum_size = Vector2(DEFAULT_WIDTH, 12)
 
 	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART  # Enable word wrapping
 	label.size_flags_horizontal = Control.SIZE_FILL
 	label.size_flags_vertical = Control.SIZE_SHRINK_END
-	label.custom_minimum_size = Vector2(64, label.get_minimum_size().y)
+	label.custom_minimum_size = Vector2(DEFAULT_WIDTH, label.get_minimum_size().y)
 
 	# Update the minimum size of the parent container
 	update_min_size()
@@ -56,5 +57,7 @@ func _on_label_minimum_size_changed():
 
 # Update the minimum size of the parent container
 func update_min_size():
-	var total_height = 64 + label.custom_minimum_size.y
+	var total_height = DEFAULT_WIDTH + label.custom_minimum_size.y
+	# Because the text might wrap around to the next line, we add 20 height to accommodate
+	# that. If the label text does not wrap around, the 20 height will be empty space
 	custom_minimum_size = Vector2(custom_minimum_size.x, total_height+20)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd
@@ -5,6 +5,7 @@ var mapID: String = ""
 var selected: bool = false
 var entityType: String = "tile"
 const DEFAULT_WIDTH = 64
+const LINE_HEIGHT = 20
 @export var tile_sprite: TextureRect
 @export var label: Label
 
@@ -58,6 +59,6 @@ func _on_label_minimum_size_changed():
 # Update the minimum size of the parent container
 func update_min_size():
 	var total_height = DEFAULT_WIDTH + label.custom_minimum_size.y
-	# Because the text might wrap around to the next line, we add 20 height to accommodate
-	# that. If the label text does not wrap around, the 20 height will be empty space
-	custom_minimum_size = Vector2(custom_minimum_size.x, total_height+20)
+	# Because the text might wrap around to the next line, we add LINE_HEIGHT to accommodate
+	# that. If the label text does not wrap around, the LINE_HEIGHT will be empty space below the text.
+	custom_minimum_size = Vector2(custom_minimum_size.x, total_height+LINE_HEIGHT)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditorTileBrush.tscn
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditorTileBrush.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTileBrush.gd" id="1_6xcxx"]
 [ext_resource type="Texture2D" uid="uid://c31w0wuk8qabw" path="res://Defaults/Sprites/2.png" id="2_82c4q"]
 
-[node name="TacticalMapEditorTileBrush" type="Control"]
+[node name="TacticalMapEditorTileBrush" type="Control" node_paths=PackedStringArray("tile_sprite", "label")]
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 3
 anchors_preset = 15
@@ -12,13 +12,25 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_6xcxx")
+tile_sprite = NodePath("VBoxContainer/TileSprite")
+label = NodePath("VBoxContainer/Label")
 
-[node name="TileSprite" type="TextureRect" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
-texture = ExtResource("2_82c4q")
-expand_mode = 3
 
-[connection signal="gui_input" from="TileSprite" to="." method="_on_texture_rect_gui_input"]
+[node name="TileSprite" type="TextureRect" parent="VBoxContainer"]
+custom_minimum_size = Vector2(64, 64)
+layout_mode = 2
+texture = ExtResource("2_82c4q")
+expand_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+custom_minimum_size = Vector2(64, 10)
+layout_mode = 2
+theme_override_font_sizes/font_size = 10
+autowrap_mode = 3
+
+[connection signal="gui_input" from="VBoxContainer/TileSprite" to="." method="_on_texture_rect_gui_input"]

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditorTileBrush.tscn
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditorTileBrush.tscn
@@ -30,7 +30,7 @@ expand_mode = 2
 [node name="Label" type="Label" parent="VBoxContainer"]
 custom_minimum_size = Vector2(64, 10)
 layout_mode = 2
-theme_override_font_sizes/font_size = 10
+theme_override_font_sizes/font_size = 14
 autowrap_mode = 3
 
 [connection signal="gui_input" from="VBoxContainer/TileSprite" to="." method="_on_texture_rect_gui_input"]


### PR DESCRIPTION
Fixes #159 

Adds labels to the brushes in the tacticalmapeditor. I fiddled with the size and font size a bit and settled on this. I want it to imitate the file explorer when you set the view to icons. It will wrap the file name below the file icon. Right now the height is set at a fixed two lines of text, even if there are more or less lines of text. 

![image](https://github.com/Khaligufzel/CataX/assets/50166150/29688ff8-b21f-4269-9e00-f9993796b8c5)
