### PR TITLE
Reduce margin on object detection in chunk

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -237,9 +237,9 @@ func get_furniture_data() -> Array:
 # We check if the furniture or mob or item's position is inside this chunk on the x and z axis
 func _is_object_in_range(objectposition: Vector3) -> bool:
 		return objectposition.x >= mypos.x and \
-		objectposition.x <= mypos.x + LEVEL_WIDTH and \
+		objectposition.x < mypos.x + LEVEL_WIDTH and \
 		objectposition.z >= mypos.z and \
-		objectposition.z <= mypos.z + LEVEL_HEIGHT
+		objectposition.z < mypos.z + LEVEL_HEIGHT
 
 
 # Save all the mobs and their current stats to the mobs file for this map


### PR DESCRIPTION
Fixes #187 

The `_is_object_in_range` was inclusive on both ends, so if an item was at position 32,32, it would be included in chunks that range from 0,0 to 32,32 and in chunks that range from 32,32 to 64,64. I adjusted it so that the chunk at 0,0 does not include items at 32,32 but only up to 32,32. So an item at 31.999, 31.999 is still included.