### PR TITLE
Update gloot to 2.4.10

### DIFF
--- a/addons/gloot/core/constraints/constraint_manager.gd
+++ b/addons/gloot/core/constraints/constraint_manager.gd
@@ -34,6 +34,11 @@ func _init(inventory_: Inventory) -> void:
 
 func _on_item_added(item: InventoryItem) -> void:
     assert(_enforce_constraints(item), "Failed to enforce constraints!")
+
+    # Enforcing constraints can result in the item being removed from the inventory
+    # (e.g. when it's merged with another item stack)
+    if !is_instance_valid(item.get_inventory()) || item.is_queued_for_deletion():
+        item = null
     
     if _weight_constraint != null:
         _weight_constraint._on_item_added(item)
@@ -52,13 +57,13 @@ func _on_item_removed(item: InventoryItem) -> void:
         _grid_constraint._on_item_removed(item)
 
 
-func _on_item_modified(item: InventoryItem) -> void:
+func _on_item_property_changed(item: InventoryItem, property_name: String) -> void:
     if _weight_constraint != null:
-        _weight_constraint._on_item_modified(item)
+        _weight_constraint._on_item_property_changed(item, property_name)
     if _stacks_constraint != null:
-        _stacks_constraint._on_item_modified(item)
+        _stacks_constraint._on_item_property_changed(item, property_name)
     if _grid_constraint != null:
-        _grid_constraint._on_item_modified(item)
+        _grid_constraint._on_item_property_changed(item, property_name)
 
 
 func _on_pre_item_swap(item1: InventoryItem, item2: InventoryItem) -> bool:

--- a/addons/gloot/core/constraints/grid_constraint.gd
+++ b/addons/gloot/core/constraints/grid_constraint.gd
@@ -5,7 +5,8 @@ signal size_changed
 const Verify = preload("res://addons/gloot/core/verify.gd")
 const GridConstraint = preload("res://addons/gloot/core/constraints/grid_constraint.gd")
 const StacksConstraint = preload("res://addons/gloot/core/constraints/stacks_constraint.gd")
-const ItemMap = preload("res://addons/gloot/core/constraints/item_map.gd")
+const QuadTree = preload("res://addons/gloot/core/constraints/quadtree.gd")
+const Utils = preload("res://addons/gloot/core/utils.gd")
 
 # TODO: Replace KEY_WIDTH and KEY_HEIGHT with KEY_SIZE
 const KEY_WIDTH: String = "width"
@@ -16,8 +17,8 @@ const KEY_POSITIVE_ROTATION: String = "positive_rotation"
 const KEY_GRID_POSITION: String = "grid_position"
 const DEFAULT_SIZE: Vector2i = Vector2i(10, 10)
 
-var _item_map := ItemMap.new(Vector2i.ZERO)
 var _swap_position := Vector2i.ZERO
+var _quad_tree := QuadTree.new(size)
 
 @export var size: Vector2i = DEFAULT_SIZE :
     set(new_size):
@@ -30,36 +31,41 @@ var _swap_position := Vector2i.ZERO
             if _bounds_broken():
                 size = old_size
         if size != old_size:
-            _refresh_item_map()
+            _refresh_quad_tree()
             size_changed.emit()
 
 
-func _refresh_item_map() -> void:
-    _item_map.resize(size)
-    _fill_item_map()
-
-
-func _fill_item_map() -> void:
+func _refresh_quad_tree() -> void:
+    _quad_tree = QuadTree.new(size)
     for item in inventory.get_items():
-        _item_map.fill_rect(get_item_rect(item), item)
+        _quad_tree.add(get_item_rect(item), item)
 
 
 func _on_inventory_set() -> void:
-    _refresh_item_map()
+    _refresh_quad_tree()
 
 
 func _on_item_added(item: InventoryItem) -> void:
     if item == null:
         return
-    _item_map.fill_rect(get_item_rect(item), item)
+    _quad_tree.add(get_item_rect(item), item)
 
 
 func _on_item_removed(item: InventoryItem) -> void:
-    _item_map.clear_rect(get_item_rect(item))
+    _quad_tree.remove(item)
 
     
-func _on_item_modified(item: InventoryItem) -> void:
-    _refresh_item_map()
+func _on_item_property_changed(item: InventoryItem, property_name: String) -> void:
+    var relevant_properties = [
+        KEY_SIZE,
+        KEY_ROTATED,
+        KEY_WIDTH,
+        KEY_HEIGHT,
+        KEY_GRID_POSITION,
+    ]
+    if property_name in relevant_properties:
+        _quad_tree.remove(item)
+        _quad_tree.add(get_item_rect(item), item)
 
 
 func _on_pre_item_swap(item1: InventoryItem, item2: InventoryItem) -> bool:
@@ -78,7 +84,7 @@ func _size_check(item1: InventoryItem, item2: InventoryItem) -> bool:
     var grid_constraint1: GridConstraint = null
     if is_instance_valid(inv1):
         grid_constraint1 = inv1._constraint_manager.get_grid_constraint()
-    var inv2 = item1.get_inventory()
+    var inv2 = item2.get_inventory()
     var grid_constraint2: GridConstraint = null
     if is_instance_valid(inv2):
         grid_constraint2 = inv2._constraint_manager.get_grid_constraint()
@@ -261,10 +267,10 @@ func create_and_add_item_at(prototype_id: String, position: Vector2i) -> Invento
 
 func get_item_at(position: Vector2i) -> InventoryItem:
     assert(inventory != null, "Inventory not set!")
-    
-    if !_item_map.contains(position):
+    var first = _quad_tree.get_first(position)
+    if first == null:
         return null
-    return _item_map.get_field(position)
+    return first.metadata
 
 
 func get_items_under(rect: Rect2i) -> Array[InventoryItem]:
@@ -297,7 +303,8 @@ func move_item_to_free_spot(item: InventoryItem) -> bool:
     if not free_place.success:
         return false
 
-    return move_item_to(item, free_place.position)
+    _move_item_to_unsafe(item, free_place.position)
+    return true
 
 
 func _move_item_to_unsafe(item: InventoryItem, position: Vector2i) -> void:
@@ -362,12 +369,7 @@ func rect_free(rect: Rect2i, exception: InventoryItem = null) -> bool:
     if rect.position.y + rect.size.y > size.y:
         return false
 
-    for i in range(rect.position.x, rect.position.x + rect.size.x):
-        for j in range(rect.position.y, rect.position.y + rect.size.y):
-            var field = _item_map.get_field(Vector2i(i, j))
-            if field != null && field != exception:
-                return false
-    return true
+    return _quad_tree.get_first(rect, exception) == null
 
 
 # TODO: Check if this is needed after adding find_free_space
@@ -419,8 +421,6 @@ func _sort_if_needed() -> void:
 func get_space_for(item: InventoryItem) -> ItemCount:
     var occupied_rects: Array[Rect2i]
     var item_size = get_item_size(item)
-    if item_size == Vector2i.ONE:
-        return ItemCount.new(_item_map.free_fields)
 
     var free_space := find_free_space(item_size, occupied_rects)
     while free_space.success:
@@ -430,10 +430,7 @@ func get_space_for(item: InventoryItem) -> ItemCount:
 
 
 func has_space_for(item: InventoryItem) -> bool:
-    var item_size = get_item_size(item)
-    if item_size == Vector2i.ONE:
-        return _item_map.free_fields > 0
-        
+    var item_size = get_item_size(item)        
     return find_free_space(item_size).success
 
 
@@ -477,7 +474,7 @@ func deserialize(source: Dictionary) -> bool:
 
     reset()
 
-    var s: Vector2i = str_to_var(source[KEY_SIZE])
+    var s: Vector2i = Utils.str_to_var(source[KEY_SIZE])
     self.size = s
 
     return true

--- a/addons/gloot/core/constraints/inventory_constraint.gd
+++ b/addons/gloot/core/constraints/inventory_constraint.gd
@@ -51,9 +51,9 @@ func _on_item_added(item: InventoryItem) -> void:
 func _on_item_removed(item: InventoryItem) -> void:
     pass
 
-    
+
 # Override this
-func _on_item_modified(item: InventoryItem) -> void:
+func _on_item_property_changed(item: InventoryItem, property_name: String) -> void:
     pass
 
 

