### PR TITLE
Custom tile brush composer for the mapeditor

### DIFF
--- a/Scenes/ContentManager/Custom_Widgets/Scripts/Scrolling_Flow_Container.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/Scrolling_Flow_Container.gd
@@ -36,5 +36,11 @@ func add_content_item(item: Node):
 	contentItems.add_child(item)
 
 
+func remove_content_item(item: Node):
+	if contentItems.has_node(item.get_path()):
+		contentItems.remove_child(item)
+		item.queue_free()
+
+
 func get_content_items() -> Array[Node]:
 	return contentItems.get_children()

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -431,6 +431,7 @@ func paint_in_rectangle():
 				tile.set_default()
 	elif selected_brush:
 		for tile in tiles:
+			selected_brush = brushcomposer.get_random_brush()
 			if selected_brush.entityType == "mob":
 				tile.set_mob_id(selected_brush.tileID)
 			elif selected_brush.entityType == "furniture":

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -247,15 +247,16 @@ func paint_single_tile(clicked_tile) -> void:
 			clicked_tile.set_default()
 	elif selected_brush:
 		selected_brush = brushcomposer.get_random_brush()
+		var tilerotation = brushcomposer.get_tilerotation(rotationAmount)
 		if selected_brush.entityType == "mob":
 			clicked_tile.set_mob_id(selected_brush.tileID)
-			clicked_tile.set_mob_rotation(rotationAmount)
+			clicked_tile.set_mob_rotation(tilerotation)
 		elif selected_brush.entityType == "furniture":
 			clicked_tile.set_furniture_id(selected_brush.tileID)
-			clicked_tile.set_furniture_rotation(rotationAmount)
+			clicked_tile.set_furniture_rotation(tilerotation)
 		else:
 			clicked_tile.set_tile_id(selected_brush.tileID)
-			clicked_tile.set_rotation_amount(rotationAmount)
+			clicked_tile.set_rotation_amount(tilerotation)
 
 
 func storeLevelData() -> void:
@@ -432,13 +433,14 @@ func paint_in_rectangle():
 	elif selected_brush:
 		for tile in tiles:
 			selected_brush = brushcomposer.get_random_brush()
+			var tilerotation = brushcomposer.get_tilerotation(rotationAmount)
 			if selected_brush.entityType == "mob":
 				tile.set_mob_id(selected_brush.tileID)
 			elif selected_brush.entityType == "furniture":
 				tile.set_furniture_id(selected_brush.tileID)
 			else:
 				tile.set_tile_id(selected_brush.tileID)
-				tile.set_rotation_amount(rotationAmount)
+				tile.set_rotation_amount(tilerotation)
 	update_rectangle()
 
 #The user has pressed the erase toggle button in the editor
@@ -489,7 +491,7 @@ func _on_copy_rectangle_toggled(toggled_on: bool) -> void:
 		checkboxCopyAllLevels.set_pressed(false)
 		currentMode = EditorMode.COPY_RECTANGLE
 		if copied_tiles_info["tiles_data"].size() > 0:
-			# You might want to update the brush preview to reflect the copied tiles
+			# Update the brush preview to reflect the copied tiles
 			update_preview_texture_with_copied_data()
 		# If there's nothing to copy, perhaps alert the user
 		else:
@@ -506,7 +508,8 @@ func _on_tilebrush_list_tile_brush_selection_change(tilebrush: Control):
 	# Toggle the copy buttons off
 	checkboxCopyRectangle.set_pressed(false)
 	checkboxCopyAllLevels.set_pressed(false)
-	currentMode = EditorMode.NONE
+	if not currentMode == EditorMode.DRAW_RECTANGLE:
+		currentMode = EditorMode.NONE
 	# Add the brush if ctrl is held, otherwise replace all
 	if Input.is_key_pressed(KEY_CTRL):
 		brushcomposer.add_tilebrush_to_container(tilebrush)
@@ -1023,4 +1026,6 @@ func _on_composer_brush_added(composerbrush: Control):
 func _on_composer_brush_removed(_composerbrush: Control):
 	if brushcomposer.is_empty():
 		selected_brush = null
-		update_preview_texture()
+	else:
+		selected_brush = brushcomposer.get_random_brush()
+	update_preview_texture()

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -234,29 +234,35 @@ func grid_tile_clicked(clicked_tile) -> void:
 # We paint a single tile if draw rectangle is not selected
 # Either erase the tile or paint it if a brush is selected.
 func paint_single_tile(clicked_tile) -> void:
+	apply_paint_to_tile(clicked_tile, selected_brush, rotationAmount, erase)
+
+
+# Helper function to apply paint or erase logic to a single tile
+func apply_paint_to_tile(tile: Control, brush: Control, tilerotate: int, erase: bool):
 	if erase:
