### PR TITLE
Container sprite fix

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -246,10 +246,8 @@ func add_mobs_to_map() -> void:
 func add_item_to_map(item: Dictionary):
 	var newItem: ContainerItem = ContainerItem.new()
 	newItem.add_to_group("mapitems")
-	var pos: Vector3 = Vector3(item.global_position_x,item.global_position_y,item.global_position_z)
-	newItem.construct_self(pos)
-	level_manager.add_child.call_deferred(newItem)
-	newItem.inventory.deserialize(item.inventory)
+	newItem.construct_self(item)
+	get_tree().get_root().add_child.call_deferred(newItem)
 
 
 # Adds furniture that has been loaded from previously saved data
@@ -269,10 +267,12 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 
 		if furnitureJSON.has("moveable") and furnitureJSON.moveable:
 			newFurniture = FurniturePhysics.new()
+			newFurniture.current_chunk = self
 		else:
 			newFurniture = FurnitureStatic.new()
 
 		add_furniture_to_chunk(newFurniture)
+		
 		# We can't set it's position until after it's in the scene tree 
 		# so we only save the position to a variable and pass it to the furniture
 		var furniturepos: Vector3 =  Vector3(furnitureData.global_position_x,furnitureData.global_position_y,furnitureData.global_position_z)

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -180,11 +180,16 @@ func add_corpse(pos: Vector3):
 			newItem.itemgroup = itemgroup
 		
 		newItem.add_to_group("mapitems")
-		newItem.construct_self(pos)
-		
+		var itemdata: Dictionary = {}
+		itemdata["global_position_x"] = pos.x
+		itemdata["global_position_y"] = pos.y
+		itemdata["global_position_z"] = pos.z
+
 		var fursprite = furnitureJSONData.get("destruction", {}).get("sprite", null)
 		if fursprite:
-			newItem.set_texture(fursprite)
+			itemdata["texture_id"] = fursprite
+		
+		newItem.construct_self(itemdata)
 		
 		# Finally add the new item with possibly set loot group to the tree
 		get_tree().get_root().add_child.call_deferred(newItem)
@@ -205,11 +210,16 @@ func add_wreck(pos: Vector3):
 			newItem.itemgroup = itemgroup
 		
 		newItem.add_to_group("mapitems")
-		newItem.construct_self(pos)
+		var itemdata: Dictionary = {}
+		itemdata["global_position_x"] = pos.x
+		itemdata["global_position_y"] = pos.y
+		itemdata["global_position_z"] = pos.z
 		
 		var fursprite = furnitureJSONData.get("disassembly", {}).get("sprite", null)
 		if fursprite:
-			newItem.set_texture(fursprite)
+			itemdata["texture_id"] = fursprite
+		
+		newItem.construct_self(itemdata)
 		
 		# Finally add the new item with possibly set loot group to the tree
 		get_tree().get_root().add_child.call_deferred(newItem)

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -17,7 +17,7 @@ var corpse_scene: PackedScene = preload("res://Defaults/Mobs/mob_corpse.tscn")
 var current_health: float = 10.0
 
 
-func _ready():
+func _ready() -> void:
 	set_position(furnitureposition)
 	#set_position.call_deferred(furnitureposition)
 	set_new_rotation(furniturerotation)
@@ -25,7 +25,7 @@ func _ready():
 
 # Keep track of the furniture's position and rotation. It starts at 0,0,0 and the moves to it's
 # assigned position after a timer. Until that has happened, we don't need to keep track of it's position
-func _physics_process(_delta):
+func _physics_process(_delta) -> void:
 	if not global_transform.origin == furnitureposition:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
@@ -33,7 +33,7 @@ func _physics_process(_delta):
 		last_rotation = current_rotation
 
 
-func set_new_rotation(amount: int):
+func set_new_rotation(amount: int) -> void:
 	var rotation_amount = amount
 	# Only previously saved furniture will have the global_position_x key. Rotation does not need adjustment
 	if not furnitureJSON.has("global_position_x"):
@@ -48,7 +48,7 @@ func set_new_rotation(amount: int):
 	sprite.rotation_degrees.x = 90 # Static 90 degrees to point at camera
 
 
-func set_sprite(newSprite: Texture):
+func set_sprite(newSprite: Texture) -> void:
 	if not sprite:
 		sprite = Sprite3D.new()
 		sprite.shaded = true
@@ -114,7 +114,7 @@ func construct_self(furniturepos: Vector3, newFurnitureJSON: Dictionary):
 
 
 # Check if we crossed the chunk boundary and update our association with the chunks
-func _moved(newpos:Vector3):
+func _moved(newpos:Vector3) -> void:
 	furnitureposition = newpos
 	var new_chunk = Helper.map_manager.get_chunk_from_position(furnitureposition)
 	if not current_chunk == new_chunk:
@@ -137,7 +137,7 @@ func get_data() -> Dictionary:
 
 # The furniture will move 0.2 meters in a random direction to indicate that it's hit
 # Then it will return to its original position
-func animate_hit():
+func animate_hit() -> void:
 	is_animating_hit = true
 
 	var directions = [Vector3(0.1, 0, 0), Vector3(-0.1, 0, 0), Vector3(0, 0, 0.1), Vector3(0, 0, -0.1)]
@@ -150,12 +150,12 @@ func animate_hit():
 	tween.finished.connect(_on_tween_finished)
 
 # The furniture is done blinking so we reset the relevant variables
-func _on_tween_finished():
+func _on_tween_finished() -> void:
 	is_animating_hit = false
 
 
 
-func get_hit(damage):
+func get_hit(damage) -> void:
 	if can_be_destroyed():
 		current_health -= damage
 		if current_health <= 0:
@@ -164,14 +164,14 @@ func get_hit(damage):
 			if not is_animating_hit:
 				animate_hit()
 
-func _die():
+func _die() -> void:
 	current_chunk.remove_furniture_from_chunk(self)
 	add_corpse.call_deferred(global_position)
 	queue_free.call_deferred()
 	
 
 # When the furniture is destroyed, it leaves a wreck behind
-func add_corpse(pos: Vector3):
+func add_corpse(pos: Vector3) -> void:
 	if can_be_destroyed():
 		var newItem: ContainerItem = ContainerItem.new()
 		
@@ -195,13 +195,13 @@ func add_corpse(pos: Vector3):
 		get_tree().get_root().add_child.call_deferred(newItem)
 
 
-func _disassemble():
+func _disassemble() -> void:
 	add_wreck.call_deferred(global_position)
 	queue_free()
 	
 
 # When the furniture is destroyed, it leaves a wreck behind
-func add_wreck(pos: Vector3):
+func add_wreck(pos: Vector3) -> void:
 	if can_be_disassembled():
 		var newItem: ContainerItem = ContainerItem.new()
 		

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -222,7 +222,11 @@ func get_data() -> Dictionary:
 func add_container(pos: Vector3):
 	if "Function" in furnitureJSONData and "container" in furnitureJSONData["Function"]:
 		container = ContainerItem.new()
-		container.construct_self(pos)
+		var containerdata: Dictionary = {}
+		containerdata["global_position_x"] = pos.x
+		containerdata["global_position_y"] = pos.y
+		containerdata["global_position_z"] = pos.z
+		container.construct_self(containerdata)
 		handle_container_population()
 		add_child(container)
 
@@ -312,7 +316,11 @@ func add_corpse(pos: Vector3):
 			newItem.itemgroup = itemgroup
 		
 		newItem.add_to_group("mapitems")
-		newItem.construct_self(pos)
+		var itemdata: Dictionary = {}
+		itemdata["global_position_x"] = pos.x
+		itemdata["global_position_y"] = pos.y
+		itemdata["global_position_z"] = pos.z
+		newItem.construct_self(itemdata)
 		
 		var fursprite = furnitureJSONData.get("destruction", {}).get("sprite", null)
 		if fursprite:
@@ -344,7 +352,11 @@ func add_wreck(pos: Vector3):
 			newItem.itemgroup = itemgroup
 		
 		newItem.add_to_group("mapitems")
-		newItem.construct_self(pos)
+		var itemdata: Dictionary = {}
+		itemdata["global_position_x"] = pos.x
+		itemdata["global_position_y"] = pos.y
+		itemdata["global_position_z"] = pos.z
+		newItem.construct_self(itemdata)
 		
 		var fursprite = furnitureJSONData.get("disassembly", {}).get("sprite", null)
 		if fursprite:

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -92,7 +92,11 @@ func add_corpse(pos: Vector3):
 		print_debug("No loot_group found for mob ID: " + str(mobJSON.id))
 	
 	newItem.add_to_group("mapitems")
-	newItem.construct_self(pos)
+	var itemdata: Dictionary = {}
+	itemdata["global_position_x"] = pos.x
+	itemdata["global_position_y"] = pos.y
+	itemdata["global_position_z"] = pos.z
+	newItem.construct_self(itemdata)
 	# Finally add the new item with possibly set loot group to the tree
 	get_tree().get_root().add_child.call_deferred(newItem)
 


### PR DESCRIPTION
Fixes #189 

No sprite was saved and loaded for containers, so I added that functionality. This only applies to containers created during gameplay, for example when moveable furniture or a mob is destroyed and loot is created. In order to do this, I had to pass more then the position into construct_self, so now construct_self takes a dictionary of the item that was first saved and then loaded. 

Then there were some issues with setting the sprite after a load. It checked if the container was added to the scene tree. But when the container was loaded, the chunk would add it to the levelmanager instead of the scene root. I changed it so that chunk adds containers to the scene root now.