--- a/addons/gloot/core/constraints/quadtree.gd
+++ b/addons/gloot/core/constraints/quadtree.gd
@@ -1,0 +1,233 @@
+
+class QtRect:
+    var rect: Rect2i
+    var metadata: Variant
+
+
+    func _init(rect_: Rect2i, metadata_: Variant) -> void:
+        rect = rect_
+        metadata = metadata_
+
+    
+    func _to_string() -> String:
+        return "[R: %s, M: %s]" % [str(rect), str(metadata)]
+
+
+class QtNode:
+    var quadrants: Array[QtNode] = [null, null, null, null]
+    var quadrant_count: int = 0
+    var qt_rects: Array[QtRect]
+    var rect: Rect2i
+
+
+    func _init(r: Rect2i) -> void:
+        rect = r
+
+
+    func _to_string() -> String:
+        return "[R: %s]" % str(rect)
+
+
+    func is_empty() -> bool:
+        return (quadrant_count == 0) && qt_rects.is_empty()
+
+
+    func get_first_under_rect(test_rect: Rect2i, exception_metadata: Variant = null) -> QtRect:
+        for qtr in qt_rects:
+            if exception_metadata != null && qtr.metadata == exception_metadata:
+                continue
+            if qtr.rect.intersects(test_rect):
+                return qtr
+
+        for quadrant in quadrants:
+            if quadrant == null:
+                continue
+            if !quadrant.rect.intersects(test_rect):
+                continue
+            var first = quadrant.get_first_under_rect(test_rect, exception_metadata)
+            if first != null:
+                return first
+
+        return null
+
+
+    func get_first_containing_point(point: Vector2i, exception_metadata: Variant = null) -> QtRect:
+        for qtr in qt_rects:
+            if exception_metadata != null && qtr.metadata == exception_metadata:
+                continue
+            if qtr.rect.has_point(point):
+                return qtr
+
+        for quadrant in quadrants:
+            if quadrant == null:
+                continue
+            if !quadrant.rect.has_point(point):
+                continue
+            var first = quadrant.get_first_containing_point(point, exception_metadata)
+            if first != null:
+                return first
+
+        return null
+
+
+    func get_all_under_rect(test_rect: Rect2i, exception_metadata: Variant = null) -> Array[QtRect]:
+        var result: Array[QtRect]
+
+        for qtr in qt_rects:
+            if exception_metadata != null && qtr.metadata == exception_metadata:
+                continue
+            if qtr.rect.intersects(test_rect):
+                result.append(qtr)
+
+        for quadrant in quadrants:
+            if quadrant == null:
+                continue
+            if !quadrant.rect.intersects(test_rect):
+                continue
+            result.append_array(quadrant.get_all_under_rect(test_rect, exception_metadata))
+
+        return result
+
+
+    func get_all_containing_point(point: Vector2i, exception_metadata: Variant = null) -> Array[QtRect]:
+        var result: Array[QtRect]
+
+        for qtr in qt_rects:
+            if exception_metadata != null && qtr.metadata == exception_metadata:
+                continue
+            if qtr.rect.has_point(point):
+                result.append(qtr)
+
+        for quadrant in quadrants:
+            if quadrant == null:
+                continue
+            if !quadrant.rect.has_point(point):
+                continue
+            result.append_array(quadrant.get_all_containing_point(point, exception_metadata))
+
+        return result
+
+
+    func add(qt_rect: QtRect) -> void:
+        if !_can_subdivide(rect.size):
+            qt_rects.append(qt_rect)
+            return
+
+        if is_empty():
+            qt_rects.append(qt_rect)
+            return
+
+        var quadrant_rects := _get_quadrant_rects(rect)
+        for i in quadrant_rects.size():
+            var quadrant_rect := quadrant_rects[i]
+            if !quadrant_rect.intersects(qt_rect.rect):
+                continue
+            if quadrants[i] == null:
+                quadrants[i] = QtNode.new(quadrant_rect)
+                quadrant_count += 1
+                while !qt_rects.is_empty():
+                    var qtr = qt_rects.pop_back()
+                    
+                    add(qtr)
+            quadrants[i].add(qt_rect)
+
+
+    func remove(metadata: Variant) -> bool:
+        # TODO: Optimize with a Rect2i
+        var result = false
+        for i in range(qt_rects.size() - 1, -1, -1):
+            if qt_rects[i].metadata == metadata:
+                qt_rects.remove_at(i)
+                result = true
+
+        for i in range(quadrants.size()):
+            if quadrants[i] == null:
+                continue
+            if quadrants[i].remove(metadata):
+                result = true
+            if quadrants[i].is_empty():
+                quadrants[i] = null
+                quadrant_count -= 1
+
+        _collapse()
+
+        return result
+
+
+    func _collapse() -> void:
+        if quadrant_count == 0:
+            return
+        var collapsing_into: QtRect = null
+        for i in quadrants.size():
+            if quadrants[i] == null:
+                continue
+            if quadrants[i].quadrant_count != 0:
+                return
+            for qtr in quadrants[i].qt_rects:
+                if collapsing_into != null && collapsing_into != qtr:
+                    return
+                collapsing_into = qtr
+
+        for i in quadrants.size():
+            quadrants[i] = null
+        quadrant_count = 0
+        qt_rects.append(collapsing_into)
+
+
+    static func _can_subdivide(size: Vector2i) -> bool:
+        return size.x > 1 && size.y > 1
+
+
+    #  +----+---+
+    #  | 0  | 1 |
+    #  |    |   |
+    #  +----+---+ (the first quadrant is rounded up when the size is odd)
+    #  | 2  | 3 |
+    #  +----+---+
+    static func _get_quadrant_rects(rect: Rect2i) -> Array[Rect2i]:
+        var q0w := roundi(float(rect.size.x) / 2.0)
+        var q0h := roundi(float(rect.size.y) / 2.0)
+        var q0 := Rect2i(rect.position, Vector2i(q0w, q0h))
+        var q3 := Rect2i(rect.position + q0.size, rect.size - q0.size)
+        var q1 := Rect2i(Vector2i(q3.position.x, q0.position.y), Vector2i(q3.size.x, q0.size.y))
+        var q2 := Rect2i(Vector2i(q0.position.x, q3.position.y), Vector2i(q0.size.x, q3.size.y))
+        return [q0, q1, q2, q3]
+
+
+var _root: QtNode
+var _size: Vector2i
+
+
+func _init(size: Vector2) -> void:
+    _size = size
+    _root = QtNode.new(Rect2i(Vector2i.ZERO, _size))
+
+
+func get_first(at: Variant, exception_metadata: Variant = null) -> QtRect:
+    assert(at is Rect2i || at is Vector2i)
+    if at is Rect2i:
+        return _root.get_first_under_rect(at, exception_metadata)
+    if at is Vector2i:
+        return _root.get_first_containing_point(at, exception_metadata)
+    return null
+
+
+func get_all(at: Variant, exception_metadata: Variant = null) -> Array[QtRect]:
+    assert(at is Rect2i || at is Vector2i)
+    if at is Rect2i:
+        return _root.get_all_under_rect(at, exception_metadata)
+    if at is Vector2i:
+        return _root.get_all_containing_point(at, exception_metadata)
+    return []
+
+
+func add(rect: Rect2i, metadata: Variant) -> void:
+    _root.add(QtRect.new(rect, metadata))
+
+
+func remove(metadata: Variant) -> bool:
+    return _root.remove(metadata)
+
+
+func is_empty() -> bool:
+    return _root.is_empty()