-		if selected_brush:
-			if selected_brush.entityType == "mob":
-				clicked_tile.set_mob_id("")
-			elif selected_brush.entityType == "furniture":
-				clicked_tile.set_furniture_id("")
+		if brush:
+			if brush.entityType == "mob":
+				tile.set_mob_id("")
+			elif brush.entityType == "furniture":
+				tile.set_furniture_id("")
 			else:
-				clicked_tile.set_tile_id("")
-				clicked_tile.set_rotation_amount(0)
+				tile.set_tile_id("")
+				tile.set_rotation_amount(0)
 		else:
-			clicked_tile.set_default()
-	elif selected_brush:
+			tile.set_default()
+	elif brush:
 		selected_brush = brushcomposer.get_random_brush()
-		var tilerotation = brushcomposer.get_tilerotation(rotationAmount)
-		if selected_brush.entityType == "mob":
-			clicked_tile.set_mob_id(selected_brush.tileID)
-			clicked_tile.set_mob_rotation(tilerotation)
-		elif selected_brush.entityType == "furniture":
-			clicked_tile.set_furniture_id(selected_brush.tileID)
-			clicked_tile.set_furniture_rotation(tilerotation)
+		var tilerotation = brushcomposer.get_tilerotation(tilerotate)
+		if brush.entityType == "mob":
+			tile.set_mob_id(brush.tileID)
+			tile.set_mob_rotation(tilerotation)
+		elif brush.entityType == "furniture":
+			tile.set_furniture_id(brush.tileID)
+			tile.set_furniture_rotation(tilerotation)
 		else:
-			clicked_tile.set_tile_id(selected_brush.tileID)
-			clicked_tile.set_rotation_amount(tilerotation)
+			tile.set_tile_id(brush.tileID)
+			tile.set_rotation_amount(tilerotation)
+
 
 
 func storeLevelData() -> void:
@@ -413,35 +419,15 @@ func highlight_tiles_in_rect() -> void:
 		tile.highlight()
 
 
-#Paint every tile in the selected rectangle
-#We always erase if erase is selected, even if no brush is selected
-#Only paint if a brush is selected and erase is false
+# Paint every tile in the selected rectangle
+# We always erase if erase is selected, even if no brush is selected
+# Only paint if a brush is selected and erase is false
 func paint_in_rectangle():
 	var tiles: Array = get_tiles_in_rectangle(start_point, end_point)
-	if erase:
-		for tile in tiles:
-			if selected_brush:
-				if selected_brush.entityType == "mob":
-					tile.set_mob_id("")
-				elif selected_brush.entityType == "furniture":
-					tile.set_furniture_id("")
-				else:
-					tile.set_tile_id("")
-					tile.set_rotation_amount(0)
-			else:
-				tile.set_default()
-	elif selected_brush:
-		for tile in tiles:
-			selected_brush = brushcomposer.get_random_brush()
-			var tilerotation = brushcomposer.get_tilerotation(rotationAmount)
-			if selected_brush.entityType == "mob":
-				tile.set_mob_id(selected_brush.tileID)
-			elif selected_brush.entityType == "furniture":
-				tile.set_furniture_id(selected_brush.tileID)
-			else:
-				tile.set_tile_id(selected_brush.tileID)
-				tile.set_rotation_amount(tilerotation)
+	for tile in tiles:
+		apply_paint_to_tile(tile, selected_brush, rotationAmount, erase)
 	update_rectangle()
+
 
 #The user has pressed the erase toggle button in the editor
 func _on_erase_toggled(button_pressed):

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -244,6 +244,7 @@ func paint_single_tile(clicked_tile) -> void:
 		else:
 			clicked_tile.set_default()
 	elif selected_brush:
+		selected_brush = brushcomposer.get_random_brush()
 		if selected_brush.entityType == "mob":
 			clicked_tile.set_mob_id(selected_brush.tileID)
 			clicked_tile.set_mob_rotation(rotationAmount)
@@ -493,7 +494,10 @@ func _on_copy_rectangle_toggled(toggled_on: bool) -> void:
 # When the user has selected one of the tile brushes to paint with
 func _on_tilebrush_list_tile_brush_selection_change(tilebrush: Control):
 	selected_brush = tilebrush
-	brushcomposer.add_tilebrush_to_container(tilebrush)
+	if Input.is_key_pressed(KEY_CTRL):
+		brushcomposer.add_tilebrush_to_container(tilebrush)
+	else:
+		brushcomposer.replace_all_with_brush(tilebrush)
 	update_preview_texture()
 
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -14,6 +14,7 @@ var currentLevelData: Array = []
 @export var checkboxDrawRectangle: CheckBox
 @export var checkboxCopyRectangle: CheckBox
 @export var checkboxCopyAllLevels: CheckBox
