### PR TITLE
Refactor chunk loading unloading, threading

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -77,18 +77,18 @@ func initialize_chunk_data():
 		if chunk_data.has("rotation") and not chunk_data.rotation == 0:
 			rotate_map(mapsegmentData)
 		_mapleveldata = mapsegmentData.levels
-		generate_new_chunk()
+		Helper.task_manager.create_task(generate_new_chunk)
 	else: # This chunk is created from previously saved data
 		generate_saved_chunk()
 
 
 func generate_new_chunk():
 	block_positions = create_block_position_dictionary_new_arraymesh()
-	await Helper.task_manager.create_task(generate_chunk_mesh).completed
-	await Helper.task_manager.create_task(update_all_navigation_data).completed
+	generate_chunk_mesh()
+	update_all_navigation_data()
 	processed_level_data = process_level_data()
-	await Helper.task_manager.create_task(add_furnitures_to_new_block).completed
-	Helper.task_manager.create_task(add_block_mobs)
+	add_furnitures_to_new_block()
+	add_block_mobs()
 
 
 # Collects the furniture and mob data from the mapdata to be spawned later
@@ -899,9 +899,10 @@ func create_colliders() -> void:
 		chunk_mesh_body.add_child.call_deferred(_create_block_collider(block_pos, block_shape, block_rotation))
 
 		block_counter += 1
-		# Check if it's time to delay
+		# Check if it's time to delay. We need to delay because the call_deferred
+		# will add the child on the main thread and we weant to spread it out
 		if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
-			await get_tree().create_timer(0.1).timeout
+			OS.delay_msec(100) # Adjust delay time as needed
 
 
 # Creates a collider for either a slope or a cube and puts it at the right place and rotation

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -79,7 +79,7 @@ func initialize_chunk_data():
 		_mapleveldata = mapsegmentData.levels
 		Helper.task_manager.create_task(generate_new_chunk)
 	else: # This chunk is created from previously saved data
-		generate_saved_chunk()
+		Helper.task_manager.create_task(generate_saved_chunk)
 
 
 func generate_new_chunk():
@@ -150,15 +150,15 @@ func create_block_position_dictionary_new_arraymesh() -> Dictionary:
 # After generating the mesh we add the items, furniture and mobs
 func generate_saved_chunk() -> void:
 	block_positions = chunk_data.block_positions
-	await Helper.task_manager.create_task(generate_chunk_mesh).completed
-	await Helper.task_manager.create_task(update_all_navigation_data).completed
+	generate_chunk_mesh()
+	update_all_navigation_data()
 	for item: Dictionary in chunk_data.items:
 		add_item_to_map(item)
 	
 	# We duplicate the furnituredata for thread safety
 	var furnituredata: Array = chunk_data.furniture.duplicate()
-	await Helper.task_manager.create_task(add_furnitures_to_map.bind(furnituredata)).completed
-	await Helper.task_manager.create_task(add_mobs_to_map).completed
+	add_furnitures_to_map(furnituredata)
+	add_mobs_to_map()
 
 
 # When a map is loaded for the first time we spawn the mob on the block
@@ -221,82 +221,12 @@ func remove_furniture_from_chunk(furniture_instance: Node3D):
 		furniture_instances.erase(furniture_instance)
 
 
-# Returns an array of furniture data that will be saved for this chunk
-# Furniture that has it's x and z position in the boundary of the chunk's position and size
-# will be included in the chunk data. So basically if the furniture is 'in' or 'on' the chunk.
-# Modified to account for moveable furniture potentially changing chunks
-func get_furniture_data() -> Array:
-	var furnitureData: Array = []
-	for furniture in furniture_instances:
-		if is_instance_valid(furniture):
-			furnitureData.append(furniture.get_data().duplicate())
-			furniture.queue_free.call_deferred()
-	return furnitureData
-
-
 # We check if the furniture or mob or item's position is inside this chunk on the x and z axis
 func _is_object_in_range(objectposition: Vector3) -> bool:
 		return objectposition.x >= mypos.x and \
 		objectposition.x <= mypos.x + LEVEL_WIDTH and \
 		objectposition.z >= mypos.z and \
 		objectposition.z <= mypos.z + LEVEL_HEIGHT