--- a/addons/gloot/core/constraints/stacks_constraint.gd
+++ b/addons/gloot/core/constraints/stacks_constraint.gd
@@ -302,7 +302,8 @@ func transfer_automerge(item: InventoryItem, destination: Inventory) -> bool:
     if !destination._constraint_manager.has_space_for(item):
         return false
     for i in destination.get_items():
-        _merge_stacks(i, item)
+        if items_mergable(i, item):
+            _merge_stacks(i, item)
         if item.is_queued_for_deletion():
             # Stack size reached 0
             return true

--- a/addons/gloot/core/constraints/weight_constraint.gd
+++ b/addons/gloot/core/constraints/weight_constraint.gd
@@ -46,8 +46,13 @@ func _on_item_removed(item: InventoryItem) -> void:
     _calculate_occupied_space()
 
     
-func _on_item_modified(item: InventoryItem) -> void:
-    _calculate_occupied_space()
+func _on_item_property_changed(item: InventoryItem, property_name: String) -> void:
+    var relevant_properties = [
+        KEY_WEIGHT,
+        StacksConstraint.KEY_STACK_SIZE,
+    ]
+    if property_name in relevant_properties:
+        _calculate_occupied_space()
 
 
 func _on_pre_item_swap(item1: InventoryItem, item2: InventoryItem) -> bool:

--- a/addons/gloot/core/inventory_grid_stacked.gd
+++ b/addons/gloot/core/inventory_grid_stacked.gd
@@ -59,6 +59,10 @@ func transfer_autosplitmerge(item: InventoryItem, destination: Inventory) -> boo
     return _constraint_manager.get_stacks_constraint().transfer_autosplitmerge(item, destination)
 
 
+static func pack(item: InventoryItem) -> void:
+    return StacksConstraint.pack_item(item)
+
+
 func transfer_to(item: InventoryItem, destination: Inventory, position: Vector2i) -> bool:
     return _constraint_manager.get_grid_constraint().transfer_to(item, destination._constraint_manager.get_grid_constraint(), position)
 

--- a/addons/gloot/core/inventory_item.gd
+++ b/addons/gloot/core/inventory_item.gd
@@ -6,10 +6,13 @@ class_name InventoryItem
 signal protoset_changed
 signal prototype_id_changed
 signal properties_changed
+signal property_changed(property_name)
 signal added_to_inventory(inventory)
 signal removed_from_inventory(inventory)
 signal equipped_in_slot(item_slot)
 signal removed_from_slot(item_slot)
+
+const Utils = preload("res://addons/gloot/core/utils.gd")
 
 @export var protoset: ItemProtoset :
     set(new_protoset):
@@ -259,17 +262,17 @@ func get_property(property_name: String, default_value = null) -> Variant:
 
 
 func set_property(property_name: String, value) -> void:
-    var old_property = null
-    if properties.has(property_name):
-        old_property = properties[property_name]
+    if properties.has(property_name) && properties[property_name] == value:
+        return
     properties[property_name] = value
-    if old_property != properties[property_name]:
-        properties_changed.emit()
+    property_changed.emit(property_name)
+    properties_changed.emit()
 
 
 func clear_property(property_name: String) -> void:
     if properties.has(property_name):
         properties.erase(property_name)
+        property_changed.emit(property_name)
         properties_changed.emit()
 
 
@@ -330,7 +333,7 @@ func deserialize(source: Dictionary) -> bool:
 
 func _deserialize_property(data: Dictionary):
     # Properties are stored as strings for JSON support.
-    var result = str_to_var(data[KEY_VALUE])
+    var result = Utils.str_to_var(data[KEY_VALUE])
     var expected_type: int = data[KEY_TYPE]
     var property_type: int = typeof(result)
     if property_type != expected_type:

--- a/addons/gloot/core/inventory_stacked.gd
+++ b/addons/gloot/core/inventory_stacked.gd
@@ -94,3 +94,7 @@ func transfer_automerge(item: InventoryItem, destination: InventoryStacked) -> b
 
 func transfer_autosplitmerge(item: InventoryItem, destination: InventoryStacked) -> bool:
     return _constraint_manager.get_stacks_constraint().transfer_autosplitmerge(item, destination)
+
+
+static func pack(item: InventoryItem) -> void:
+    return StacksConstraint.pack_item(item)

--- a/addons/gloot/core/item_protoset.gd
+++ b/addons/gloot/core/item_protoset.gd
@@ -7,7 +7,7 @@ const Utils = preload("res://addons/gloot/core/utils.gd")
 
 const KEY_ID: String = "id"
 
-@export_multiline var json_data :
+@export_multiline var json_data: String :
     set(new_json_data):
         json_data = new_json_data
         if !json_data.is_empty():

--- a/addons/gloot/core/item_protoset.gd
+++ b/addons/gloot/core/item_protoset.gd
@@ -3,6 +3,8 @@
 class_name ItemProtoset
 extends Resource
 
+const Utils = preload("res://addons/gloot/core/utils.gd")
+
 const KEY_ID: String = "id"
 
 @export_multiline var json_data :
@@ -71,7 +73,7 @@ func _unstringify_prototype(prototype: Dictionary) -> void:
     for key in prototype.keys():
         var type = typeof(prototype[key])
         if type == TYPE_STRING:
-            var variant = str_to_var(prototype[key])
+            var variant = Utils.str_to_var(prototype[key])
             if variant != null:
                 prototype[key] = variant
 