+@export var brushcomposer: Control # Contains one or more selected brushes to paint with
 
 var selected_brush: Control
 
@@ -490,8 +491,9 @@ func _on_copy_rectangle_toggled(toggled_on: bool) -> void:
 
 
 # When the user has selected one of the tile brushes to paint with
-func _on_tilebrush_list_tile_brush_selection_change(tilebrush):
+func _on_tilebrush_list_tile_brush_selection_change(tilebrush: Control):
 	selected_brush = tilebrush
+	brushcomposer.add_tilebrush_to_container(tilebrush)
 	update_preview_texture()
 
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -65,6 +65,8 @@ func _on_mapeditor_ready() -> void:
 	levelgrid_above.hide()
 	_on_zoom_level_changed(mapEditor.zoom_level)
 	data_changed.connect(Gamedata.on_mapdata_changed)
+	brushcomposer.brush_added.connect(_on_composer_brush_added)
+	brushcomposer.brush_removed.connect(_on_composer_brush_removed)
 
 
 # This function will fill fill this GridContainer with a grid of 32x32 instances of "res://Scenes/ContentManager/Mapeditor/mapeditortile.tscn"
@@ -493,12 +495,10 @@ func _on_copy_rectangle_toggled(toggled_on: bool) -> void:
 
 # When the user has selected one of the tile brushes to paint with
 func _on_tilebrush_list_tile_brush_selection_change(tilebrush: Control):
-	selected_brush = tilebrush
 	if Input.is_key_pressed(KEY_CTRL):
 		brushcomposer.add_tilebrush_to_container(tilebrush)
 	else:
 		brushcomposer.replace_all_with_brush(tilebrush)
-	update_preview_texture()
 
 
 # The cursor will have a preview of the texture that the user will paint with next to it
@@ -997,3 +997,16 @@ func set_brush_preview_texture(image: Texture) -> void:
 		brushPreviewTexture.texture = null
 		brushPreviewTexture.visible = false
 		brushPreviewTexture.size = Vector2(128,128)
+
+
+# The user has added a brush to the brush composer
+func _on_composer_brush_added(composerbrush: Control):
+	selected_brush = composerbrush
+	update_preview_texture()
+
+
+# The user has removed a brush from the brush composer
+func _on_composer_brush_removed(composerbrush: Control):
+	if brushcomposer.is_empty():
+		selected_brush = null
+		update_preview_texture()

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -24,7 +24,7 @@ enum EditorMode {
 	COPY_RECTANGLE, # When the user has clicked the CopyRectangle checkbox
 	COPY_ALL_LEVELS # When the user has clicked the CopyAllLevels checkbox
 }
-# Replace your booleans with a single variable to track the current editor mode
+# Track the current editor mode
 var currentMode: EditorMode = EditorMode.NONE
 var erase: bool = false
 var showBelow: bool = false
@@ -456,6 +456,10 @@ func _on_draw_rectangle_toggled(toggled_on: bool) -> void:
 			set_brush_preview_texture(selected_brush.get_texture())
 	else:
 		currentMode = EditorMode.NONE
+		if selected_brush:
+			set_brush_preview_texture(selected_brush.get_texture())
+		else:
+			set_brush_preview_texture(null)
 
 
 # When the user toggles the copy all levels button in the toolbar
@@ -472,7 +476,10 @@ func _on_copy_all_levels_toggled(toggled_on: bool):
 			set_brush_preview_texture(null)
 	else:
 		currentMode = EditorMode.NONE
-
+		if selected_brush:
+			set_brush_preview_texture(selected_brush.get_texture())
+		else:
+			set_brush_preview_texture(null)
 
 # Called when the Copy Rectangle ToggleButton's state changes.
 func _on_copy_rectangle_toggled(toggled_on: bool) -> void:
@@ -496,6 +503,11 @@ func _on_copy_rectangle_toggled(toggled_on: bool) -> void:
 
 # When the user has selected one of the tile brushes to paint with
 func _on_tilebrush_list_tile_brush_selection_change(tilebrush: Control):
+	# Toggle the copy buttons off
+	checkboxCopyRectangle.set_pressed(false)
+	checkboxCopyAllLevels.set_pressed(false)
+	currentMode = EditorMode.NONE
+	# Add the brush if ctrl is held, otherwise replace all
 	if Input.is_key_pressed(KEY_CTRL):
 		brushcomposer.add_tilebrush_to_container(tilebrush)
 	else:
@@ -993,6 +1005,7 @@ func set_brush_preview_texture(image: Texture) -> void:
 	brushPreviewTexture.rotation_degrees = rotationAmount
 	if image: 
 		brushPreviewTexture.texture = image
