### PR TITLE
Fix startup when no load file is provided

### DIFF
--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -23,7 +23,11 @@ signal change_level_pressed()
 func _ready():
 	var gameFileJson: Dictionary = Helper.json_helper.load_json_dictionary_file(\
 	Helper.save_helper.current_save_folder + "/game.json")
-	noise.seed = gameFileJson.mapseed
+	if gameFileJson:
+		noise.seed = gameFileJson.mapseed
+	else:
+		var rng = RandomNumberGenerator.new()
+		noise.seed = rng.randi()
 	noise.fractal_octaves = 5
 	noise.fractal_gain = 0.5
 	noise.frequency = 0.04

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -79,7 +79,7 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 	var target_folder = current_save_folder+ "/" + map_folder
 	# For example, the target_folder could be: "C:\Users\User\AppData\Roaming\Godot\app_userdata\
 	# CataX\save\2024-01-08T202236\map_x0_y0"
-	if dir.dir_exists(map_folder):
+	if dir and dir.dir_exists(map_folder):
 		return target_folder
 	return ""
 

--- a/Scripts/scene_selector.gd
+++ b/Scripts/scene_selector.gd
@@ -1,9 +1,14 @@
 extends Control
 
 var saved_game_folders : Array
+@onready var load_game_button = $LoadGameButton
 @export var load_game_list : OptionButton 
 func _ready():
 	saved_game_folders = Helper.json_helper.folder_names_in_dir("user://save/")
+	if saved_game_folders.is_empty():
+		return
+
+	load_game_button.disabled = false
 	# Reverse the order of the saved_game_folders array
 	saved_game_folders.reverse()
 
@@ -13,11 +18,11 @@ func _ready():
 
 func _on_load_game_button_pressed():
 	var selected_game_id = load_game_list.get_selected_id()
-	try_load_game(selected_game_id)
-	# We pass the name of the default map and coordinates
-	# If there is a saved game, it will not load the provided map
-	# but rather the one that was saved in the game that was loaded
-	Helper.switch_level("DefaultTacticalMap.json", Vector2(0, 0))
+	if try_load_game(selected_game_id):
+		# We pass the name of the default map and coordinates
+		# If there is a saved game, it will not load the provided map
+		# but rather the one that was saved in the game that was loaded
+		Helper.switch_level("DefaultTacticalMap.json", Vector2(0, 0))
 
 # When the play demo button is pressed
 # Create a new folder in the user directory
@@ -33,13 +38,14 @@ func _on_help_button_pressed():
 func _on_content_manager_button_button_up():
 	get_tree().change_scene_to_file("res://Scenes/ContentManager/contentmanager.tscn")
 
-func try_load_game(selected_id):
+func try_load_game(selected_id: int) -> bool:
 	if selected_id < 0 or selected_id >= saved_game_folders.size():
-		print("Loading skipped: selected game ID(%d) is out of saved_game_folders range." % selected_id)
-		return
+		push_error("Loading failed: selected game ID(%d) is out of saved_game_folders range." % selected_id)
+		return false
 	var selected_game_folder = saved_game_folders[selected_id]
 	Helper.save_helper.load_game_from_folder(selected_game_folder)
 	Helper.save_helper.load_overmap_state()
 	Helper.save_helper.load_player_inventory()
 	Helper.save_helper.load_player_equipment()
+	return true
 

--- a/Scripts/scene_selector.gd
+++ b/Scripts/scene_selector.gd
@@ -12,11 +12,8 @@ func _ready():
 		load_game_list.add_item(saved_game)
 
 func _on_load_game_button_pressed():
-	var selected_game_folder = saved_game_folders[load_game_list.get_selected_id()]
-	Helper.save_helper.load_game_from_folder(selected_game_folder)
-	Helper.save_helper.load_overmap_state()
-	Helper.save_helper.load_player_inventory()
-	Helper.save_helper.load_player_equipment()
+	var selected_game_id = load_game_list.get_selected_id()
+	try_load_game(selected_game_id)
 	# We pass the name of the default map and coordinates
 	# If there is a saved game, it will not load the provided map
 	# but rather the one that was saved in the game that was loaded
@@ -35,3 +32,14 @@ func _on_help_button_pressed():
 
 func _on_content_manager_button_button_up():
 	get_tree().change_scene_to_file("res://Scenes/ContentManager/contentmanager.tscn")
+
+func try_load_game(selected_id):
+	if selected_id < 0 or selected_id >= saved_game_folders.size():
+		print("Loading skipped: selected game ID(%d) is out of saved_game_folders range." % selected_id)
+		return
+	var selected_game_folder = saved_game_folders[selected_id]
+	Helper.save_helper.load_game_from_folder(selected_game_folder)
+	Helper.save_helper.load_overmap_state()
+	Helper.save_helper.load_player_inventory()
+	Helper.save_helper.load_player_equipment()
+

--- a/scene_selector.tscn
+++ b/scene_selector.tscn
@@ -30,6 +30,7 @@ offset_right = 453.0
 offset_bottom = 457.0
 theme_override_fonts/font = ExtResource("1_sue5h")
 theme_override_font_sizes/font_size = 25
+disabled = true
 text = "Load game ---->>>"
 
 [node name="LoadGameList" type="OptionButton" parent="."]


### PR DESCRIPTION
`Load game ---->>>` button doesn't work out of the box. This pull request adds validation for `selected_game_id` and sets random `noise_seed` in case the `map_folder` doesn't exist. 