--- a/addons/gloot/core/utils.gd
+++ b/addons/gloot/core/utils.gd
@@ -1,0 +1,11 @@
+
+static func str_to_var(s: String) -> Variant:
+    var variant = str_to_var(s)
+    # str_to_var considers all strings that start with a digit convertable to
+    # int/float (which is not consistent with String.is_valid_int and
+    # String.is_valid_float).
+    if typeof(variant) == TYPE_INT && !s.is_valid_int():
+        variant = null
+    if typeof(variant) == TYPE_FLOAT && !s.is_valid_float():
+        variant = null
+    return variant

--- a/addons/gloot/editor/common/multivalue_editor.gd
+++ b/addons/gloot/editor/common/multivalue_editor.gd
@@ -2,6 +2,7 @@ extends GridContainer
 
 signal value_changed(value_index)
 
+const Utils = preload("res://addons/gloot/core/utils.gd")
 
 var values: Array = [] :
     set(new_values):
@@ -44,7 +45,7 @@ func _on_line_edit_value_entered(_text: String, line_edit: LineEdit, idx: int) -
 
 
 func _on_line_edit_focus_exited(line_edit: LineEdit, idx: int) -> void:
-    var value = str_to_var(line_edit.text)
+    var value = Utils.str_to_var(line_edit.text)
     if typeof(value) != type:
         line_edit.text = var_to_str(values[idx])
         return

--- a/addons/gloot/editor/common/value_editor.gd
+++ b/addons/gloot/editor/common/value_editor.gd
@@ -3,6 +3,7 @@ extends MarginContainer
 signal value_changed
 
 const MultivalueEditor = preload("res://addons/gloot/editor/common/multivalue_editor.gd")
+const Utils = preload("res://addons/gloot/core/utils.gd")
 
 var value :
     set(new_value):
@@ -73,7 +74,7 @@ func _on_line_edit_value_entered(_text: String, line_edit: LineEdit) -> void:
 
 
 func _on_line_edit_focus_exited(line_edit: LineEdit) -> void:
-    var new_value = str_to_var(line_edit.text)
+    var new_value = Utils.str_to_var(line_edit.text)
     if typeof(new_value) != typeof(value):
         line_edit.text = var_to_str(value)
         return

--- a/addons/gloot/ui/ctrl_dragable.gd
+++ b/addons/gloot/ui/ctrl_dragable.gd
@@ -31,6 +31,8 @@ var _enabled: bool = true
 
 
 static func get_grabbed_dragable() -> CtrlDragable:
+    if !is_instance_valid(_grabbed_dragable):
+        return null
     return _grabbed_dragable
 
 
@@ -77,4 +79,3 @@ func is_active() -> bool:
 
 func is_dragged() -> bool:
     return _grabbed_dragable == self
-

--- a/addons/gloot/ui/ctrl_inventory.gd
+++ b/addons/gloot/ui/ctrl_inventory.gd
@@ -46,9 +46,6 @@ var _vbox_container: VBoxContainer
 var _item_list: ItemList
 var _refresh_queued: bool = false
 
-const KEY_IMAGE = "image"
-const KEY_NAME = "name"
-
 
 func _get_configuration_warnings() -> PackedStringArray:
     if inventory_path.is_empty():
@@ -91,8 +88,8 @@ func _connect_inventory_signals() -> void:
 
     if !inventory.contents_changed.is_connected(_queue_refresh):
         inventory.contents_changed.connect(_queue_refresh)
-    if !inventory.item_modified.is_connected(_on_item_modified):
-        inventory.item_modified.connect(_on_item_modified)
+    if !inventory.item_property_changed.is_connected(_on_item_property_changed):
+        inventory.item_property_changed.connect(_on_item_property_changed)
 
 
 func _disconnect_inventory_signals() -> void:
@@ -101,8 +98,8 @@ func _disconnect_inventory_signals() -> void:
 
     if inventory.contents_changed.is_connected(_queue_refresh):
         inventory.contents_changed.disconnect(_queue_refresh)
-    if inventory.item_modified.is_connected(_on_item_modified):
-        inventory.item_modified.disconnect(_on_item_modified)
+    if inventory.item_property_changed.is_connected(_on_item_property_changed):
+        inventory.item_property_changed.disconnect(_on_item_property_changed)
 
 
 func _on_list_item_activated(index: int) -> void:
@@ -114,8 +111,9 @@ func _on_list_item_clicked(index: int, at_position: Vector2, mouse_button_index:
         inventory_item_context_activated.emit(_get_inventory_item(index))
 
 
-func _on_item_modified(_item: InventoryItem) -> void:
-    _queue_refresh()
+func _on_item_property_changed(_item: InventoryItem, property_name: String) -> void:
+    if property_name in [InventoryItem.KEY_NAME, InventoryItem.KEY_IMAGE]:
+        _queue_refresh()
 
 
 func _process(_delta) -> void:

--- a/addons/gloot/ui/ctrl_inventory_grid_basic.gd
+++ b/addons/gloot/ui/ctrl_inventory_grid_basic.gd
@@ -128,8 +128,8 @@ func _connect_inventory_signals() -> void:
 
     if !inventory.contents_changed.is_connected(_queue_refresh):
         inventory.contents_changed.connect(_queue_refresh)
-    if !inventory.item_modified.is_connected(_on_item_modified):
-        inventory.item_modified.connect(_on_item_modified)
+    if !inventory.item_property_changed.is_connected(_on_item_property_changed):
+        inventory.item_property_changed.connect(_on_item_property_changed)
     if !inventory.size_changed.is_connected(_on_inventory_resized):
         inventory.size_changed.connect(_on_inventory_resized)
     if !inventory.item_removed.is_connected(_on_item_removed):
@@ -142,16 +142,25 @@ func _disconnect_inventory_signals() -> void:
 
     if inventory.contents_changed.is_connected(_queue_refresh):
         inventory.contents_changed.disconnect(_queue_refresh)
-    if inventory.item_modified.is_connected(_on_item_modified):
-        inventory.item_modified.disconnect(_on_item_modified)
+    if inventory.item_property_changed.is_connected(_on_item_property_changed):
+        inventory.item_property_changed.disconnect(_on_item_property_changed)
     if inventory.size_changed.is_connected(_on_inventory_resized):
         inventory.size_changed.disconnect(_on_inventory_resized)
     if inventory.item_removed.is_connected(_on_item_removed):
         inventory.item_removed.disconnect(_on_item_removed)
 
 
-func _on_item_modified(_item: InventoryItem) -> void:
-    _queue_refresh()
+func _on_item_property_changed(_item: InventoryItem, property_name: String) -> void:
+    var relevant_properties = [
+        GridConstraint.KEY_WIDTH,
+        GridConstraint.KEY_HEIGHT,
+        GridConstraint.KEY_SIZE,
+        GridConstraint.KEY_ROTATED,
+        GridConstraint.KEY_GRID_POSITION,
+        InventoryItem.KEY_IMAGE,
+    ]
+    if property_name in relevant_properties:
+        _queue_refresh()
 
 
 func _on_inventory_resized() -> void:

--- a/addons/gloot/ui/ctrl_inventory_item_rect.gd
+++ b/addons/gloot/ui/ctrl_inventory_item_rect.gd
@@ -52,8 +52,8 @@ func _connect_item_signals(new_item: InventoryItem) -> void:
         new_item.protoset_changed.connect(_refresh)
     if !new_item.prototype_id_changed.is_connected(_refresh):
         new_item.prototype_id_changed.connect(_refresh)
-    if !new_item.properties_changed.is_connected(_refresh):
-        new_item.properties_changed.connect(_refresh)
+    if !new_item.property_changed.is_connected(_on_item_property_changed):
+        new_item.property_changed.connect(_on_item_property_changed)
 
 
 func _disconnect_item_signals() -> void:
@@ -64,8 +64,22 @@ func _disconnect_item_signals() -> void:
         item.protoset_changed.disconnect(_refresh)
     if item.prototype_id_changed.is_connected(_refresh):
         item.prototype_id_changed.disconnect(_refresh)
-    if item.properties_changed.is_connected(_refresh):
-        item.properties_changed.disconnect(_refresh)
+    if item.property_changed.is_connected(_on_item_property_changed):
+        item.property_changed.disconnect(_on_item_property_changed)
+
+
+func _on_item_property_changed(property_name: String) -> void:
+    var relevant_properties = [
+        StacksConstraint.KEY_STACK_SIZE, 
+        GridConstraint.KEY_WIDTH,
+        GridConstraint.KEY_HEIGHT,
+        GridConstraint.KEY_SIZE,
+        GridConstraint.KEY_ROTATED,
+        GridConstraint.KEY_GRID_POSITION,
+        InventoryItem.KEY_IMAGE,
+    ]
+    if property_name in relevant_properties:
+        _refresh()
 
 
 func _ready() -> void:

--- a/addons/gloot/ui/ctrl_item_slot.gd
+++ b/addons/gloot/ui/ctrl_item_slot.gd
@@ -8,6 +8,8 @@ const CtrlDropZone = preload("res://addons/gloot/ui/ctrl_drop_zone.gd")
 const CtrlDragable = preload("res://addons/gloot/ui/ctrl_dragable.gd")
 const StacksConstraint = preload("res://addons/gloot/core/constraints/stacks_constraint.gd")
 
+signal item_mouse_entered
+signal item_mouse_exited
 
 @export var item_slot_path: NodePath :
     set(new_item_slot_path):
@@ -150,6 +152,8 @@ func _ready():
     _ctrl_inventory_item_rect.size_flags_vertical = SIZE_EXPAND_FILL
     _ctrl_inventory_item_rect.item_slot = item_slot
     _ctrl_inventory_item_rect.stretch_mode = icon_stretch_mode
+    _ctrl_inventory_item_rect.mouse_entered.connect(_on_mouse_entered)
+    _ctrl_inventory_item_rect.mouse_exited.connect(_on_mouse_exited)
     _hbox_container.add_child(_ctrl_inventory_item_rect)
 
     _ctrl_drop_zone = CtrlDropZone.new()
@@ -230,6 +234,16 @@ func _on_any_dragable_dropped(dragable: CtrlDragable, zone: CtrlDropZone, drop_p
     _ctrl_drop_zone.deactivate()
 
 
+func _on_mouse_entered():
+    var item = item_slot.get_item()
+    emit_signal("item_mouse_entered", item)
+
+
+func _on_mouse_exited():
+    var item = item_slot.get_item()
+    emit_signal("item_mouse_exited", item)
+
+
 func _notification(what: int) -> void:
     if what == NOTIFICATION_DRAG_END:
         _ctrl_drop_zone.deactivate()
@@ -246,7 +260,7 @@ func _refresh() -> void:
 
     var item = item_slot.get_item()
     if is_instance_valid(_label):
-        _label.text = item.get_property(CtrlInventory.KEY_NAME, item.prototype_id)
+        _label.text = item.get_property(InventoryItem.KEY_NAME, item.prototype_id)
     if is_instance_valid(_ctrl_inventory_item_rect):
         _ctrl_inventory_item_rect.item = item
         if item.get_texture():

--- a/addons/gloot/ui/ctrl_item_slot_ex.gd
+++ b/addons/gloot/ui/ctrl_item_slot_ex.gd
@@ -47,13 +47,15 @@ func _set_panel_style(panel: Panel, style: StyleBox) -> void:
         panel.add_theme_stylebox_override("panel", style)
 
 
-func _input(event) -> void:
-    if event is InputEventMouseMotion:
-        if get_global_rect().has_point(get_global_mouse_position()) && slot_highlighted_style:
-            _set_panel_style(_background_panel, slot_highlighted_style)
-            return
-        
-        if slot_style:
-            _set_panel_style(_background_panel, slot_style)
-        else:
-            _background_panel.hide()
+func _on_mouse_entered():
+    if slot_highlighted_style:
+        _set_panel_style(_background_panel, slot_highlighted_style)
+    super._on_mouse_entered()
+
+
+func _on_mouse_exited():
+    if slot_style:
+        _set_panel_style(_background_panel, slot_style)
+    else:
+        _background_panel.hide()
+    super._on_mouse_exited()


### PR DESCRIPTION
Updates Gloot to 2.4.10. The previous version we were on was 2.4.8

The 2.4.9 release contained an [issue](https://github.com/peter-kish/gloot/issues/216). See release notes here: https://github.com/peter-kish/gloot/releases/tag/v2.4.9

The 2.4.10 release notes are here: https://github.com/peter-kish/gloot/releases/tag/v2.4.10

I tested it and the inventory works normally. No new functionality from the new version is applied unless it concerns performance or something.