+		brushPreviewTexture.size = image.get_size()
 		brushPreviewTexture.visible = true
 	else:
 		brushPreviewTexture.texture = null
@@ -1007,7 +1020,7 @@ func _on_composer_brush_added(composerbrush: Control):
 
 
 # The user has removed a brush from the brush composer
-func _on_composer_brush_removed(composerbrush: Control):
+func _on_composer_brush_removed(_composerbrush: Control):
 	if brushcomposer.is_empty():
 		selected_brush = null
 		update_preview_texture()

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -114,26 +114,27 @@ func find_list_by_category(category: String) -> Control:
 			categoryFound = categoryList
 			break
 	return categoryFound
-	
+
 
 #Mark the clicked tilebrush as selected, but only after deselecting all other brushes
 func tilebrush_clicked(tilebrush: Control) -> void:
 	deselect_all_brushes()
-	# If the clicked brush was not select it, we select it. Otherwise we deselect it
-	if selected_brush != tilebrush:
-		selected_brush = tilebrush
-		selected_brush.set_selected(true)
-	else:
-		selected_brush = null
-		
+	# Update the selected brush to the one that was clicked, 
+	# even if it was already selected
+	selected_brush = tilebrush
+	selected_brush.set_selected(true)
+
+
 # Deselects all brushes by setting their selected state to false
 func deselect_all_brushes():
 	for child in instanced_brushes:
 		child.set_selected(false)
 
+
 # Called when the collapse button is pressed, saves the collapse state for the given header
 func _on_collapse_button_pressed(header: String):
 	save_collapse_state(header)
+
 
 # Saves the collapsed state of the list associated with the given header to the configuration file
 func save_collapse_state(header: String):
@@ -151,6 +152,7 @@ func save_collapse_state(header: String):
 		# Save the collapsed state to the configuration file
 		config.set_value("mapeditor:brushlist:" + header, "is_collapsed", list_node.is_collapsed)
 		config.save(path)
+
 
 # Loads the collapsed state for the given header from the configuration file and returns it
 func load_collapse_state(header: String) -> bool:

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
@@ -5,6 +5,7 @@ extends Control
 @export var gridContainer: ColorRect = null
 @export var tileGrid: GridContainer = null
 
+
 signal zoom_level_changed(value: int)
 var tileSize: int = 128
 var mapHeight: int = 32

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -50,13 +50,15 @@ func _process(delta):
 
 # Function to clear the children of brush_container
 func clear_brush_container():
-	for child in brush_container.get_children():
-		brush_container.remove_child(child)
+	for child in brush_container.get_content_items():
+		brush_container.remove_content_item(child)
 		child.queue_free()
 
 
 # Function to add a new tilebrush to the brush_container
 func add_tilebrush_to_container(original_tilebrush: Control):
+	if not original_tilebrush:
+		return
 	var brushInstance: Control = tileBrush.instantiate()
 	brushInstance.set_tile_texture(original_tilebrush.get_texture())
 	brushInstance.tileID = original_tilebrush.tileID
@@ -64,20 +66,23 @@ func add_tilebrush_to_container(original_tilebrush: Control):
 	brushInstance.entityType = original_tilebrush.entityType
 	brushInstance.set_minimum_size(Vector2(32,32))
 	brush_container.add_content_item(brushInstance)
-	emit_signal("brush_added", brushInstance)
+	brush_added.emit(brushInstance)
+
+
+func replace_all_with_brush(original_tilebrush: Control):
+	clear_brush_container()
+	add_tilebrush_to_container(original_tilebrush)
 
 
 # Function to handle tilebrush click and remove it from the container
 func _on_tilebrush_clicked(brush):
-	if brush_container.has_node(brush.get_path()):
-		brush_container.remove_child(brush)
-		brush.queue_free()
-		emit_signal("brush_removed", brush)
+	brush_container.remove_content_item(brush)
+	brush_removed.emit(brush)
 
 
 # Function to get a random child from the brush_container
 func get_random_brush() -> Control:
-	var children = brush_container.get_children()
+	var children = brush_container.get_content_items()
 	if children.size() == 0:
 		return null
 	return children[randi() % children.size()]

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -16,8 +16,6 @@ extends VBoxContainer
 	# To demonstrate the use case: Add 6 null tiles and 1 mob and you can 
 	# randomly distribute mobs on your map, having them spawn 1 in 7 chance
 	