-
-
-# Save all the mobs and their current stats to the mobs file for this map
-func get_mob_data() -> Array:
-	var mobData: Array = []
-	var mapMobs = get_tree().get_nodes_in_group("mobs")
-	var newMobData: Dictionary
-	for mob in mapMobs:
-		# Check if furniture's position is within the desired range
-		if _is_object_in_range(mob.last_position):
-			mob.remove_from_group.call_deferred("mobs")
-			newMobData = {
-				"id": mob.mobJSON.id,
-				"global_position_x": mob.last_position.x,
-				"global_position_y": mob.last_position.y,
-				"global_position_z": mob.last_position.z,
-				"rotation": mob.last_rotation,
-				"melee_damage": mob.melee_damage,
-				"melee_range": mob.melee_range,
-				"health": mob.health,
-				"current_health": mob.current_health,
-				"move_speed": mob.moveSpeed,
-				"current_move_speed": mob.current_move_speed,
-				"idle_move_speed": mob.idle_move_speed,
-				"current_idle_move_speed": mob.current_idle_move_speed,
-				"sight_range": mob.sightRange,
-				"sense_range": mob.senseRange,
-				"hearing_range": mob.hearingRange
-			}
-			mobData.append(newMobData.duplicate())
-			mob.queue_free.call_deferred()
-	return mobData
-
-
-#Save the type and position of all mobs on the map
-func get_item_data() -> Array:
-	var itemData: Array = []
-	var myItem: Dictionary = {
-		"itemid": "item1", 
-		"global_position_x": 0, 
-		"global_position_y": 0, 
-		"global_position_z": 0, 
-		"inventory": []
-	}
-	var mapitems = get_tree().get_nodes_in_group("mapitems")
-	var newitemData: Dictionary
-	for item in mapitems:
-		if _is_object_in_range(item.containerpos):
-			item.remove_from_group.call_deferred("mapitems")
-			newitemData = myItem.duplicate()
-			newitemData["global_position_x"] = item.containerpos.x
-			newitemData["global_position_y"] = item.containerpos.y
-			newitemData["global_position_z"] = item.containerpos.z
-			newitemData["inventory"] = item.inventory.serialize()
-			itemData.append(newitemData.duplicate())
-			item.queue_free.call_deferred()
-	return itemData
 
 
 # Called when a save is loaded
@@ -358,33 +288,95 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 		OS.delay_msec(10)
 
 
+# Function to free all chunk-related instances
+func free_chunk_resources():
+	free_furniture_instances()
+	free_mob_instances(get_tree().get_nodes_in_group("mobs"))
+	free_item_instances(get_tree().get_nodes_in_group("mapitems"))
+	chunk_mesh_body.queue_free()
+	navigation_region.queue_free()
+	NavigationServer3D.free_rid(navigation_map_id)
+
+
+# Function to free the furniture instances
+func free_furniture_instances():
+	for furniture in furniture_instances:
+		if is_instance_valid(furniture):
+			furniture.queue_free.call_deferred()
+
+# Function to free the mob instances
+func free_mob_instances(mapMobs):
+	for mob in mapMobs:
+		if _is_object_in_range(mob.last_position):
+			mob.queue_free.call_deferred()
+
+# Function to free the item instances
+func free_item_instances(mapitems):
+	for item in mapitems:
+		if _is_object_in_range(item.containerpos):
+			item.queue_free.call_deferred()
+
+# Returns an array of furniture data that will be saved for this chunk
+# Furniture that has it's x and z position in the boundary of the chunk's position and size
+# will be included in the chunk data. So basically if the furniture is 'in' or 'on' the chunk.
+func get_furniture_data() -> Array:
+	var furnitureData: Array = []
+	for furniture in furniture_instances:
+		if is_instance_valid(furniture):
+			furnitureData.append(furniture.get_data().duplicate())
+	return furnitureData
+
+
+# Save all the mobs and their current stats to the mobs file for this map
+# Modified to remove queue_free calls
+func get_mob_data() -> Array:
+	var mobData: Array = []
+	var mapMobs = get_tree().get_nodes_in_group("mobs")
+	for mob in mapMobs:
+		if _is_object_in_range(mob.last_position):
+			mobData.append(mob.get_data().duplicate())
+	return mobData
+
+
+# Save the type and position of all items on the map
+func get_item_data() -> Array:
+	var itemData: Array = []
+	var mapitems = get_tree().get_nodes_in_group("mapitems")
+
+	for item in mapitems:
+		if _is_object_in_range(item.containerpos):
+			itemData.append(item.get_data())
+
+	return itemData
+
+
 # Returns all the chunk data used for saving and loading
-func get_chunk_data(chunkdata: Dictionary) -> void:
+func get_chunk_data() -> Dictionary:
+	var chunkdata = {}
 	mutex.lock()
 	chunkdata.chunk_x = mypos.x
 	chunkdata.chunk_z = mypos.z
 	mutex.unlock()
-	# The chunk is made from the block_positions data so we save this
 	chunkdata.block_positions = block_positions.duplicate()
 	chunkdata.furniture = get_furniture_data()
 	chunkdata.mobs = get_mob_data()
 	chunkdata.items = get_item_data()
-	
-	# Free the mesh and navigation elements
-	chunk_mesh_body.queue_free()
-	navigation_region.queue_free()
-	NavigationServer3D.free_rid(navigation_map_id)
+	return chunkdata
 
 
 # Called by LevelGenerator.gd which manages the chunks and also by Helper.save_helper when
 # switching to a different map. We start a new thread to collect map data and save it in
 # the helper variable. First we wait until the current thread is finished.
 func unload_chunk():