-	# TODO: Have a button to enable/disable random rotation while painting
-	
 	# TODO: Have a button to toggle whether you want to pick a random tile each brush 
 	# stroke or each click. When selecting 'each brush stroke', it will pick a 
 	# random one each time it would paint a tile, so when clicking and dragging. 

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -43,15 +43,11 @@ func _ready():
 	pass # Replace with function body.
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-
-
 # Function to clear the children of brush_container
 func clear_brush_container():
 	for child in brush_container.get_content_items():
 		brush_container.remove_content_item(child)
+		brush_removed.emit(child)
 		child.queue_free()
 
 
@@ -86,3 +82,7 @@ func get_random_brush() -> Control:
 	if children.size() == 0:
 		return null
 	return children[randi() % children.size()]
+
+# Returns true if there are no brushes in the list. Otherwise it returns false
+func is_empty() -> bool:
+	return brush_container.get_content_items().size() == 0

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -31,6 +31,7 @@ extends VBoxContainer
 
 @export var brush_container: Control
 @export var tileBrush: PackedScene = null
+@export var rotation_button: Button
 
 
 # Signals to indicate when a brush is added or removed
@@ -86,3 +87,13 @@ func get_random_brush() -> Control:
 # Returns true if there are no brushes in the list. Otherwise it returns false
 func is_empty() -> bool:
 	return brush_container.get_content_items().size() == 0
+
+
+# Returns a rotation amount based on whether or not the rotation button is checked
+# If the rotation button is unchecked, we return the original rotation
+# If the rotation button is checked, we return a random value of 0, 90, 180 or 270
+func get_tilerotation(original_rotation: int) -> int:
+	if rotation_button.button_pressed:
+		var rotations = [0, 90, 180, 270]
+		return rotations[randi() % rotations.size()]
+	return original_rotation

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -1,0 +1,83 @@
+extends VBoxContainer
+
+# This script is intended to be used with the mapeditor_brushcomposer.tscn
+# This brushcomposer allows the user to compose a brush made up of one or more
+# tile brushes. When a brush is selected, you can hold ctrl and click another brush
+# to add it to the selected brushes. When 2 or more brushes are selected, the map 
+# editor will pick one at random and paint it onto the map.
+
+# This allows you to compose a custom brush. For example, if I want to add a grass
+# field where some dirt patches are randomy added, I can add the grass tile six times 
+# and the dirt tile 1 time and then start painting to have it randomly distributed.
+
+#Additional features:
+
+	# TODO: Have a button to add a 'null' tile that will include an empty brush. 
+	# To demonstrate the use case: Add 6 null tiles and 1 mob and you can 
+	# randomly distribute mobs on your map, having them spawn 1 in 7 chance
+	
+	# TODO: Have a button to enable/disable random rotation while painting
+	
+	# TODO: Have a button to toggle whether you want to pick a random tile each brush 
+	# stroke or each click. When selecting 'each brush stroke', it will pick a 
+	# random one each time it would paint a tile, so when clicking and dragging. 
+	# When selecting 'each click', it will pick one tile and keep painting it 
+	# until you release the mouse button. This is useful for painting house 
+	# floors where you might want a random floor, but have each tile in the 
+	# floor be the same.
+	
+	# TODO: Add an erase button to clear the brush
+	# TODO: Have the brush be remembered when leaving the map editor
+
+@export var brush_container: Control
+@export var tileBrush: PackedScene = null
+
+
+# Signals to indicate when a brush is added or removed
+signal brush_added(brush: Control)
+signal brush_removed(brush: Control)
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+
+# Function to clear the children of brush_container
+func clear_brush_container():
+	for child in brush_container.get_children():
+		brush_container.remove_child(child)
+		child.queue_free()
+
+
+# Function to add a new tilebrush to the brush_container
+func add_tilebrush_to_container(original_tilebrush: Control):
+	var brushInstance: Control = tileBrush.instantiate()
+	brushInstance.set_tile_texture(original_tilebrush.get_texture())
+	brushInstance.tileID = original_tilebrush.tileID
+	brushInstance.tilebrush_clicked.connect(_on_tilebrush_clicked)
+	brushInstance.entityType = original_tilebrush.entityType
+	brushInstance.set_minimum_size(Vector2(32,32))
+	brush_container.add_content_item(brushInstance)
+	emit_signal("brush_added", brushInstance)
+
+
+# Function to handle tilebrush click and remove it from the container
+func _on_tilebrush_clicked(brush):
+	if brush_container.has_node(brush.get_path()):
+		brush_container.remove_child(brush)
+		brush.queue_free()
+		emit_signal("brush_removed", brush)
+
+
+# Function to get a random child from the brush_container
+func get_random_brush() -> Control:
+	var children = brush_container.get_children()
+	if children.size() == 0:
+		return null
+	return children[randi() % children.size()]

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -115,6 +115,7 @@ func set_furniture_rotation(rotationDegrees):
 		tileData.furniture.rotation = rotationDegrees
 
 
+# If the user holds the mouse button while entering this tile, we consider it clicked
 func _on_texture_rect_mouse_entered() -> void:
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 		tile_clicked.emit(self)

--- a/Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd
@@ -11,11 +11,14 @@ func _on_texture_rect_gui_input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		tilebrush_clicked.emit(self)
 
+
 func set_tile_texture(res: Resource) -> void:
 	$TileSprite.texture = res
 
+
 func get_texture() -> Resource:
 	return $TileSprite.texture
+
 
 #Mark the clicked tilebrush as selected
 func set_selected(is_selected: bool) -> void:

--- a/Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd
@@ -4,6 +4,7 @@ signal tilebrush_clicked(clicked_tile: Control)
 var tileID: String = ""
 var selected: bool = false
 var entityType: String = "tile"
+const TILEMARGIN: int = 10
 
 #When the event was a left mouse button press, adjust the modulate property of the $TileSprite to be 3aa2c1
 func _on_texture_rect_gui_input(event):
@@ -23,3 +24,8 @@ func set_selected(is_selected: bool) -> void:
 		modulate = Color(0.227, 0.635, 0.757)
 	else:
 		modulate = Color(1,1,1)
+
+
+func set_minimum_size(newsize: Vector2):
+	custom_minimum_size = Vector2(newsize.x+TILEMARGIN, newsize.y+TILEMARGIN)
+	$TileSprite.custom_minimum_size = newsize

--- a/Scenes/ContentManager/Mapeditor/mapeditor.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=29 format=3 uid="uid://d3001f5xxpup1"]
+[gd_scene load_steps=30 format=3 uid="uid://d3001f5xxpup1"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd" id="1_0c7s4"]
 [ext_resource type="PackedScene" uid="uid://bswccbbg6ijep" path="res://Scenes/ContentManager/Mapeditor/Toolbar/mapeditorzoomscroller.tscn" id="1_0ytmu"]
@@ -20,6 +20,7 @@
 [ext_resource type="Texture2D" uid="uid://bsxgq272ca2kw" path="res://Images/Icons/IconArrowDownUnchecked.png" id="8_xcusj"]
 [ext_resource type="Texture2D" uid="uid://dk8cdxff84idk" path="res://Images/Icons/IconArrowUpChecked.png" id="9_etume"]
 [ext_resource type="Texture2D" uid="uid://biircfcjvj7lp" path="res://Images/Icons/IconArrowUpUnchecked.png" id="10_0rhye"]
+[ext_resource type="PackedScene" uid="uid://c80hblyn3jedv" path="res://Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn" id="18_ov0cf"]
 
 [sub_resource type="Gradient" id="Gradient_x1sdl"]
 
@@ -189,7 +190,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.313726, 0.313726, 0.313726, 1)
 
-[node name="TileGrid" type="GridContainer" parent="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer" node_paths=PackedStringArray("mapEditor", "LevelScrollBar", "levelgrid_below", "levelgrid_above", "mapScrollWindow", "brushPreviewTexture", "buttonRotateRight", "checkboxDrawRectangle", "checkboxCopyRectangle", "checkboxCopyAllLevels")]
+[node name="TileGrid" type="GridContainer" parent="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer" node_paths=PackedStringArray("mapEditor", "LevelScrollBar", "levelgrid_below", "levelgrid_above", "mapScrollWindow", "brushPreviewTexture", "buttonRotateRight", "checkboxDrawRectangle", "checkboxCopyRectangle", "checkboxCopyAllLevels", "brushcomposer")]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -211,6 +212,7 @@ buttonRotateRight = NodePath("../../../../../Toolbar/RotateRight")
 checkboxDrawRectangle = NodePath("../../../../../Toolbar/DrawRectangle")
 checkboxCopyRectangle = NodePath("../../../../../Toolbar/CopyRectangle")
 checkboxCopyAllLevels = NodePath("../../../../../Toolbar/CopyAllLevels")
+brushcomposer = NodePath("../../../../../../EntitiesVBoxContainer/CustomBrushComposer")
 
 [node name="Level_Below" type="GridContainer" parent="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer"]
 modulate = Color(1, 1, 1, 0.117647)
@@ -265,9 +267,19 @@ max_value = 10.0
 step = 1.0
 rounded = true
 