-	var chunkdata: Dictionary = {}
-	await Helper.task_manager.create_task(get_chunk_data.bind(chunkdata)).completed
+	await Helper.task_manager.create_task(save_and_unload_chunk).completed
+	chunk_unloaded.emit()
+
+
+func save_and_unload_chunk():
+	var chunkdata: Dictionary = get_chunk_data()
 	var chunkposition: Vector2 = Vector2(int(chunkdata.chunk_x/32),int(chunkdata.chunk_z/32))
 	Helper.loaded_chunk_data.chunks[chunkposition] = chunkdata
-	chunk_unloaded.emit()
+	free_chunk_resources()
 
 
 # Adds triangles represented by 3 vertices to the navigation mesh data

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -15,39 +15,18 @@ var current_chunk: Chunk
 var is_animating_hit: bool = false # flag to prevent multiple blink actions
 var corpse_scene: PackedScene = preload("res://Defaults/Mobs/mob_corpse.tscn")
 var current_health: float = 10.0
-# Wait for the chunk to completely spawn. Otherwise the furniture will fall
-# trough the floor. TODO: Replace with signal from the chunk to finish loading
-var allow_move: bool = false 
 
 
 func _ready():
-	# Add a Timer node so we can wait for the chunk to pawn
-	freeze = true
-	var timer = Timer.new()
-	timer.wait_time = 2
-	timer.one_shot = true
-	add_child(timer)
-	timer.start()
-	timer.timeout.connect(_on_timer_timeout)
-	
+	set_position(furnitureposition)
 	#set_position.call_deferred(furnitureposition)
 	set_new_rotation(furniturerotation)
 	last_rotation = furniturerotation
 
-func _on_timer_timeout():
-	# After the chunk is (hopefully) spawned, set the position
-	set_position.call_deferred(furnitureposition)
-
 # Keep track of the furniture's position and rotation. It starts at 0,0,0 and the moves to it's
 # assigned position after a timer. Until that has happened, we don't need to keep track of it's position
 func _physics_process(_delta):
-	if global_transform.origin == furnitureposition and freeze:
-		# This is a hacky way to keep the furniture in it's position after
-		# _on_timer_timeout is called. All furniture will be at 0,0,0 until
-		# _on_timer_timeout is called
-		allow_move = true
-		freeze = false
-	elif allow_move:
+	if not global_transform.origin == furnitureposition:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -291,3 +291,25 @@ func _on_tween_finished():
 	var surfacematerial = surfacemesh.surface_get_material(0)
 	surfacematerial.set_feature(BaseMaterial3D.FEATURE_EMISSION, false)
 	is_blinking = false
+
+
+func get_data() -> Dictionary:
+	var newMobData = {
+				"id": mobJSON.id,
+				"global_position_x": last_position.x,
+				"global_position_y": last_position.y,
+				"global_position_z": last_position.z,
+				"rotation": last_rotation,
+				"melee_damage": melee_damage,
+				"melee_range": melee_range,
+				"health": health,
+				"current_health": current_health,
+				"move_speed": moveSpeed,
+				"current_move_speed": current_move_speed,
+				"idle_move_speed": idle_move_speed,
+				"current_idle_move_speed": current_idle_move_speed,
+				"sight_range": sightRange,
+				"sense_range": senseRange,
+				"hearing_range": hearingRange
+			}
+	return newMobData

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -209,3 +209,12 @@ func insert_item(item: InventoryItem) -> bool:
 	if not item.get_inventory().transfer_autosplitmerge(item, inventory):
 		print_debug("Failed to transfer item: " + str(item))
 	return true
+
+func get_data() -> Dictionary:
+	var newitemData: Dictionary = {
+		"global_position_x": containerpos.x, 
+		"global_position_y": containerpos.y, 
+		"global_position_z": containerpos.z, 
+		"inventory": inventory.serialize()
+	}
+	return newitemData


### PR DESCRIPTION
There was some hacky code regarding the loading and unloading of chunks. This is specifically concerning the order in which the world and it's objects are loaded and unloaded.

I did some debuging and found that the block colliders and the furniture were created in the wrong order, causing the furniture to fall if no spawn delay was added. The wrong order was due to the `await` keyword being used in threads. The `await` keyword will put the code after it on the main thread, disrupting the order of execution.

I put every step of chunks loading in one function and put that inside a thread task instead of creating thread tasks for each step of the chunk loading. This makes sure that the order is correct.

I separated getting the data from the map and the unloading of the map. Previously, getting the data and unloading would happen close to eachother. furniture and items first, the mapdata second. However, due to the order not being consistent, sometimes saving was done after the chunk was unloaded, at least from the levelgenerator's perspective. 

I tested my changes with a big map (6x6) and I was able to walk fom 0,0 all the way to the bottom right (6,6) and back. The chunks were loaded and unloaded and re-loaded correctly. Changing map and going back to the main menu and loading the game also worked. 

I tried to maintain the performance of the chunk loading and unloading at the same level as it was and I think it hasn't degraded. I still think that the creation of the block colliders are causing the most fps drop, although it's pretty acceptable already.