-[node name="EntitiesContainer" type="VBoxContainer" parent="HSplitContainer"]
+[node name="EntitiesVBoxContainer" type="VBoxContainer" parent="HSplitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.2
+
+[node name="CustomBrushComposer" parent="HSplitContainer/EntitiesVBoxContainer" instance=ExtResource("18_ov0cf")]
+custom_minimum_size = Vector2(0, 100)
+layout_mode = 2
+
+[node name="EntitiesContainer" type="VBoxContainer" parent="HSplitContainer/EntitiesVBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 size_flags_stretch_ratio = 0.2
 script = ExtResource("5_he816")
 scrolling_Flow_Container = ExtResource("6_onaby")
@@ -298,4 +310,4 @@ offset_bottom = 40.0
 [connection signal="zoom_level_changed" from="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" to="." method="_on_tile_grid_zoom_level_changed"]
 [connection signal="value_changed" from="HSplitContainer/MapeditorContainer/HBoxContainer/Levelscroller/LevelScrollbar" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="_on_level_scrollbar_value_changed"]
 [connection signal="value_changed" from="HSplitContainer/MapeditorContainer/HBoxContainer/Levelscroller/LevelScrollbar" to="HSplitContainer/MapeditorContainer/HBoxContainer/Levelscroller" method="_on_level_scrollbar_value_changed"]
-[connection signal="tile_brush_selection_change" from="HSplitContainer/EntitiesContainer" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="_on_tilebrush_list_tile_brush_selection_change"]
+[connection signal="tile_brush_selection_change" from="HSplitContainer/EntitiesVBoxContainer/EntitiesContainer" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="_on_tilebrush_list_tile_brush_selection_change"]

--- a/Scenes/ContentManager/Mapeditor/mapeditor.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor.tscn
@@ -165,6 +165,31 @@ tooltip_text = "Show the level above"
 theme_override_icons/checked = ExtResource("9_etume")
 theme_override_icons/unchecked = ExtResource("10_0rhye")
 
+[node name="HelpButton" type="Button" parent="HSplitContainer/MapeditorContainer/Toolbar"]
+layout_mode = 2
+tooltip_text = "This is the map editor. It allows you to create a map of 32x32x21 blocks. If you need more, you need to make a new map and combine them in a tacticalmap.
+
+You can hover your cursor over the controls to see what they do. Below you can find some general tips to use the map editor.
+
+These are the controls:
+Brushcomposer (Top-right): This area allows you to compose a custom brush with one or more tile brushes. You can add multiple brushes by 
+holding CTRL and clicking another brush. When painting, a random tile will be picked from the composer. It also has a button to enable 
+random rotation. To remove a single brush from the brushcomposer, click it with the left mouse button.
+
+Brush pallette (right): Click to add the selected brush to the brush composer. Hold CTRL and click another brush to add multiple brushes. 
+You can add multiple of the same tile to control the proportions when painting.
+
+Level Scroll Bar (vertical bar on the right): Use this scrollbar to navigate between different levels. The current level is 
+displayed on the scrollbar. ALternatively, hold ALT while using the mouse wheel to switch to a different level.
+
+Zoom Level (top): Use the slider to zoom. Alternatively, use the mouse wheel while holding CTRL to zoom in and out. 
+The current zoom level affects the size of the brush preview and grid tiles.
+"
+theme_override_colors/font_disabled_color = Color(1, 0.374252, 0.322802, 1)
+theme_override_constants/outline_size = 4
+disabled = true
+text = " ? "
+
 [node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/MapeditorContainer"]
 layout_mode = 2
 size_flags_vertical = 3

--- a/Scenes/ContentManager/Mapeditor/mapeditor.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor.tscn
@@ -273,14 +273,15 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.2
 
 [node name="CustomBrushComposer" parent="HSplitContainer/EntitiesVBoxContainer" instance=ExtResource("18_ov0cf")]
-custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.1
 
 [node name="EntitiesContainer" type="VBoxContainer" parent="HSplitContainer/EntitiesVBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-size_flags_stretch_ratio = 0.2
+size_flags_stretch_ratio = 0.8
 script = ExtResource("5_he816")
 scrolling_Flow_Container = ExtResource("6_onaby")
 tileBrush = ExtResource("8_o4x7s")

--- a/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
@@ -1,19 +1,24 @@
-[gd_scene load_steps=4 format=3 uid="uid://c80hblyn3jedv"]
+[gd_scene load_steps=6 format=3 uid="uid://c80hblyn3jedv"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd" id="1_bl6cv"]
 [ext_resource type="PackedScene" uid="uid://be62h2ytgw2kb" path="res://Scenes/ContentManager/Custom_Widgets/Scrolling_Flow_Container.tscn" id="1_ump07"]
 [ext_resource type="PackedScene" uid="uid://cccnrdolr1bfo" path="res://Scenes/ContentManager/Mapeditor/tilebrush.tscn" id="2_epuda"]
+[ext_resource type="Texture2D" uid="uid://dixj0spya5p0y" path="res://Images/Icons/IconRotateRight.png" id="3_nbxmi"]
+[ext_resource type="Texture2D" uid="uid://b6m2bbbpmsyik" path="res://Images/Icons/IconRotateRightDark.png" id="4_gh7br"]
 
-[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container")]
+[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container", "rotation_button")]
 script = ExtResource("1_bl6cv")
 brush_container = NodePath("CurrentBrushScrolling_Flow_Container")
 tileBrush = ExtResource("2_epuda")
+rotation_button = NodePath("CustomBrushToolsHBoxContainer/RotationCheckbox")
 
 [node name="CustomBrushToolsHBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="Button" type="Button" parent="CustomBrushToolsHBoxContainer"]
+[node name="RotationCheckbox" type="CheckBox" parent="CustomBrushToolsHBoxContainer"]
 layout_mode = 2
+theme_override_icons/checked = ExtResource("3_nbxmi")
+theme_override_icons/unchecked = ExtResource("4_gh7br")
 text = "x"
 
 [node name="Button2" type="Button" parent="CustomBrushToolsHBoxContainer"]

--- a/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
@@ -17,26 +17,15 @@ layout_mode = 2
 
 [node name="RotationCheckbox" type="CheckBox" parent="CustomBrushToolsHBoxContainer"]
 layout_mode = 2
+tooltip_text = "Apply random rotation to the brushes in this brushcomposer. To apply a fixed 
+rotation, disable this button and click the tile rotation button on the general toolbar"
 theme_override_icons/checked = ExtResource("3_nbxmi")
 theme_override_icons/unchecked = ExtResource("4_gh7br")
-text = "x"
-
-[node name="Button2" type="Button" parent="CustomBrushToolsHBoxContainer"]
-layout_mode = 2
-text = "x"
-
-[node name="Button3" type="Button" parent="CustomBrushToolsHBoxContainer"]
-layout_mode = 2
-text = "x"
-
-[node name="Button4" type="Button" parent="CustomBrushToolsHBoxContainer"]
-layout_mode = 2
-text = "x"
-
-[node name="Button5" type="Button" parent="CustomBrushToolsHBoxContainer"]
-layout_mode = 2
-text = "x"
 
 [node name="CurrentBrushScrolling_Flow_Container" parent="." instance=ExtResource("1_ump07")]
 layout_mode = 2
+tooltip_text = "This is the brush composer. It allows you to create a custom brush to paint for your purposes. To add a tile 
+to the brush composer, click one of the tiles in the tile brush pallette below. Hold CTRL to add multiple. You 
+can add more then one of the same tile. When painting, a random brush will be picked from the collection 
+of brushes you added. You can also apply random rotation by clicking the button above."
 header = ""

--- a/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=4 format=3 uid="uid://c80hblyn3jedv"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd" id="1_bl6cv"]
+[ext_resource type="PackedScene" uid="uid://be62h2ytgw2kb" path="res://Scenes/ContentManager/Custom_Widgets/Scrolling_Flow_Container.tscn" id="1_ump07"]
+[ext_resource type="PackedScene" uid="uid://cccnrdolr1bfo" path="res://Scenes/ContentManager/Mapeditor/tilebrush.tscn" id="2_epuda"]
+
+[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container")]
+script = ExtResource("1_bl6cv")
+brush_container = NodePath("CurrentBrushScrolling_Flow_Container")
+tileBrush = ExtResource("2_epuda")
+
+[node name="CustomBrushToolsHBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="Button" type="Button" parent="CustomBrushToolsHBoxContainer"]
+layout_mode = 2
+text = "x"
+
+[node name="Button2" type="Button" parent="CustomBrushToolsHBoxContainer"]
+layout_mode = 2
+text = "x"
+
+[node name="Button3" type="Button" parent="CustomBrushToolsHBoxContainer"]
+layout_mode = 2
+text = "x"
+
+[node name="Button4" type="Button" parent="CustomBrushToolsHBoxContainer"]
+layout_mode = 2
+text = "x"
+
+[node name="Button5" type="Button" parent="CustomBrushToolsHBoxContainer"]
+layout_mode = 2
+text = "x"
+
+[node name="CurrentBrushScrolling_Flow_Container" parent="." instance=ExtResource("1_ump07")]
+layout_mode = 2
+header = ""


### PR DESCRIPTION
Fixes #161 for the most part. I left some TODO's in the script comments

This PR adds a brush composer to make more advanced brushes. Painting still works the same as before, you just have more options.

I added this general tooltip:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/fed174b4-cefc-48ea-b8cb-d2dd6fd431d6)

And this one specific to the brushcomposer:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/e7d3db33-2867-4a84-82fd-38793c3f7137)


Here is a demonstration: 
https://github.com/Khaligufzel/CataX/assets/50166150/4b9dbd26-0493-4f91-8e2a-bc49932bc01c


