### PR TITLE
Crafting menu respects volume in inventory

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cllbo1owveorj"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cqdiuynwooaok"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 
@@ -9,7 +9,7 @@ json_data = "[
 		\"description\": \"A wooden plank that could be used for all kinds of crafting and construction\",
 		\"id\": \"plank_2x4\",
 		\"image\": \"./Mods/Core/Items/plank.png\",
-		\"max_stack_size\": \"3\",
+		\"max_stack_size\": 3,
 		\"name\": \"Plank 2x4\",
 		\"references\": {
 			\"core\": {
@@ -25,16 +25,16 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"plank.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"300\",
-		\"weight\": \"2\"
+		\"volume\": 300,
+		\"weight\": 2
 	},
 	{
 		\"description\": \"Some metal bits and pieces. Useful for something, right?\",
 		\"id\": \"steel_scrap\",
 		\"image\": \"./Mods/Core/Items/steel_scrap.png\",
-		\"max_stack_size\": \"100\",
+		\"max_stack_size\": 100,
 		\"name\": \"Steel scrap\",
 		\"references\": {
 			\"core\": {
@@ -51,10 +51,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"steel_scrap.png\",
-		\"stack_size\": \"2\",
+		\"stack_size\": 2,
 		\"two_handed\": false,
-		\"volume\": \"15\",
-		\"weight\": \"0.25\"
+		\"volume\": 15,
+		\"weight\": 0.25
 	},
 	{
 		\"Ammo\": {
@@ -63,7 +63,7 @@ json_data = "[
 		\"description\": \"Standard type of ammunition. Very common.\",
 		\"id\": \"bullet_9mm\",
 		\"image\": \"./Mods/Core/Items/9mm.png\",
-		\"max_stack_size\": \"100\",
+		\"max_stack_size\": 100,
 		\"name\": \"bullet 9mm\",
 		\"references\": {
 			\"core\": {
@@ -77,10 +77,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"9mm.png\",
-		\"stack_size\": \"20\",
+		\"stack_size\": 20,
 		\"two_handed\": false,
-		\"volume\": \"0.1\",
-		\"weight\": \"0.01\"
+		\"volume\": 0.1,
+		\"weight\": 0.01
 	},
 	{
 		\"Craft\": [
@@ -118,7 +118,7 @@ json_data = "[
 		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
 		\"id\": \"pistol_magazine\",
 		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Pistol magazine\",
 		\"references\": {
 			\"core\": {
@@ -129,10 +129,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"pistol_magazine.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.25\"
+		\"volume\": 10,
+		\"weight\": 0.25
 	},
 	{
 		\"Ranged\": {
@@ -152,7 +152,7 @@ json_data = "[
 		\"description\": \"A standard issue pistol that uses 9mm ammunition\",
 		\"id\": \"pistol_9mm\",
 		\"image\": \"./Mods/Core/Items/pistol_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Pistol 9mm\",
 		\"references\": {
 			\"core\": {
@@ -162,10 +162,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"pistol_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"150\",
-		\"weight\": \"2\"
+		\"volume\": 150,
+		\"weight\": 2
 	},
 	{
 		\"Ranged\": {
@@ -185,13 +185,13 @@ json_data = "[
 		\"description\": \"A standard issue rifle that uses 9mm ammunition\",
 		\"id\": \"rifle_m4a1\",
 		\"image\": \"./Mods/Core/Items/rifle_64_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"M4a1 rifle\",
 		\"sprite\": \"rifle_64_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": true,
-		\"volume\": \"300\",
-		\"weight\": \"4\"
+		\"volume\": 300,
+		\"weight\": 4
 	},
 	{
 		\"Ranged\": {
@@ -211,13 +211,13 @@ json_data = "[
 		\"description\": \"Chugun in Russian is for cast steel, MPAP is \\\"Multi Purpose Automatic Pistol\\\"\",
 		\"id\": \"chugunov_mpap\",
 		\"image\": \"./Mods/Core/Items/chugunov_mpap_32_28.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Chugunov MPAP\",
 		\"sprite\": \"chugunov_mpap_32_28.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": true,
-		\"volume\": \"150\",
-		\"weight\": \"3\"
+		\"volume\": 150,
+		\"weight\": 3
 	},
 	{
 		\"Magazine\": {
@@ -228,19 +228,19 @@ json_data = "[
 		\"description\": \"A magazine to be loaded into a Chuganov MPAP\",
 		\"id\": \"chugunov_mpap_magazine\",
 		\"image\": \"./Mods/Core/Items/chugunov_mpap_magazine_16_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Chuganov MPAP magazine\",
 		\"sprite\": \"chugunov_mpap_magazine_16_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.25\"
+		\"volume\": 10,
+		\"weight\": 0.25
 	},
 	{
 		\"description\": \"This plastic bottle only contains air\",
 		\"id\": \"bottle_plastic_empty\",
 		\"image\": \"./Mods/Core/Items/bottle_empty_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Empty plastic bottle\",
 		\"references\": {
 			\"core\": {
@@ -253,10 +253,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"bottle_empty_32.png\",
-		\"stack_size\": \"2\",
+		\"stack_size\": 2,
 		\"two_handed\": false,
-		\"volume\": \"15\",
-		\"weight\": \"0.1\"
+		\"volume\": 15,
+		\"weight\": 0.1
 	},
 	{
 		\"Food\": {
@@ -265,27 +265,28 @@ json_data = "[
 		\"description\": \"This plastic bottle is filled with water\",
 		\"id\": \"bottle_plastic_water\",
 		\"image\": \"./Mods/Core/Items/bottle_water_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Plastic bottle with water\",
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
 					\"kitchen_cupboard\",
-					\"cabinet_general\"
+					\"cabinet_general\",
+					\"refridgerator\"
 				]
 			}
 		},
 		\"sprite\": \"bottle_water_32.png\",
-		\"stack_size\": \"2\",
+		\"stack_size\": 2,
 		\"two_handed\": false,
-		\"volume\": \"15\",
-		\"weight\": \"0.25\"
+		\"volume\": 15,
+		\"weight\": 0.25
 	},
 	{
 		\"description\": \"The contents will satisfy your hunger\",
 		\"id\": \"canned_food\",
 		\"image\": \"./Mods/Core/Items/canned_food_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Canned food\\t\",
 		\"references\": {
 			\"core\": {
@@ -295,10 +296,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"canned_food_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"30\",
-		\"weight\": \"0.25\"
+		\"volume\": 30,
+		\"weight\": 0.25
 	},
 	{
 		\"Melee\": {
@@ -308,31 +309,31 @@ json_data = "[
 		\"description\": \"A sharp blade with a handle for excellent control\",
 		\"id\": \"machete\",
 		\"image\": \"./Mods/Core/Items/machete_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Machete\",
 		\"sprite\": \"machete_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"4\"
+		\"volume\": 100,
+		\"weight\": 4
 	},
 	{
 		\"description\": \"Anyone is able to craft this simple arrow\",
 		\"id\": \"wood_arrow_basic\",
 		\"image\": \"./Mods/Core/Items/arrow_basic_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Basic wooden arrow\",
 		\"sprite\": \"arrow_basic_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"1\",
-		\"weight\": \"0.1\"
+		\"volume\": 1,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A stick with a block of steel on it. It is used to apply force to objects like nails\",
 		\"id\": \"hammer\",
 		\"image\": \"./Mods/Core/Items/hammer_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Hammer\",
 		\"references\": {
 			\"core\": {
@@ -342,10 +343,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"hammer_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"2\"
+		\"volume\": 50,
+		\"weight\": 2
 	},
 	{
 		\"Craft\": [
@@ -370,7 +371,7 @@ json_data = "[
 		\"description\": \"A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects\",
 		\"id\": \"screwdriver\",
 		\"image\": \"./Mods/Core/Items/screwdriver_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Screwdriver\",
 		\"references\": {
 			\"core\": {
@@ -381,16 +382,16 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"screwdriver_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"20\",
-		\"weight\": \"0.5\"
+		\"volume\": 20,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A basic bandage that will help to heal a wound\",
 		\"id\": \"bandage_basic\",
 		\"image\": \"./Mods/Core/Items/bandage_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Bandage\",
 		\"references\": {
 			\"core\": {
@@ -401,16 +402,16 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"bandage_32.png\",
-		\"stack_size\": \"3\",
+		\"stack_size\": 3,
 		\"two_handed\": false,
-		\"volume\": \"1\",
-		\"weight\": \"0.1\"
+		\"volume\": 1,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A small bottle that contains antibiotics. It helps to recover from disease.\",
 		\"id\": \"bottle_antibiotics\",
 		\"image\": \"./Mods/Core/Items/antibiotics_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Bottle of antibiotics\",
 		\"references\": {
 			\"core\": {
@@ -420,10 +421,10 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"antibiotics_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"Wearable\": {
@@ -432,13 +433,20 @@ json_data = "[
 		\"description\": \"A piece of clothing to wear on the torso. It will keep you warm and offers a bit of protection.\",
 		\"id\": \"jacket\",
 		\"image\": \"./Mods/Core/Items/jacket_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Jacket\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"clothing_general\"
+				]
+			}
+		},
 		\"sprite\": \"jacket_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"1\"
+		\"volume\": 100,
+		\"weight\": 1
 	},
 	{
 		\"Wearable\": {
@@ -447,38 +455,39 @@ json_data = "[
 		\"description\": \"Comfortable footwear to keep your feet safe\",
 		\"id\": \"boots\",
 		\"image\": \"./Mods/Core/Items/boots_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Boots\",
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"cabinet_general\"
+					\"cabinet_general\",
+					\"clothing_general\"
 				]
 			}
 		},
 		\"sprite\": \"boots_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"1\"
+		\"volume\": 100,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A large container that holds gasoline\",
 		\"id\": \"jerrycan_gasoline\",
 		\"image\": \"./Mods/Core/Items/jerrycan_gas_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Jerrycan of gasoline\",
 		\"sprite\": \"jerrycan_gas_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"400\",
-		\"weight\": \"10\"
+		\"volume\": 400,
+		\"weight\": 10
 	},
 	{
 		\"description\": \"It's a can that contains oil. It has a spout that allows you to pour it out.\",
 		\"id\": \"can_oil\",
 		\"image\": \"./Mods/Core/Items/can_oil_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Can of oil\",
 		\"references\": {
 			\"core\": {
@@ -488,28 +497,28 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"can_oil_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"2\"
+		\"volume\": 100,
+		\"weight\": 2
 	},
 	{
 		\"description\": \"A small radio that can be powered by batteries or an electical cord.\",
 		\"id\": \"radio_handheld\",
 		\"image\": \"./Mods/Core/Items/battery_powered_radio_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Handheld radio\",
 		\"sprite\": \"battery_powered_radio_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"1\"
+		\"volume\": 100,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A basic battery powered flashlight. It will shine a beam of light when it is turned on\",
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Core/Items/flashlight_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Flashlight\",
 		\"references\": {
 			\"core\": {
@@ -519,41 +528,42 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"flashlight_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"0.5\"
+		\"volume\": 100,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"It's a can that contains beer. Don't drink a lot of it or you will get drunk\",
 		\"id\": \"can_beer\",
 		\"image\": \"./Mods/Core/Items/can_beer_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Can of beer\",
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"kitchen_cupboard\"
+					\"kitchen_cupboard\",
+					\"refridgerator\"
 				]
 			}
 		},
 		\"sprite\": \"can_beer_32.png\",
-		\"stack_size\": \"2\",
+		\"stack_size\": 2,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.5\"
+		\"volume\": 50,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking\",
 		\"id\": \"pack_sigarrettes\",
 		\"image\": \"./Mods/Core/Items/sigarrette_pack_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Pack of sigarrettes\",
 		\"sprite\": \"sigarrette_pack_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.1\"
+		\"volume\": 10,
+		\"weight\": 0.1
 	},
 	{
 		\"Wearable\": {
@@ -562,43 +572,50 @@ json_data = "[
 		\"description\": \"A piece of clothing that offers protection from environmental hazards\",
 		\"id\": \"gas_mask\",
 		\"image\": \"./Mods/Core/Items/gasmask_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Gas mask\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"clothing_general\"
+				]
+			}
+		},
 		\"sprite\": \"gasmask_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"80\",
-		\"weight\": \"1\"
+		\"volume\": 80,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A piece of clothing that offers protection from ballistic forces\",
 		\"id\": \"vest_ballistic\",
 		\"image\": \"./Mods/Core/Items/vest_ballistic_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Ballistic vest\",
 		\"sprite\": \"vest_ballistic_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"150\",
-		\"weight\": \"4\"
+		\"volume\": 150,
+		\"weight\": 4
 	},
 	{
 		\"description\": \"A device that shows your orientation relative to the earth's poles\",
 		\"id\": \"compass\",
 		\"image\": \"./Mods/Core/Items/compass_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Compass\",
 		\"sprite\": \"compass_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"6\",
-		\"weight\": \"0.1\"
+		\"volume\": 6,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A very common type of battery that fits most battery-powered devices\",
 		\"id\": \"battery_small\",
 		\"image\": \"./Mods/Core/Items/battery_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Small battery\",
 		\"references\": {
 			\"core\": {
@@ -608,76 +625,76 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"battery_32.png\",
-		\"stack_size\": \"2\",
+		\"stack_size\": 2,
 		\"two_handed\": false,
-		\"volume\": \"0.1\",
-		\"weight\": \"0.1\"
+		\"volume\": 0.01,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A large panel that draws power from the sun\",
 		\"id\": \"solar_panel\",
 		\"image\": \"./Mods/Core/Items/solar_panel_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Solar panel\",
 		\"sprite\": \"solar_panel_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"1000\",
-		\"weight\": \"10\"
+		\"volume\": 1000,
+		\"weight\": 10
 	},
 	{
 		\"description\": \"A large piece of paper that visualizes the area around you\",
 		\"id\": \"map_paper\",
 		\"image\": \"./Mods/Core/Items/map_paper_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Paper map\",
 		\"sprite\": \"map_paper_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A piece of fabric and some strings. You can deploy it to get some shelter from the weather\",
 		\"id\": \"tarp\",
 		\"image\": \"./Mods/Core/Items/tarp_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Tarp\",
 		\"sprite\": \"tarp_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"150\",
-		\"weight\": \"3\"
+		\"volume\": 150,
+		\"weight\": 3
 	},
 	{
 		\"description\": \"A piece of fabric and some strings. You can deploy it to get some shelter from the weather. It is currently folded to save space.\",
 		\"id\": \"tent\",
 		\"image\": \"./Mods/Core/Items/tent_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Tent\",
 		\"sprite\": \"tent_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"600\",
-		\"weight\": \"9\"
+		\"volume\": 600,
+		\"weight\": 9
 	},
 	{
 		\"description\": \"A small book explaining the very basics of survival\",
 		\"id\": \"guide_survival_basic\",
 		\"image\": \"./Mods/Core/Items/survival_guide_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Basic survival guide\",
 		\"sprite\": \"survival_guide_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.1\"
+		\"volume\": 10,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A book containing an entertaining story\",
 		\"id\": \"book_novel\",
 		\"image\": \"./Mods/Core/Items/book_novel_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Novel\",
 		\"references\": {
 			\"core\": {
@@ -687,16 +704,16 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"book_novel_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.4\"
+		\"volume\": 10,
+		\"weight\": 0.4
 	},
 	{
 		\"description\": \"A small bottle that contains disinfectant. It helps to disinfect wounds\",
 		\"id\": \"bottle_disinfectant\",
 		\"image\": \"./Mods/Core/Items/bottle_disinfectant_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Bottle of disinfectant\",
 		\"references\": {
 			\"core\": {
@@ -706,94 +723,94 @@ json_data = "[
 			}
 		},
 		\"sprite\": \"bottle_disinfectant_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A small radio that allows you to communicate with someone over a large distance\",
 		\"id\": \"radio_two_way\",
 		\"image\": \"./Mods/Core/Items/radio_two_way_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Two way radio\",
 		\"sprite\": \"radio_two_way_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"1\"
+		\"volume\": 50,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A small device that provides a spark that can be used to light a fire. No power or fuel required.\",
 		\"id\": \"firestarter_basic\",
 		\"image\": \"./Mods/Core/Items/firestarter_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Firestarter\",
 		\"sprite\": \"firestarter_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.2\"
+		\"volume\": 10,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"\\n    A true survival fishing kit in a very small, lightweight package!\\n    Contains 118 foot line and winder\\n    2 lures, 2 hooks\\n    2 swivels, 2 weghts\\n    Comes in a strong durable heavy duty resealable plastic bag\",
 		\"id\": \"kit_fishing_small\",
 		\"image\": \"./Mods/Core/Items/kit_fishing_small_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Small fishing kit\",
 		\"sprite\": \"kit_fishing_small_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.4\"
+		\"volume\": 50,
+		\"weight\": 0.4
 	},
 	{
 		\"description\": \"A versatile kitchen tool, essential for slicing, dicing, and chopping food.\",
 		\"id\": \"kitchen_knife\",
 		\"image\": \"./Mods/Core/Items/kitchen_knife_64_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Kitchen Knife\",
 		\"sprite\": \"kitchen_knife_64_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"0.4\"
+		\"volume\": 100,
+		\"weight\": 0.4
 	},
 	{
 		\"description\": \"A compact and portable stove, perfect for cooking meals during survival situations.\",
 		\"id\": \"portable_stove\",
 		\"image\": \"./Mods/Core/Items/portable_stove_64_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Portable Stove\",
 		\"sprite\": \"portable_stove_64_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"200\",
-		\"weight\": \"3\"
+		\"volume\": 200,
+		\"weight\": 3
 	},
 	{
 		\"description\": \"A durable cooking pot, essential for boiling water and preparing meals.\",
 		\"id\": \"cooking_pot\",
 		\"image\": \"./Mods/Core/Items/cooking_pot_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Cooking Pot\",
 		\"sprite\": \"cooking_pot_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"350\",
-		\"weight\": \"3\"
+		\"volume\": 350,
+		\"weight\": 3
 	},
 	{
 		\"description\": \"A small tool crucial for opening canned food, an essential for survival.\",
 		\"id\": \"can_opener\",
 		\"image\": \"./Mods/Core/Items/can_opener_64_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Can opener\",
 		\"sprite\": \"can_opener_64_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"60\",
-		\"weight\": \"0.2\"
+		\"volume\": 60,
+		\"weight\": 0.2
 	},
 	{
 		\"Craft\": [
@@ -822,61 +839,61 @@ json_data = "[
 		\"description\": \"A sturdy cutting board, ideal for preparing food safely and efficiently.\",
 		\"id\": \"cutting_board\",
 		\"image\": \"./Mods/Core/Items/cutting_board_64_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Cutting Board\",
 		\"sprite\": \"cutting_board_64_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"200\",
-		\"weight\": \"1\"
+		\"volume\": 200,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A large bowl used for mixing ingredients, indispensable for any cooking or baking tasks.\",
 		\"id\": \"mixing_bowl\",
 		\"image\": \"./Mods/Core/Items/mixing_bowl_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Mixing Bowl\",
 		\"sprite\": \"mixing_bowl_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"250\",
-		\"weight\": \"0.5\"
+		\"volume\": 250,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A metal kettle perfect for boiling water to make tea or instant meals.\",
 		\"id\": \"tea_kettle\",
 		\"image\": \"./Mods/Core/Items/tea_kettle_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Tea Kettle\",
 		\"sprite\": \"tea_kettle_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"200\",
-		\"weight\": \"1\"
+		\"volume\": 200,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A small rack containing various spices to enhance the flavor of food.\",
 		\"id\": \"spice_rack\",
 		\"image\": \"./Mods/Core/Items/spice_rack_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Spice Rack\",
 		\"sprite\": \"spice_rack_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"150\",
-		\"weight\": \"1\"
+		\"volume\": 150,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A measuring cup, essential for precisely measuring ingredients for recipes.\",
 		\"id\": \"measuring_cup\",
 		\"image\": \"./Mods/Core/Items/measuring_cup_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Measuring Cup\",
 		\"sprite\": \"measuring_cup_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"0.3\"
+		\"volume\": 100,
+		\"weight\": 0.3
 	},
 	{
 		\"Craft\": [
@@ -905,696 +922,794 @@ json_data = "[
 		\"description\": \"A wooden rolling pin, essential for flattening dough for baking.\",
 		\"id\": \"rolling_pin\",
 		\"image\": \"./Mods/Core/Items/rolling_pin_64_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Rolling Pin\",
 		\"sprite\": \"rolling_pin_64_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"150\",
-		\"weight\": \"0.5\"
+		\"volume\": 150,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A heavy-duty frying pan, perfect for cooking everything from eggs to stir-fry.\",
 		\"id\": \"frying_pan\",
 		\"image\": \"./Mods/Core/Items/frying_pan_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Frying Pan\",
 		\"sprite\": \"frying_pan_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"200\",
-		\"weight\": \"2\"
+		\"volume\": 200,
+		\"weight\": 2
 	},
 	{
 		\"description\": \"A metal colander, ideal for draining pasta or washing vegetables.\",
 		\"id\": \"steel_colander\",
 		\"image\": \"./Mods/Core/Items/steel_colander_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Colander\",
 		\"sprite\": \"steel_colander_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"200\",
-		\"weight\": \"0.7\"
+		\"volume\": 200,
+		\"weight\": 0.7
 	},
 	{
 		\"description\": \"A handy peeler, perfect for skinning vegetables and fruits with ease.\",
 		\"id\": \"peeler\",
 		\"image\": \"./Mods/Core/Items/peeler_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Peeler\",
 		\"sprite\": \"peeler_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.1\"
+		\"volume\": 50,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A metal grater, essential for shredding cheese, vegetables, and more.\",
 		\"id\": \"grater\",
 		\"image\": \"./Mods/Core/Items/grater_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Grater\",
 		\"sprite\": \"grater_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.3\"
+		\"volume\": 50,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A compact electric toaster, ideal for toasting bread quickly.\",
 		\"id\": \"toaster\",
 		\"image\": \"./Mods/Core/Items/toaster_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Toaster\",
 		\"sprite\": \"toaster_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"300\",
-		\"weight\": \"1.5\"
+		\"volume\": 300,
+		\"weight\": 1.5
 	},
 	{
 		\"description\": \"An electric blender, perfect for making smoothies, soups, and other blended concoctions.\",
 		\"id\": \"blender\",
 		\"image\": \"./Mods/Core/Items/blender_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Blender\",
 		\"sprite\": \"blender_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"300\",
-		\"weight\": \"2\"
+		\"volume\": 300,
+		\"weight\": 2
 	},
 	{
 		\"description\": \"A coffee maker, essential for brewing the perfect cup of coffee to start your day.\",
 		\"id\": \"coffee_maker\",
 		\"image\": \"./Mods/Core/Items/coffeemaker_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Coffee Maker\",
 		\"sprite\": \"coffeemaker_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"300\",
-		\"weight\": \"2.5\"
+		\"volume\": 300,
+		\"weight\": 2.5
 	},
 	{
 		\"description\": \"A microwave oven, perfect for quickly heating or cooking food.\",
 		\"id\": \"microwave_oven\",
 		\"image\": \"./Mods/Core/Items/microwave_oven_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Microwave Oven\",
 		\"sprite\": \"microwave_oven_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"400\",
-		\"weight\": \"12\"
+		\"volume\": 400,
+		\"weight\": 12
 	},
 	{
 		\"description\": \"A dish rack, useful for organizing and drying dishes after washing.\",
 		\"id\": \"dish_rack\",
 		\"image\": \"./Mods/Core/Items/dish_rack_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Dish Rack\",
 		\"sprite\": \"dish_rack_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"400\",
-		\"weight\": \"1\"
+		\"volume\": 400,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A pressure cooker, ideal for fast cooking and preserving nutrients in food.\",
 		\"id\": \"pressure_cooker\",
 		\"image\": \"./Mods/Core/Items/pressure_cooker_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Pressure Cooker\",
 		\"sprite\": \"pressure_cooker_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"400\",
-		\"weight\": \"5\"
+		\"volume\": 400,
+		\"weight\": 5
 	},
 	{
 		\"description\": \"A bread maker, perfect for effortlessly baking fresh bread at home.\",
 		\"id\": \"bread_maker\",
 		\"image\": \"./Mods/Core/Items/bread_maker_32.png\",
-		\"max_stack_size\": \"1\",
+		\"max_stack_size\": 1,
 		\"name\": \"Bread Maker\",
 		\"sprite\": \"bread_maker_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"300\",
-		\"weight\": \"5\"
+		\"volume\": 300,
+		\"weight\": 5
 	},
 	{
 		\"description\": \"Small but crucial for holding together wooden structures and crafting. Often found in the remnants of furniture and buildings.\",
 		\"id\": \"nails\",
 		\"image\": \"./Mods/Core/Items/nails_32.png\",
-		\"max_stack_size\": \"100\",
+		\"max_stack_size\": 100,
 		\"name\": \"Nails\",
 		\"sprite\": \"nails_32.png\",
-		\"stack_size\": \"10\",
+		\"stack_size\": 10,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"Large pieces of wood obtained from cutting down trees. Useful for building and crafting larger items.\",
 		\"id\": \"log\",
 		\"image\": \"./Mods/Core/Items/log_32.png\",
-		\"max_stack_size\": \"3\",
+		\"max_stack_size\": 3,
 		\"name\": \"Log\",
 		\"sprite\": \"log_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": true,
-		\"volume\": \"500\",
-		\"weight\": \"10\"
+		\"volume\": 500,
+		\"weight\": 10
 	},
 	{
 		\"description\": \"Versatile fasteners used in both wooden and metal constructions. Can be scavenged from disassembled furniture and machinery.\",
 		\"id\": \"screw\",
 		\"image\": \"./Mods/Core/Items/screw_32.png\",
-		\"max_stack_size\": \"100\",
+		\"max_stack_size\": 100,
 		\"name\": \"Screw\",
 		\"sprite\": \"screw_32.png\",
-		\"stack_size\": \"10\",
+		\"stack_size\": 10,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"Smaller pieces of wood that can be used for kindling, basic crafting, and creating primitive tools.\",
 		\"id\": \"branch\",
 		\"image\": \"./Mods/Core/Items/branches_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Branch\",
 		\"sprite\": \"branches_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"2\"
+		\"volume\": 50,
+		\"weight\": 2
 	},
 	{
 		\"description\": \"Can be used for camouflage, crafting bedding, or as a basic source of compost.\",
 		\"id\": \"leaf\",
 		\"image\": \"./Mods/Core/Items/leaves_32.png\",
-		\"max_stack_size\": \"50\",
+		\"max_stack_size\": 50,
 		\"name\": \"Leaf\",
 		\"sprite\": \"leaves_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"1\",
-		\"weight\": \"0.01\"
+		\"volume\": 1,
+		\"weight\": 0.01
 	},
 	{
 		\"description\": \"Resinous branches that can be used for kindling or basic crafting.\",
 		\"id\": \"pine_branch\",
 		\"image\": \"./Mods/Core/Items/pine_branch_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Pine Branch\",
 		\"sprite\": \"pine_branch_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"2\"
+		\"volume\": 50,
+		\"weight\": 2
 	},
 	{
 		\"description\": \"Natural material that can be molded when wet and hardens when dried, useful for creating pottery, bricks, and reinforcing structures.\",
 		\"id\": \"clay\",
 		\"image\": \"./Mods/Core/Items/clay_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Clay\",
 		\"sprite\": \"clay_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"20\",
-		\"weight\": \"1\"
+		\"volume\": 20,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"Basic resource for growing plants and creating makeshift gardens for food production.\",
 		\"id\": \"soil\",
 		\"image\": \"./Mods/Core/Items/soil_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Soil\",
 		\"sprite\": \"soil_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"200\",
-		\"weight\": \"5\"
+		\"volume\": 200,
+		\"weight\": 5
 	},
 	{
 		\"description\": \"Metal parts that allow doors and cabinets to open and close. Can be used in various mechanical constructions.\",
 		\"id\": \"hinge\",
 		\"image\": \"./Mods/Core/Items/hinge_32.png\",
-		\"max_stack_size\": \"50\",
+		\"max_stack_size\": 50,
 		\"name\": \"Hinge\",
 		\"sprite\": \"hinge_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.2\"
+		\"volume\": 5,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"Useful for creating compost, crafting, or even as emergency food sources.\",
 		\"id\": \"plant_remnants\",
 		\"image\": \"./Mods/Core/Items/plant_remnants_32.png\",
-		\"max_stack_size\": \"50\",
+		\"max_stack_size\": 50,
 		\"name\": \"Plant Remnants\",
 		\"sprite\": \"plant_remnants_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.1\"
+		\"volume\": 10,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"Essential for repairing or crafting electronic devices.\",
 		\"id\": \"electrical_components\",
 		\"image\": \"./Mods/Core/Items/electrical_components_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Electrical Components\",
 		\"sprite\": \"electrical_components_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"20\",
-		\"weight\": \"0.5\"
+		\"volume\": 20,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"Versatile material used in various crafting recipes, often scavenged from modern appliances and containers.\",
 		\"id\": \"plastic_parts\",
 		\"image\": \"./Mods/Core/Items/plastic_parts_32.png\",
-		\"max_stack_size\": \"50\",
+		\"max_stack_size\": 50,
 		\"name\": \"Plastic Parts\",
 		\"sprite\": \"plastic_parts_32.png\",
-		\"stack_size\": \"10\",
+		\"stack_size\": 10,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.3\"
+		\"volume\": 10,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"Shards of broken ceramic items, useful for crafting new items or reinforcing existing structures.\",
 		\"id\": \"ceramic_fragments\",
 		\"image\": \"./Mods/Core/Items/ceramic_fragments_32.png\",
-		\"max_stack_size\": \"30\",
+		\"max_stack_size\": 30,
 		\"name\": \"Ceramic Fragments\",
 		\"sprite\": \"ceramic_fragments_32.png\",
-		\"stack_size\": \"5\",
+		\"stack_size\": 5,
 		\"two_handed\": false,
-		\"volume\": \"15\",
-		\"weight\": \"1\"
+		\"volume\": 15,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"General metal components used in various crafting and construction recipes.\",
 		\"id\": \"metal_parts\",
 		\"image\": \"./Mods/Core/Items/metal_parts_32.png\",
-		\"max_stack_size\": \"50\",
+		\"max_stack_size\": 50,
 		\"name\": \"Metal Parts\",
 		\"sprite\": \"metal_parts_32.png\",
-		\"stack_size\": \"10\",
+		\"stack_size\": 10,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.5\"
+		\"volume\": 10,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A jar of preserved parsley, useful for adding flavor to dishes.\",
 		\"id\": \"jar_parsley\",
 		\"image\": \"./Mods/Core/Items/jar_parsley_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Jar of Parsley\",
 		\"sprite\": \"jar_parsley_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"60\",
-		\"weight\": \"0.5\"
+		\"volume\": 60,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A block of tofu, a good source of protein.\",
 		\"id\": \"tofu\",
 		\"image\": \"./Mods/Core/Items/tofu_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Tofu\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"tofu_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"30\",
-		\"weight\": \"0.5\"
+		\"volume\": 30,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A bottle of yogurt, useful for nutrition and digestion.\",
 		\"id\": \"bottle_yogurt\",
 		\"image\": \"./Mods/Core/Items/bottle_yogurt_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Bottle of Yogurt\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"bottle_yogurt_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"100\",
-		\"weight\": \"0.3\"
+		\"volume\": 100,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A jar of pickles, a tasty preserved food.\",
 		\"id\": \"jar_pickles\",
 		\"image\": \"./Mods/Core/Items/jar_pickles_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Jar of Pickles\",
 		\"sprite\": \"jar_pickles_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"1\"
+		\"volume\": 50,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A can of condensed milk, a rich source of nutrition.\",
 		\"id\": \"condensed_milk\",
 		\"image\": \"./Mods/Core/Items/condensed_milk_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Condensed Milk\",
 		\"sprite\": \"condensed_milk_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"60\",
-		\"weight\": \"0.8\"
+		\"volume\": 60,
+		\"weight\": 0.8
 	},
 	{
 		\"description\": \"A vial of insulin, necessary for diabetics.\",
 		\"id\": \"insulin\",
 		\"image\": \"./Mods/Core/Items/insulin_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Insulin\",
 		\"sprite\": \"insulin_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"An epinephrine auto-injector, useful for treating severe allergic reactions.\",
 		\"id\": \"epipen\",
 		\"image\": \"./Mods/Core/Items/epipen_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"EpiPen\",
 		\"sprite\": \"epipen_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A bag of bacon, rich in fats and proteins.\",
 		\"id\": \"bag_bacon\",
 		\"image\": \"./Mods/Core/Items/bag_bacon_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Bag of Bacon\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"bag_bacon_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"30\",
-		\"weight\": \"0.5\"
+		\"volume\": 30,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A bottle of wine, useful for bartering or a morale boost.\",
 		\"id\": \"wine_bottle\",
 		\"image\": \"./Mods/Core/Items/wine_bottle_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Wine Bottle\",
 		\"sprite\": \"wine_bottle_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"90\",
-		\"weight\": \"1.5\"
+		\"volume\": 90,
+		\"weight\": 1.5
 	},
 	{
 		\"description\": \"A loaf of bread, a staple food item.\",
 		\"id\": \"bread\",
 		\"image\": \"./Mods/Core/Items/bread_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Bread\",
 		\"sprite\": \"bread_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"90\",
-		\"weight\": \"0.5\"
+		\"volume\": 90,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A syringe, useful for administering medical treatments.\",
 		\"id\": \"syringe\",
 		\"image\": \"./Mods/Core/Items/syringe_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Syringe\",
 		\"sprite\": \"syringe_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.05\"
+		\"volume\": 5,
+		\"weight\": 0.05
 	},
 	{
 		\"description\": \"A slice of pizza, not very fresh but still edible.\",
 		\"id\": \"slice_of_pizza\",
 		\"image\": \"./Mods/Core/Items/slice_of_pizza_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Slice of Pizza\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"slice_of_pizza_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.3\"
+		\"volume\": 50,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A package of vacuum-sealed fish, preserved for longer storage.\",
 		\"id\": \"vacuum_sealed_fish\",
 		\"image\": \"./Mods/Core/Items/vacuum_sealed_fish_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Vacuum Sealed Fish\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"vacuum_sealed_fish_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.8\"
+		\"volume\": 50,
+		\"weight\": 0.8
 	},
 	{
 		\"description\": \"A ripe tomato, still fresh and edible.\",
 		\"id\": \"tomato\",
 		\"image\": \"./Mods/Core/Items/tomato_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Tomato\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"tomato_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.2\"
+		\"volume\": 10,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"A head of lettuce, slightly wilted but still usable.\",
 		\"id\": \"lettuce\",
 		\"image\": \"./Mods/Core/Items/lettuce_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Lettuce\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"lettuce_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"90\",
-		\"weight\": \"0.3\"
+		\"volume\": 90,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A container of protein powder, useful for maintaining nutrition.\",
 		\"id\": \"protein_powder\",
 		\"image\": \"./Mods/Core/Items/protein_powder_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Protein Powder\",
 		\"sprite\": \"protein_powder_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"1\"
+		\"volume\": 50,
+		\"weight\": 1
 	},
 	{
 		\"description\": \"A bar of chocolate, a morale booster and energy source.\",
 		\"id\": \"chocolate\",
 		\"image\": \"./Mods/Core/Items/chocolate_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Chocolate\",
 		\"sprite\": \"chocolate_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"25\",
-		\"weight\": \"0.2\"
+		\"volume\": 25,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"A jar of olives, preserved and ready to eat.\",
 		\"id\": \"jar_olives\",
 		\"image\": \"./Mods/Core/Items/jar_olives_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Jar of Olives\",
 		\"sprite\": \"jar_olives_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"40\",
-		\"weight\": \"0.5\"
+		\"volume\": 40,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A jar of preserved basil, useful for seasoning.\",
 		\"id\": \"jar_basil\",
 		\"image\": \"./Mods/Core/Items/jar_basil_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Jar of Basil\",
 		\"sprite\": \"jar_basil_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"25\",
-		\"weight\": \"0.5\"
+		\"volume\": 25,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"A jar of mustard, adds flavor to meals.\",
 		\"id\": \"jar_mustard\",
 		\"image\": \"./Mods/Core/Items/jar_mustard_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Jar of Mustard\",
 		\"sprite\": \"jar_mustard_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"25\",
-		\"weight\": \"0.3\"
+		\"volume\": 25,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A bottle of ketchup, a common condiment.\",
 		\"id\": \"bottle_ketchup\",
 		\"image\": \"./Mods/Core/Items/bottle_ketchup_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Bottle of Ketchup\",
 		\"sprite\": \"bottle_ketchup_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"60\",
-		\"weight\": \"0.3\"
+		\"volume\": 60,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A loaf of bread that has gone stale, but still edible in a pinch.\",
 		\"id\": \"stale_bread\",
 		\"image\": \"./Mods/Core/Items/stale_bread_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Stale Bread\",
 		\"sprite\": \"stale_bread_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"90\",
-		\"weight\": \"0.5\"
+		\"volume\": 90,
+		\"weight\": 0.5
 	},
 	{
 		\"description\": \"Pain relief medication, useful for treating injuries.\",
 		\"id\": \"painkiller\",
 		\"image\": \"./Mods/Core/Items/painkiller_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Painkiller\",
 		\"sprite\": \"painkiller_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"5\",
-		\"weight\": \"0.1\"
+		\"volume\": 5,
+		\"weight\": 0.1
 	},
 	{
 		\"description\": \"A fresh orange, a good source of vitamin C.\",
 		\"id\": \"orange\",
 		\"image\": \"./Mods/Core/Items/orange_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Orange\",
 		\"sprite\": \"orange_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.2\"
+		\"volume\": 10,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"A fresh apple, a healthy snack.\",
 		\"id\": \"apple\",
 		\"image\": \"./Mods/Core/Items/apple_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Apple\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"apple_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.2\"
+		\"volume\": 10,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"A raw potato, versatile in many recipes.\",
 		\"id\": \"potato\",
 		\"image\": \"./Mods/Core/Items/potato_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Potato\",
 		\"sprite\": \"potato_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"15\",
-		\"weight\": \"0.3\"
+		\"volume\": 15,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A fresh carrot, good for nutrition.\",
 		\"id\": \"carrot\",
 		\"image\": \"./Mods/Core/Items/carrot_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Carrot\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"carrot_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"10\",
-		\"weight\": \"0.2\"
+		\"volume\": 10,
+		\"weight\": 0.2
 	},
 	{
 		\"description\": \"A carton of eggs, a versatile food item.\",
 		\"id\": \"eggs\",
 		\"image\": \"./Mods/Core/Items/eggs_32.png\",
-		\"max_stack_size\": \"5\",
+		\"max_stack_size\": 5,
 		\"name\": \"Eggs\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"eggs_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.6\"
+		\"volume\": 50,
+		\"weight\": 0.6
 	},
 	{
 		\"description\": \"A stick of butter, useful for cooking and baking.\",
 		\"id\": \"butter\",
 		\"image\": \"./Mods/Core/Items/butter_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Butter\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"butter_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"20\",
-		\"weight\": \"0.4\"
+		\"volume\": 20,
+		\"weight\": 0.4
 	},
 	{
 		\"description\": \"A can of energy drink, boosts stamina temporarily.\",
 		\"id\": \"can_energydrink\",
 		\"image\": \"./Mods/Core/Items/can_energydrink_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Energy Drink\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"can_energydrink_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.3\"
+		\"volume\": 50,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A can of soda, a refreshing beverage.\",
 		\"id\": \"can_soda\",
 		\"image\": \"./Mods/Core/Items/can_soda_32.png\",
-		\"max_stack_size\": \"20\",
+		\"max_stack_size\": 20,
 		\"name\": \"Soda\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"can_soda_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"50\",
-		\"weight\": \"0.3\"
+		\"volume\": 50,
+		\"weight\": 0.3
 	},
 	{
 		\"description\": \"A block of cheese, a versatile food item.\",
 		\"id\": \"cheese\",
 		\"image\": \"./Mods/Core/Items/cheese_32.png\",
-		\"max_stack_size\": \"10\",
+		\"max_stack_size\": 10,
 		\"name\": \"Cheese\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"refridgerator\"
+				]
+			}
+		},
 		\"sprite\": \"cheese_32.png\",
-		\"stack_size\": \"1\",
+		\"stack_size\": 1,
 		\"two_handed\": false,
-		\"volume\": \"40\",
-		\"weight\": \"0.5\"
+		\"volume\": 40,
+		\"weight\": 0.5
 	}
 ]"

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -185,7 +185,7 @@
 		"stack_size": "1",
 		"two_handed": true,
 		"volume": "300",
-		"weight": "4"
+		"weight": 4
 	},
 	{
 		"Ranged": {
@@ -211,7 +211,7 @@
 		"stack_size": "1",
 		"two_handed": true,
 		"volume": "150",
-		"weight": "3"
+		"weight": 3
 	},
 	{
 		"Magazine": {
@@ -228,7 +228,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.25"
+		"weight": 0.25
 	},
 	{
 		"description": "This plastic bottle only contains air",
@@ -250,7 +250,7 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"Food": {
@@ -274,7 +274,7 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "0.25"
+		"weight": 0.25
 	},
 	{
 		"description": "The contents will satisfy your hunger",
@@ -293,7 +293,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "30",
-		"weight": "0.25"
+		"weight": 0.25
 	},
 	{
 		"Melee": {
@@ -309,7 +309,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "4"
+		"weight": 4
 	},
 	{
 		"description": "Anyone is able to craft this simple arrow",
@@ -321,7 +321,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "1",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A stick with a block of steel on it. It is used to apply force to objects like nails",
@@ -340,7 +340,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "2"
+		"weight": 2
 	},
 	{
 		"Craft": [
@@ -379,7 +379,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "20",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A basic bandage that will help to heal a wound",
@@ -399,7 +399,7 @@
 		"stack_size": "3",
 		"two_handed": false,
 		"volume": "1",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A small bottle that contains antibiotics. It helps to recover from disease.",
@@ -418,7 +418,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"Wearable": {
@@ -440,7 +440,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"Wearable": {
@@ -463,7 +463,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A large container that holds gasoline",
@@ -475,7 +475,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "400",
-		"weight": "10"
+		"weight": 10
 	},
 	{
 		"description": "It's a can that contains oil. It has a spout that allows you to pour it out.",
@@ -494,7 +494,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "2"
+		"weight": 2
 	},
 	{
 		"description": "A small radio that can be powered by batteries or an electical cord.",
@@ -506,7 +506,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A basic battery powered flashlight. It will shine a beam of light when it is turned on",
@@ -525,7 +525,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "It's a can that contains beer. Don't drink a lot of it or you will get drunk",
@@ -545,7 +545,7 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking",
@@ -557,7 +557,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"Wearable": {
@@ -579,7 +579,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "80",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A piece of clothing that offers protection from ballistic forces",
@@ -591,7 +591,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "4"
+		"weight": 4
 	},
 	{
 		"description": "A device that shows your orientation relative to the earth's poles",
@@ -622,7 +622,7 @@
 		"stack_size": "2",
 		"two_handed": false,
 		"volume": "0.1",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A large panel that draws power from the sun",
@@ -634,7 +634,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "1000",
-		"weight": "10"
+		"weight": 10
 	},
 	{
 		"description": "A large piece of paper that visualizes the area around you",
@@ -646,7 +646,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A piece of fabric and some strings. You can deploy it to get some shelter from the weather",
@@ -658,7 +658,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "3"
+		"weight": 3
 	},
 	{
 		"description": "A piece of fabric and some strings. You can deploy it to get some shelter from the weather. It is currently folded to save space.",
@@ -670,7 +670,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "600",
-		"weight": "9"
+		"weight": 9
 	},
 	{
 		"description": "A small book explaining the very basics of survival",
@@ -682,7 +682,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A book containing an entertaining story",
@@ -701,7 +701,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.4"
+		"weight": 0.4
 	},
 	{
 		"description": "A small bottle that contains disinfectant. It helps to disinfect wounds",
@@ -720,7 +720,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A small radio that allows you to communicate with someone over a large distance",
@@ -732,7 +732,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A small device that provides a spark that can be used to light a fire. No power or fuel required.",
@@ -744,7 +744,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "\n    A true survival fishing kit in a very small, lightweight package!\n    Contains 118 foot line and winder\n    2 lures, 2 hooks\n    2 swivels, 2 weghts\n    Comes in a strong durable heavy duty resealable plastic bag",
@@ -756,7 +756,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.4"
+		"weight": 0.4
 	},
 	{
 		"description": "A versatile kitchen tool, essential for slicing, dicing, and chopping food.",
@@ -768,7 +768,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.4"
+		"weight": 0.4
 	},
 	{
 		"description": "A compact and portable stove, perfect for cooking meals during survival situations.",
@@ -780,7 +780,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "3"
+		"weight": 3
 	},
 	{
 		"description": "A durable cooking pot, essential for boiling water and preparing meals.",
@@ -792,7 +792,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "350",
-		"weight": "3"
+		"weight": 3
 	},
 	{
 		"description": "A small tool crucial for opening canned food, an essential for survival.",
@@ -804,7 +804,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "60",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"Craft": [
@@ -851,7 +851,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "250",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A metal kettle perfect for boiling water to make tea or instant meals.",
@@ -863,7 +863,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A small rack containing various spices to enhance the flavor of food.",
@@ -875,7 +875,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A measuring cup, essential for precisely measuring ingredients for recipes.",
@@ -887,7 +887,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"Craft": [
@@ -922,7 +922,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "150",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A heavy-duty frying pan, perfect for cooking everything from eggs to stir-fry.",
@@ -934,7 +934,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "2"
+		"weight": 2
 	},
 	{
 		"description": "A metal colander, ideal for draining pasta or washing vegetables.",
@@ -946,7 +946,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "0.7"
+		"weight": 0.7
 	},
 	{
 		"description": "A handy peeler, perfect for skinning vegetables and fruits with ease.",
@@ -958,7 +958,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A metal grater, essential for shredding cheese, vegetables, and more.",
@@ -970,7 +970,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A compact electric toaster, ideal for toasting bread quickly.",
@@ -982,7 +982,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "300",
-		"weight": "1.5"
+		"weight": 1.5
 	},
 	{
 		"description": "An electric blender, perfect for making smoothies, soups, and other blended concoctions.",
@@ -994,7 +994,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "300",
-		"weight": "2"
+		"weight": 2
 	},
 	{
 		"description": "A coffee maker, essential for brewing the perfect cup of coffee to start your day.",
@@ -1006,7 +1006,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "300",
-		"weight": "2.5"
+		"weight": 2.5
 	},
 	{
 		"description": "A microwave oven, perfect for quickly heating or cooking food.",
@@ -1018,7 +1018,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "400",
-		"weight": "12"
+		"weight": 12
 	},
 	{
 		"description": "A dish rack, useful for organizing and drying dishes after washing.",
@@ -1030,7 +1030,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "400",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A pressure cooker, ideal for fast cooking and preserving nutrients in food.",
@@ -1042,7 +1042,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "400",
-		"weight": "5"
+		"weight": 5
 	},
 	{
 		"description": "A bread maker, perfect for effortlessly baking fresh bread at home.",
@@ -1054,7 +1054,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "300",
-		"weight": "5"
+		"weight": 5
 	},
 	{
 		"description": "Small but crucial for holding together wooden structures and crafting. Often found in the remnants of furniture and buildings.",
@@ -1066,7 +1066,7 @@
 		"stack_size": "10",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "Large pieces of wood obtained from cutting down trees. Useful for building and crafting larger items.",
@@ -1078,7 +1078,7 @@
 		"stack_size": "1",
 		"two_handed": true,
 		"volume": "500",
-		"weight": "10"
+		"weight": 10
 	},
 	{
 		"description": "Versatile fasteners used in both wooden and metal constructions. Can be scavenged from disassembled furniture and machinery.",
@@ -1090,7 +1090,7 @@
 		"stack_size": "10",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "Smaller pieces of wood that can be used for kindling, basic crafting, and creating primitive tools.",
@@ -1102,7 +1102,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "2"
+		"weight": 2
 	},
 	{
 		"description": "Can be used for camouflage, crafting bedding, or as a basic source of compost.",
@@ -1114,7 +1114,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "1",
-		"weight": "0.01"
+		"weight": 0.01
 	},
 	{
 		"description": "Resinous branches that can be used for kindling or basic crafting.",
@@ -1126,7 +1126,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "2"
+		"weight": 2
 	},
 	{
 		"description": "Natural material that can be molded when wet and hardens when dried, useful for creating pottery, bricks, and reinforcing structures.",
@@ -1138,7 +1138,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "20",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "Basic resource for growing plants and creating makeshift gardens for food production.",
@@ -1150,7 +1150,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "200",
-		"weight": "5"
+		"weight": 5
 	},
 	{
 		"description": "Metal parts that allow doors and cabinets to open and close. Can be used in various mechanical constructions.",
@@ -1162,7 +1162,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "Useful for creating compost, crafting, or even as emergency food sources.",
@@ -1174,7 +1174,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "Essential for repairing or crafting electronic devices.",
@@ -1186,7 +1186,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "20",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "Versatile material used in various crafting recipes, often scavenged from modern appliances and containers.",
@@ -1198,7 +1198,7 @@
 		"stack_size": "10",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "Shards of broken ceramic items, useful for crafting new items or reinforcing existing structures.",
@@ -1210,7 +1210,7 @@
 		"stack_size": "5",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "General metal components used in various crafting and construction recipes.",
@@ -1222,7 +1222,7 @@
 		"stack_size": "10",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A jar of preserved parsley, useful for adding flavor to dishes.",
@@ -1234,7 +1234,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "60",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A block of tofu, a good source of protein.",
@@ -1253,7 +1253,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "30",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A bottle of yogurt, useful for nutrition and digestion.",
@@ -1272,7 +1272,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "100",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A jar of pickles, a tasty preserved food.",
@@ -1284,7 +1284,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A can of condensed milk, a rich source of nutrition.",
@@ -1296,7 +1296,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "60",
-		"weight": "0.8"
+		"weight": 0.8
 	},
 	{
 		"description": "A vial of insulin, necessary for diabetics.",
@@ -1308,7 +1308,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "An epinephrine auto-injector, useful for treating severe allergic reactions.",
@@ -1320,7 +1320,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A bag of bacon, rich in fats and proteins.",
@@ -1339,7 +1339,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "30",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A bottle of wine, useful for bartering or a morale boost.",
@@ -1351,7 +1351,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "90",
-		"weight": "1.5"
+		"weight": 1.5
 	},
 	{
 		"description": "A loaf of bread, a staple food item.",
@@ -1363,7 +1363,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "90",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A syringe, useful for administering medical treatments.",
@@ -1375,7 +1375,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.05"
+		"weight": 0.05
 	},
 	{
 		"description": "A slice of pizza, not very fresh but still edible.",
@@ -1394,7 +1394,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A package of vacuum-sealed fish, preserved for longer storage.",
@@ -1413,7 +1413,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.8"
+		"weight": 0.8
 	},
 	{
 		"description": "A ripe tomato, still fresh and edible.",
@@ -1432,7 +1432,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "A head of lettuce, slightly wilted but still usable.",
@@ -1451,7 +1451,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "90",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A container of protein powder, useful for maintaining nutrition.",
@@ -1463,7 +1463,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "1"
+		"weight": 1
 	},
 	{
 		"description": "A bar of chocolate, a morale booster and energy source.",
@@ -1475,7 +1475,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "25",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "A jar of olives, preserved and ready to eat.",
@@ -1487,7 +1487,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "40",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A jar of preserved basil, useful for seasoning.",
@@ -1499,7 +1499,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "25",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "A jar of mustard, adds flavor to meals.",
@@ -1511,7 +1511,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "25",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A bottle of ketchup, a common condiment.",
@@ -1523,7 +1523,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "60",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A loaf of bread that has gone stale, but still edible in a pinch.",
@@ -1535,7 +1535,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "90",
-		"weight": "0.5"
+		"weight": 0.5
 	},
 	{
 		"description": "Pain relief medication, useful for treating injuries.",
@@ -1547,7 +1547,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "5",
-		"weight": "0.1"
+		"weight": 0.1
 	},
 	{
 		"description": "A fresh orange, a good source of vitamin C.",
@@ -1559,7 +1559,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "A fresh apple, a healthy snack.",
@@ -1578,7 +1578,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "A raw potato, versatile in many recipes.",
@@ -1590,7 +1590,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "15",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A fresh carrot, good for nutrition.",
@@ -1609,7 +1609,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "10",
-		"weight": "0.2"
+		"weight": 0.2
 	},
 	{
 		"description": "A carton of eggs, a versatile food item.",
@@ -1628,7 +1628,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.6"
+		"weight": 0.6
 	},
 	{
 		"description": "A stick of butter, useful for cooking and baking.",
@@ -1647,7 +1647,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "20",
-		"weight": "0.4"
+		"weight": 0.4
 	},
 	{
 		"description": "A can of energy drink, boosts stamina temporarily.",
@@ -1666,7 +1666,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A can of soda, a refreshing beverage.",
@@ -1685,7 +1685,7 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "50",
-		"weight": "0.3"
+		"weight": 0.3
 	},
 	{
 		"description": "A block of cheese, a versatile food item.",
@@ -1704,6 +1704,6 @@
 		"stack_size": "1",
 		"two_handed": false,
 		"volume": "40",
-		"weight": "0.5"
+		"weight": 0.5
 	}
 ]

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -184,7 +184,7 @@
 		"sprite": "rifle_64_32.png",
 		"stack_size": "1",
 		"two_handed": true,
-		"volume": "300",
+		"volume": 300,
 		"weight": 4
 	},
 	{
@@ -210,7 +210,7 @@
 		"sprite": "chugunov_mpap_32_28.png",
 		"stack_size": "1",
 		"two_handed": true,
-		"volume": "150",
+		"volume": 150,
 		"weight": 3
 	},
 	{
@@ -227,7 +227,7 @@
 		"sprite": "chugunov_mpap_magazine_16_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.25
 	},
 	{
@@ -249,7 +249,7 @@
 		"sprite": "bottle_empty_32.png",
 		"stack_size": "2",
 		"two_handed": false,
-		"volume": "15",
+		"volume": 15,
 		"weight": 0.1
 	},
 	{
@@ -273,7 +273,7 @@
 		"sprite": "bottle_water_32.png",
 		"stack_size": "2",
 		"two_handed": false,
-		"volume": "15",
+		"volume": 15,
 		"weight": 0.25
 	},
 	{
@@ -292,7 +292,7 @@
 		"sprite": "canned_food_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "30",
+		"volume": 30,
 		"weight": 0.25
 	},
 	{
@@ -308,7 +308,7 @@
 		"sprite": "machete_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 4
 	},
 	{
@@ -320,7 +320,7 @@
 		"sprite": "arrow_basic_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "1",
+		"volume": 1,
 		"weight": 0.1
 	},
 	{
@@ -339,7 +339,7 @@
 		"sprite": "hammer_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 2
 	},
 	{
@@ -378,7 +378,7 @@
 		"sprite": "screwdriver_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "20",
+		"volume": 20,
 		"weight": 0.5
 	},
 	{
@@ -398,7 +398,7 @@
 		"sprite": "bandage_32.png",
 		"stack_size": "3",
 		"two_handed": false,
-		"volume": "1",
+		"volume": 1,
 		"weight": 0.1
 	},
 	{
@@ -417,7 +417,7 @@
 		"sprite": "antibiotics_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -439,7 +439,7 @@
 		"sprite": "jacket_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 1
 	},
 	{
@@ -462,7 +462,7 @@
 		"sprite": "boots_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 1
 	},
 	{
@@ -474,7 +474,7 @@
 		"sprite": "jerrycan_gas_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "400",
+		"volume": 400,
 		"weight": 10
 	},
 	{
@@ -493,7 +493,7 @@
 		"sprite": "can_oil_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 2
 	},
 	{
@@ -505,7 +505,7 @@
 		"sprite": "battery_powered_radio_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 1
 	},
 	{
@@ -524,7 +524,7 @@
 		"sprite": "flashlight_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 0.5
 	},
 	{
@@ -544,7 +544,7 @@
 		"sprite": "can_beer_32.png",
 		"stack_size": "2",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.5
 	},
 	{
@@ -556,7 +556,7 @@
 		"sprite": "sigarrette_pack_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.1
 	},
 	{
@@ -578,7 +578,7 @@
 		"sprite": "gasmask_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "80",
+		"volume": 80,
 		"weight": 1
 	},
 	{
@@ -590,7 +590,7 @@
 		"sprite": "vest_ballistic_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "150",
+		"volume": 150,
 		"weight": 4
 	},
 	{
@@ -621,7 +621,7 @@
 		"sprite": "battery_32.png",
 		"stack_size": "2",
 		"two_handed": false,
-		"volume": "0.1",
+		"volume": 0,
 		"weight": 0.1
 	},
 	{
@@ -633,7 +633,7 @@
 		"sprite": "solar_panel_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "1000",
+		"volume": 1000,
 		"weight": 10
 	},
 	{
@@ -645,7 +645,7 @@
 		"sprite": "map_paper_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -657,7 +657,7 @@
 		"sprite": "tarp_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "150",
+		"volume": 150,
 		"weight": 3
 	},
 	{
@@ -669,7 +669,7 @@
 		"sprite": "tent_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "600",
+		"volume": 600,
 		"weight": 9
 	},
 	{
@@ -681,7 +681,7 @@
 		"sprite": "survival_guide_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.1
 	},
 	{
@@ -700,7 +700,7 @@
 		"sprite": "book_novel_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.4
 	},
 	{
@@ -719,7 +719,7 @@
 		"sprite": "bottle_disinfectant_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -731,7 +731,7 @@
 		"sprite": "radio_two_way_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 1
 	},
 	{
@@ -743,7 +743,7 @@
 		"sprite": "firestarter_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.2
 	},
 	{
@@ -755,7 +755,7 @@
 		"sprite": "kit_fishing_small_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.4
 	},
 	{
@@ -767,7 +767,7 @@
 		"sprite": "kitchen_knife_64_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 0.4
 	},
 	{
@@ -779,7 +779,7 @@
 		"sprite": "portable_stove_64_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "200",
+		"volume": 200,
 		"weight": 3
 	},
 	{
@@ -791,7 +791,7 @@
 		"sprite": "cooking_pot_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "350",
+		"volume": 350,
 		"weight": 3
 	},
 	{
@@ -803,7 +803,7 @@
 		"sprite": "can_opener_64_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "60",
+		"volume": 60,
 		"weight": 0.2
 	},
 	{
@@ -850,7 +850,7 @@
 		"sprite": "mixing_bowl_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "250",
+		"volume": 250,
 		"weight": 0.5
 	},
 	{
@@ -862,7 +862,7 @@
 		"sprite": "tea_kettle_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "200",
+		"volume": 200,
 		"weight": 1
 	},
 	{
@@ -874,7 +874,7 @@
 		"sprite": "spice_rack_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "150",
+		"volume": 150,
 		"weight": 1
 	},
 	{
@@ -886,7 +886,7 @@
 		"sprite": "measuring_cup_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 0.3
 	},
 	{
@@ -921,7 +921,7 @@
 		"sprite": "rolling_pin_64_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "150",
+		"volume": 150,
 		"weight": 0.5
 	},
 	{
@@ -933,7 +933,7 @@
 		"sprite": "frying_pan_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "200",
+		"volume": 200,
 		"weight": 2
 	},
 	{
@@ -945,7 +945,7 @@
 		"sprite": "steel_colander_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "200",
+		"volume": 200,
 		"weight": 0.7
 	},
 	{
@@ -957,7 +957,7 @@
 		"sprite": "peeler_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.1
 	},
 	{
@@ -969,7 +969,7 @@
 		"sprite": "grater_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.3
 	},
 	{
@@ -981,7 +981,7 @@
 		"sprite": "toaster_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "300",
+		"volume": 300,
 		"weight": 1.5
 	},
 	{
@@ -993,7 +993,7 @@
 		"sprite": "blender_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "300",
+		"volume": 300,
 		"weight": 2
 	},
 	{
@@ -1005,7 +1005,7 @@
 		"sprite": "coffeemaker_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "300",
+		"volume": 300,
 		"weight": 2.5
 	},
 	{
@@ -1017,7 +1017,7 @@
 		"sprite": "microwave_oven_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "400",
+		"volume": 400,
 		"weight": 12
 	},
 	{
@@ -1029,7 +1029,7 @@
 		"sprite": "dish_rack_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "400",
+		"volume": 400,
 		"weight": 1
 	},
 	{
@@ -1041,7 +1041,7 @@
 		"sprite": "pressure_cooker_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "400",
+		"volume": 400,
 		"weight": 5
 	},
 	{
@@ -1053,7 +1053,7 @@
 		"sprite": "bread_maker_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "300",
+		"volume": 300,
 		"weight": 5
 	},
 	{
@@ -1065,7 +1065,7 @@
 		"sprite": "nails_32.png",
 		"stack_size": "10",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -1077,7 +1077,7 @@
 		"sprite": "log_32.png",
 		"stack_size": "1",
 		"two_handed": true,
-		"volume": "500",
+		"volume": 500,
 		"weight": 10
 	},
 	{
@@ -1089,7 +1089,7 @@
 		"sprite": "screw_32.png",
 		"stack_size": "10",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -1101,7 +1101,7 @@
 		"sprite": "branches_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 2
 	},
 	{
@@ -1113,7 +1113,7 @@
 		"sprite": "leaves_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "1",
+		"volume": 1,
 		"weight": 0.01
 	},
 	{
@@ -1125,7 +1125,7 @@
 		"sprite": "pine_branch_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 2
 	},
 	{
@@ -1137,7 +1137,7 @@
 		"sprite": "clay_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "20",
+		"volume": 20,
 		"weight": 1
 	},
 	{
@@ -1149,7 +1149,7 @@
 		"sprite": "soil_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "200",
+		"volume": 200,
 		"weight": 5
 	},
 	{
@@ -1161,7 +1161,7 @@
 		"sprite": "hinge_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.2
 	},
 	{
@@ -1173,7 +1173,7 @@
 		"sprite": "plant_remnants_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.1
 	},
 	{
@@ -1185,7 +1185,7 @@
 		"sprite": "electrical_components_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "20",
+		"volume": 20,
 		"weight": 0.5
 	},
 	{
@@ -1197,7 +1197,7 @@
 		"sprite": "plastic_parts_32.png",
 		"stack_size": "10",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.3
 	},
 	{
@@ -1209,7 +1209,7 @@
 		"sprite": "ceramic_fragments_32.png",
 		"stack_size": "5",
 		"two_handed": false,
-		"volume": "15",
+		"volume": 15,
 		"weight": 1
 	},
 	{
@@ -1221,7 +1221,7 @@
 		"sprite": "metal_parts_32.png",
 		"stack_size": "10",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.5
 	},
 	{
@@ -1233,7 +1233,7 @@
 		"sprite": "jar_parsley_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "60",
+		"volume": 60,
 		"weight": 0.5
 	},
 	{
@@ -1252,7 +1252,7 @@
 		"sprite": "tofu_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "30",
+		"volume": 30,
 		"weight": 0.5
 	},
 	{
@@ -1271,7 +1271,7 @@
 		"sprite": "bottle_yogurt_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "100",
+		"volume": 100,
 		"weight": 0.3
 	},
 	{
@@ -1283,7 +1283,7 @@
 		"sprite": "jar_pickles_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 1
 	},
 	{
@@ -1295,7 +1295,7 @@
 		"sprite": "condensed_milk_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "60",
+		"volume": 60,
 		"weight": 0.8
 	},
 	{
@@ -1307,7 +1307,7 @@
 		"sprite": "insulin_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -1319,7 +1319,7 @@
 		"sprite": "epipen_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -1338,7 +1338,7 @@
 		"sprite": "bag_bacon_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "30",
+		"volume": 30,
 		"weight": 0.5
 	},
 	{
@@ -1350,7 +1350,7 @@
 		"sprite": "wine_bottle_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "90",
+		"volume": 90,
 		"weight": 1.5
 	},
 	{
@@ -1362,7 +1362,7 @@
 		"sprite": "bread_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "90",
+		"volume": 90,
 		"weight": 0.5
 	},
 	{
@@ -1374,7 +1374,7 @@
 		"sprite": "syringe_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.05
 	},
 	{
@@ -1393,7 +1393,7 @@
 		"sprite": "slice_of_pizza_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.3
 	},
 	{
@@ -1412,7 +1412,7 @@
 		"sprite": "vacuum_sealed_fish_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.8
 	},
 	{
@@ -1431,7 +1431,7 @@
 		"sprite": "tomato_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.2
 	},
 	{
@@ -1450,7 +1450,7 @@
 		"sprite": "lettuce_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "90",
+		"volume": 90,
 		"weight": 0.3
 	},
 	{
@@ -1462,7 +1462,7 @@
 		"sprite": "protein_powder_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 1
 	},
 	{
@@ -1474,7 +1474,7 @@
 		"sprite": "chocolate_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "25",
+		"volume": 25,
 		"weight": 0.2
 	},
 	{
@@ -1486,7 +1486,7 @@
 		"sprite": "jar_olives_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "40",
+		"volume": 40,
 		"weight": 0.5
 	},
 	{
@@ -1498,7 +1498,7 @@
 		"sprite": "jar_basil_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "25",
+		"volume": 25,
 		"weight": 0.5
 	},
 	{
@@ -1510,7 +1510,7 @@
 		"sprite": "jar_mustard_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "25",
+		"volume": 25,
 		"weight": 0.3
 	},
 	{
@@ -1522,7 +1522,7 @@
 		"sprite": "bottle_ketchup_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "60",
+		"volume": 60,
 		"weight": 0.3
 	},
 	{
@@ -1534,7 +1534,7 @@
 		"sprite": "stale_bread_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "90",
+		"volume": 90,
 		"weight": 0.5
 	},
 	{
@@ -1546,7 +1546,7 @@
 		"sprite": "painkiller_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "5",
+		"volume": 5,
 		"weight": 0.1
 	},
 	{
@@ -1558,7 +1558,7 @@
 		"sprite": "orange_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.2
 	},
 	{
@@ -1577,7 +1577,7 @@
 		"sprite": "apple_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.2
 	},
 	{
@@ -1589,7 +1589,7 @@
 		"sprite": "potato_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "15",
+		"volume": 15,
 		"weight": 0.3
 	},
 	{
@@ -1608,7 +1608,7 @@
 		"sprite": "carrot_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "10",
+		"volume": 10,
 		"weight": 0.2
 	},
 	{
@@ -1627,7 +1627,7 @@
 		"sprite": "eggs_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.6
 	},
 	{
@@ -1646,7 +1646,7 @@
 		"sprite": "butter_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "20",
+		"volume": 20,
 		"weight": 0.4
 	},
 	{
@@ -1665,7 +1665,7 @@
 		"sprite": "can_energydrink_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.3
 	},
 	{
@@ -1684,7 +1684,7 @@
 		"sprite": "can_soda_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "50",
+		"volume": 50,
 		"weight": 0.3
 	},
 	{
@@ -1703,7 +1703,7 @@
 		"sprite": "cheese_32.png",
 		"stack_size": "1",
 		"two_handed": false,
-		"volume": "40",
+		"volume": 40,
 		"weight": 0.5
 	}
 ]

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -179,10 +179,10 @@
 		"description": "A standard issue rifle that uses 9mm ammunition",
 		"id": "rifle_m4a1",
 		"image": "./Mods/Core/Items/rifle_64_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "M4a1 rifle",
 		"sprite": "rifle_64_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": true,
 		"volume": 300,
 		"weight": 4
@@ -205,10 +205,10 @@
 		"description": "Chugun in Russian is for cast steel, MPAP is \"Multi Purpose Automatic Pistol\"",
 		"id": "chugunov_mpap",
 		"image": "./Mods/Core/Items/chugunov_mpap_32_28.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Chugunov MPAP",
 		"sprite": "chugunov_mpap_32_28.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": true,
 		"volume": 150,
 		"weight": 3
@@ -222,10 +222,10 @@
 		"description": "A magazine to be loaded into a Chuganov MPAP",
 		"id": "chugunov_mpap_magazine",
 		"image": "./Mods/Core/Items/chugunov_mpap_magazine_16_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Chuganov MPAP magazine",
 		"sprite": "chugunov_mpap_magazine_16_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.25
@@ -234,7 +234,7 @@
 		"description": "This plastic bottle only contains air",
 		"id": "bottle_plastic_empty",
 		"image": "./Mods/Core/Items/bottle_empty_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Empty plastic bottle",
 		"references": {
 			"core": {
@@ -247,7 +247,7 @@
 			}
 		},
 		"sprite": "bottle_empty_32.png",
-		"stack_size": "2",
+		"stack_size": 2,
 		"two_handed": false,
 		"volume": 15,
 		"weight": 0.1
@@ -259,7 +259,7 @@
 		"description": "This plastic bottle is filled with water",
 		"id": "bottle_plastic_water",
 		"image": "./Mods/Core/Items/bottle_water_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Plastic bottle with water",
 		"references": {
 			"core": {
@@ -271,7 +271,7 @@
 			}
 		},
 		"sprite": "bottle_water_32.png",
-		"stack_size": "2",
+		"stack_size": 2,
 		"two_handed": false,
 		"volume": 15,
 		"weight": 0.25
@@ -280,7 +280,7 @@
 		"description": "The contents will satisfy your hunger",
 		"id": "canned_food",
 		"image": "./Mods/Core/Items/canned_food_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Canned food\t",
 		"references": {
 			"core": {
@@ -290,7 +290,7 @@
 			}
 		},
 		"sprite": "canned_food_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 30,
 		"weight": 0.25
@@ -303,10 +303,10 @@
 		"description": "A sharp blade with a handle for excellent control",
 		"id": "machete",
 		"image": "./Mods/Core/Items/machete_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Machete",
 		"sprite": "machete_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 4
@@ -315,10 +315,10 @@
 		"description": "Anyone is able to craft this simple arrow",
 		"id": "wood_arrow_basic",
 		"image": "./Mods/Core/Items/arrow_basic_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Basic wooden arrow",
 		"sprite": "arrow_basic_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 1,
 		"weight": 0.1
@@ -327,7 +327,7 @@
 		"description": "A stick with a block of steel on it. It is used to apply force to objects like nails",
 		"id": "hammer",
 		"image": "./Mods/Core/Items/hammer_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Hammer",
 		"references": {
 			"core": {
@@ -337,7 +337,7 @@
 			}
 		},
 		"sprite": "hammer_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 2
@@ -365,7 +365,7 @@
 		"description": "A handle with a rod of steel in it. The tip can be flat or shaped like a star. Useful for construction projects",
 		"id": "screwdriver",
 		"image": "./Mods/Core/Items/screwdriver_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Screwdriver",
 		"references": {
 			"core": {
@@ -376,7 +376,7 @@
 			}
 		},
 		"sprite": "screwdriver_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 20,
 		"weight": 0.5
@@ -385,7 +385,7 @@
 		"description": "A basic bandage that will help to heal a wound",
 		"id": "bandage_basic",
 		"image": "./Mods/Core/Items/bandage_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Bandage",
 		"references": {
 			"core": {
@@ -396,7 +396,7 @@
 			}
 		},
 		"sprite": "bandage_32.png",
-		"stack_size": "3",
+		"stack_size": 3,
 		"two_handed": false,
 		"volume": 1,
 		"weight": 0.1
@@ -405,7 +405,7 @@
 		"description": "A small bottle that contains antibiotics. It helps to recover from disease.",
 		"id": "bottle_antibiotics",
 		"image": "./Mods/Core/Items/antibiotics_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Bottle of antibiotics",
 		"references": {
 			"core": {
@@ -415,7 +415,7 @@
 			}
 		},
 		"sprite": "antibiotics_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -427,7 +427,7 @@
 		"description": "A piece of clothing to wear on the torso. It will keep you warm and offers a bit of protection.",
 		"id": "jacket",
 		"image": "./Mods/Core/Items/jacket_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Jacket",
 		"references": {
 			"core": {
@@ -437,7 +437,7 @@
 			}
 		},
 		"sprite": "jacket_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 1
@@ -449,7 +449,7 @@
 		"description": "Comfortable footwear to keep your feet safe",
 		"id": "boots",
 		"image": "./Mods/Core/Items/boots_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Boots",
 		"references": {
 			"core": {
@@ -460,7 +460,7 @@
 			}
 		},
 		"sprite": "boots_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 1
@@ -469,10 +469,10 @@
 		"description": "A large container that holds gasoline",
 		"id": "jerrycan_gasoline",
 		"image": "./Mods/Core/Items/jerrycan_gas_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Jerrycan of gasoline",
 		"sprite": "jerrycan_gas_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 400,
 		"weight": 10
@@ -481,7 +481,7 @@
 		"description": "It's a can that contains oil. It has a spout that allows you to pour it out.",
 		"id": "can_oil",
 		"image": "./Mods/Core/Items/can_oil_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Can of oil",
 		"references": {
 			"core": {
@@ -491,7 +491,7 @@
 			}
 		},
 		"sprite": "can_oil_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 2
@@ -500,10 +500,10 @@
 		"description": "A small radio that can be powered by batteries or an electical cord.",
 		"id": "radio_handheld",
 		"image": "./Mods/Core/Items/battery_powered_radio_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Handheld radio",
 		"sprite": "battery_powered_radio_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 1
@@ -512,7 +512,7 @@
 		"description": "A basic battery powered flashlight. It will shine a beam of light when it is turned on",
 		"id": "flashlight_basic",
 		"image": "./Mods/Core/Items/flashlight_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Flashlight",
 		"references": {
 			"core": {
@@ -522,7 +522,7 @@
 			}
 		},
 		"sprite": "flashlight_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 0.5
@@ -531,7 +531,7 @@
 		"description": "It's a can that contains beer. Don't drink a lot of it or you will get drunk",
 		"id": "can_beer",
 		"image": "./Mods/Core/Items/can_beer_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Can of beer",
 		"references": {
 			"core": {
@@ -542,7 +542,7 @@
 			}
 		},
 		"sprite": "can_beer_32.png",
-		"stack_size": "2",
+		"stack_size": 2,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.5
@@ -551,10 +551,10 @@
 		"description": "It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking",
 		"id": "pack_sigarrettes",
 		"image": "./Mods/Core/Items/sigarrette_pack_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Pack of sigarrettes",
 		"sprite": "sigarrette_pack_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.1
@@ -566,7 +566,7 @@
 		"description": "A piece of clothing that offers protection from environmental hazards",
 		"id": "gas_mask",
 		"image": "./Mods/Core/Items/gasmask_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Gas mask",
 		"references": {
 			"core": {
@@ -576,7 +576,7 @@
 			}
 		},
 		"sprite": "gasmask_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 80,
 		"weight": 1
@@ -585,10 +585,10 @@
 		"description": "A piece of clothing that offers protection from ballistic forces",
 		"id": "vest_ballistic",
 		"image": "./Mods/Core/Items/vest_ballistic_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Ballistic vest",
 		"sprite": "vest_ballistic_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 150,
 		"weight": 4
@@ -609,7 +609,7 @@
 		"description": "A very common type of battery that fits most battery-powered devices",
 		"id": "battery_small",
 		"image": "./Mods/Core/Items/battery_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Small battery",
 		"references": {
 			"core": {
@@ -619,19 +619,19 @@
 			}
 		},
 		"sprite": "battery_32.png",
-		"stack_size": "2",
+		"stack_size": 2,
 		"two_handed": false,
-		"volume": 0,
+		"volume": 0.01,
 		"weight": 0.1
 	},
 	{
 		"description": "A large panel that draws power from the sun",
 		"id": "solar_panel",
 		"image": "./Mods/Core/Items/solar_panel_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Solar panel",
 		"sprite": "solar_panel_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 1000,
 		"weight": 10
@@ -640,10 +640,10 @@
 		"description": "A large piece of paper that visualizes the area around you",
 		"id": "map_paper",
 		"image": "./Mods/Core/Items/map_paper_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Paper map",
 		"sprite": "map_paper_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -652,10 +652,10 @@
 		"description": "A piece of fabric and some strings. You can deploy it to get some shelter from the weather",
 		"id": "tarp",
 		"image": "./Mods/Core/Items/tarp_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Tarp",
 		"sprite": "tarp_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 150,
 		"weight": 3
@@ -664,10 +664,10 @@
 		"description": "A piece of fabric and some strings. You can deploy it to get some shelter from the weather. It is currently folded to save space.",
 		"id": "tent",
 		"image": "./Mods/Core/Items/tent_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Tent",
 		"sprite": "tent_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 600,
 		"weight": 9
@@ -676,10 +676,10 @@
 		"description": "A small book explaining the very basics of survival",
 		"id": "guide_survival_basic",
 		"image": "./Mods/Core/Items/survival_guide_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Basic survival guide",
 		"sprite": "survival_guide_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.1
@@ -688,7 +688,7 @@
 		"description": "A book containing an entertaining story",
 		"id": "book_novel",
 		"image": "./Mods/Core/Items/book_novel_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Novel",
 		"references": {
 			"core": {
@@ -698,7 +698,7 @@
 			}
 		},
 		"sprite": "book_novel_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.4
@@ -707,7 +707,7 @@
 		"description": "A small bottle that contains disinfectant. It helps to disinfect wounds",
 		"id": "bottle_disinfectant",
 		"image": "./Mods/Core/Items/bottle_disinfectant_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Bottle of disinfectant",
 		"references": {
 			"core": {
@@ -717,7 +717,7 @@
 			}
 		},
 		"sprite": "bottle_disinfectant_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -726,10 +726,10 @@
 		"description": "A small radio that allows you to communicate with someone over a large distance",
 		"id": "radio_two_way",
 		"image": "./Mods/Core/Items/radio_two_way_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Two way radio",
 		"sprite": "radio_two_way_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 1
@@ -738,10 +738,10 @@
 		"description": "A small device that provides a spark that can be used to light a fire. No power or fuel required.",
 		"id": "firestarter_basic",
 		"image": "./Mods/Core/Items/firestarter_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Firestarter",
 		"sprite": "firestarter_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.2
@@ -750,10 +750,10 @@
 		"description": "\n    A true survival fishing kit in a very small, lightweight package!\n    Contains 118 foot line and winder\n    2 lures, 2 hooks\n    2 swivels, 2 weghts\n    Comes in a strong durable heavy duty resealable plastic bag",
 		"id": "kit_fishing_small",
 		"image": "./Mods/Core/Items/kit_fishing_small_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Small fishing kit",
 		"sprite": "kit_fishing_small_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.4
@@ -762,10 +762,10 @@
 		"description": "A versatile kitchen tool, essential for slicing, dicing, and chopping food.",
 		"id": "kitchen_knife",
 		"image": "./Mods/Core/Items/kitchen_knife_64_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Kitchen Knife",
 		"sprite": "kitchen_knife_64_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 0.4
@@ -774,10 +774,10 @@
 		"description": "A compact and portable stove, perfect for cooking meals during survival situations.",
 		"id": "portable_stove",
 		"image": "./Mods/Core/Items/portable_stove_64_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Portable Stove",
 		"sprite": "portable_stove_64_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 200,
 		"weight": 3
@@ -786,10 +786,10 @@
 		"description": "A durable cooking pot, essential for boiling water and preparing meals.",
 		"id": "cooking_pot",
 		"image": "./Mods/Core/Items/cooking_pot_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Cooking Pot",
 		"sprite": "cooking_pot_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 350,
 		"weight": 3
@@ -798,10 +798,10 @@
 		"description": "A small tool crucial for opening canned food, an essential for survival.",
 		"id": "can_opener",
 		"image": "./Mods/Core/Items/can_opener_64_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Can opener",
 		"sprite": "can_opener_64_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 60,
 		"weight": 0.2
@@ -845,10 +845,10 @@
 		"description": "A large bowl used for mixing ingredients, indispensable for any cooking or baking tasks.",
 		"id": "mixing_bowl",
 		"image": "./Mods/Core/Items/mixing_bowl_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Mixing Bowl",
 		"sprite": "mixing_bowl_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 250,
 		"weight": 0.5
@@ -857,10 +857,10 @@
 		"description": "A metal kettle perfect for boiling water to make tea or instant meals.",
 		"id": "tea_kettle",
 		"image": "./Mods/Core/Items/tea_kettle_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Tea Kettle",
 		"sprite": "tea_kettle_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 200,
 		"weight": 1
@@ -869,10 +869,10 @@
 		"description": "A small rack containing various spices to enhance the flavor of food.",
 		"id": "spice_rack",
 		"image": "./Mods/Core/Items/spice_rack_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Spice Rack",
 		"sprite": "spice_rack_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 150,
 		"weight": 1
@@ -881,10 +881,10 @@
 		"description": "A measuring cup, essential for precisely measuring ingredients for recipes.",
 		"id": "measuring_cup",
 		"image": "./Mods/Core/Items/measuring_cup_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Measuring Cup",
 		"sprite": "measuring_cup_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 0.3
@@ -916,10 +916,10 @@
 		"description": "A wooden rolling pin, essential for flattening dough for baking.",
 		"id": "rolling_pin",
 		"image": "./Mods/Core/Items/rolling_pin_64_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Rolling Pin",
 		"sprite": "rolling_pin_64_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 150,
 		"weight": 0.5
@@ -928,10 +928,10 @@
 		"description": "A heavy-duty frying pan, perfect for cooking everything from eggs to stir-fry.",
 		"id": "frying_pan",
 		"image": "./Mods/Core/Items/frying_pan_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Frying Pan",
 		"sprite": "frying_pan_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 200,
 		"weight": 2
@@ -940,10 +940,10 @@
 		"description": "A metal colander, ideal for draining pasta or washing vegetables.",
 		"id": "steel_colander",
 		"image": "./Mods/Core/Items/steel_colander_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Colander",
 		"sprite": "steel_colander_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 200,
 		"weight": 0.7
@@ -952,10 +952,10 @@
 		"description": "A handy peeler, perfect for skinning vegetables and fruits with ease.",
 		"id": "peeler",
 		"image": "./Mods/Core/Items/peeler_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Peeler",
 		"sprite": "peeler_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.1
@@ -964,10 +964,10 @@
 		"description": "A metal grater, essential for shredding cheese, vegetables, and more.",
 		"id": "grater",
 		"image": "./Mods/Core/Items/grater_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Grater",
 		"sprite": "grater_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.3
@@ -976,10 +976,10 @@
 		"description": "A compact electric toaster, ideal for toasting bread quickly.",
 		"id": "toaster",
 		"image": "./Mods/Core/Items/toaster_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Toaster",
 		"sprite": "toaster_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 300,
 		"weight": 1.5
@@ -988,10 +988,10 @@
 		"description": "An electric blender, perfect for making smoothies, soups, and other blended concoctions.",
 		"id": "blender",
 		"image": "./Mods/Core/Items/blender_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Blender",
 		"sprite": "blender_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 300,
 		"weight": 2
@@ -1000,10 +1000,10 @@
 		"description": "A coffee maker, essential for brewing the perfect cup of coffee to start your day.",
 		"id": "coffee_maker",
 		"image": "./Mods/Core/Items/coffeemaker_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Coffee Maker",
 		"sprite": "coffeemaker_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 300,
 		"weight": 2.5
@@ -1012,10 +1012,10 @@
 		"description": "A microwave oven, perfect for quickly heating or cooking food.",
 		"id": "microwave_oven",
 		"image": "./Mods/Core/Items/microwave_oven_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Microwave Oven",
 		"sprite": "microwave_oven_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 400,
 		"weight": 12
@@ -1024,10 +1024,10 @@
 		"description": "A dish rack, useful for organizing and drying dishes after washing.",
 		"id": "dish_rack",
 		"image": "./Mods/Core/Items/dish_rack_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Dish Rack",
 		"sprite": "dish_rack_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 400,
 		"weight": 1
@@ -1036,10 +1036,10 @@
 		"description": "A pressure cooker, ideal for fast cooking and preserving nutrients in food.",
 		"id": "pressure_cooker",
 		"image": "./Mods/Core/Items/pressure_cooker_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Pressure Cooker",
 		"sprite": "pressure_cooker_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 400,
 		"weight": 5
@@ -1048,10 +1048,10 @@
 		"description": "A bread maker, perfect for effortlessly baking fresh bread at home.",
 		"id": "bread_maker",
 		"image": "./Mods/Core/Items/bread_maker_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Bread Maker",
 		"sprite": "bread_maker_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 300,
 		"weight": 5
@@ -1060,10 +1060,10 @@
 		"description": "Small but crucial for holding together wooden structures and crafting. Often found in the remnants of furniture and buildings.",
 		"id": "nails",
 		"image": "./Mods/Core/Items/nails_32.png",
-		"max_stack_size": "100",
+		"max_stack_size": 100,
 		"name": "Nails",
 		"sprite": "nails_32.png",
-		"stack_size": "10",
+		"stack_size": 10,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -1072,10 +1072,10 @@
 		"description": "Large pieces of wood obtained from cutting down trees. Useful for building and crafting larger items.",
 		"id": "log",
 		"image": "./Mods/Core/Items/log_32.png",
-		"max_stack_size": "3",
+		"max_stack_size": 3,
 		"name": "Log",
 		"sprite": "log_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": true,
 		"volume": 500,
 		"weight": 10
@@ -1084,10 +1084,10 @@
 		"description": "Versatile fasteners used in both wooden and metal constructions. Can be scavenged from disassembled furniture and machinery.",
 		"id": "screw",
 		"image": "./Mods/Core/Items/screw_32.png",
-		"max_stack_size": "100",
+		"max_stack_size": 100,
 		"name": "Screw",
 		"sprite": "screw_32.png",
-		"stack_size": "10",
+		"stack_size": 10,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -1096,10 +1096,10 @@
 		"description": "Smaller pieces of wood that can be used for kindling, basic crafting, and creating primitive tools.",
 		"id": "branch",
 		"image": "./Mods/Core/Items/branches_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Branch",
 		"sprite": "branches_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 2
@@ -1108,10 +1108,10 @@
 		"description": "Can be used for camouflage, crafting bedding, or as a basic source of compost.",
 		"id": "leaf",
 		"image": "./Mods/Core/Items/leaves_32.png",
-		"max_stack_size": "50",
+		"max_stack_size": 50,
 		"name": "Leaf",
 		"sprite": "leaves_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 1,
 		"weight": 0.01
@@ -1120,10 +1120,10 @@
 		"description": "Resinous branches that can be used for kindling or basic crafting.",
 		"id": "pine_branch",
 		"image": "./Mods/Core/Items/pine_branch_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Pine Branch",
 		"sprite": "pine_branch_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 2
@@ -1132,10 +1132,10 @@
 		"description": "Natural material that can be molded when wet and hardens when dried, useful for creating pottery, bricks, and reinforcing structures.",
 		"id": "clay",
 		"image": "./Mods/Core/Items/clay_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Clay",
 		"sprite": "clay_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 20,
 		"weight": 1
@@ -1144,10 +1144,10 @@
 		"description": "Basic resource for growing plants and creating makeshift gardens for food production.",
 		"id": "soil",
 		"image": "./Mods/Core/Items/soil_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Soil",
 		"sprite": "soil_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 200,
 		"weight": 5
@@ -1156,10 +1156,10 @@
 		"description": "Metal parts that allow doors and cabinets to open and close. Can be used in various mechanical constructions.",
 		"id": "hinge",
 		"image": "./Mods/Core/Items/hinge_32.png",
-		"max_stack_size": "50",
+		"max_stack_size": 50,
 		"name": "Hinge",
 		"sprite": "hinge_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.2
@@ -1168,10 +1168,10 @@
 		"description": "Useful for creating compost, crafting, or even as emergency food sources.",
 		"id": "plant_remnants",
 		"image": "./Mods/Core/Items/plant_remnants_32.png",
-		"max_stack_size": "50",
+		"max_stack_size": 50,
 		"name": "Plant Remnants",
 		"sprite": "plant_remnants_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.1
@@ -1180,10 +1180,10 @@
 		"description": "Essential for repairing or crafting electronic devices.",
 		"id": "electrical_components",
 		"image": "./Mods/Core/Items/electrical_components_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Electrical Components",
 		"sprite": "electrical_components_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 20,
 		"weight": 0.5
@@ -1192,10 +1192,10 @@
 		"description": "Versatile material used in various crafting recipes, often scavenged from modern appliances and containers.",
 		"id": "plastic_parts",
 		"image": "./Mods/Core/Items/plastic_parts_32.png",
-		"max_stack_size": "50",
+		"max_stack_size": 50,
 		"name": "Plastic Parts",
 		"sprite": "plastic_parts_32.png",
-		"stack_size": "10",
+		"stack_size": 10,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.3
@@ -1204,10 +1204,10 @@
 		"description": "Shards of broken ceramic items, useful for crafting new items or reinforcing existing structures.",
 		"id": "ceramic_fragments",
 		"image": "./Mods/Core/Items/ceramic_fragments_32.png",
-		"max_stack_size": "30",
+		"max_stack_size": 30,
 		"name": "Ceramic Fragments",
 		"sprite": "ceramic_fragments_32.png",
-		"stack_size": "5",
+		"stack_size": 5,
 		"two_handed": false,
 		"volume": 15,
 		"weight": 1
@@ -1216,10 +1216,10 @@
 		"description": "General metal components used in various crafting and construction recipes.",
 		"id": "metal_parts",
 		"image": "./Mods/Core/Items/metal_parts_32.png",
-		"max_stack_size": "50",
+		"max_stack_size": 50,
 		"name": "Metal Parts",
 		"sprite": "metal_parts_32.png",
-		"stack_size": "10",
+		"stack_size": 10,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.5
@@ -1228,10 +1228,10 @@
 		"description": "A jar of preserved parsley, useful for adding flavor to dishes.",
 		"id": "jar_parsley",
 		"image": "./Mods/Core/Items/jar_parsley_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Jar of Parsley",
 		"sprite": "jar_parsley_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 60,
 		"weight": 0.5
@@ -1240,7 +1240,7 @@
 		"description": "A block of tofu, a good source of protein.",
 		"id": "tofu",
 		"image": "./Mods/Core/Items/tofu_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Tofu",
 		"references": {
 			"core": {
@@ -1250,7 +1250,7 @@
 			}
 		},
 		"sprite": "tofu_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 30,
 		"weight": 0.5
@@ -1259,7 +1259,7 @@
 		"description": "A bottle of yogurt, useful for nutrition and digestion.",
 		"id": "bottle_yogurt",
 		"image": "./Mods/Core/Items/bottle_yogurt_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Bottle of Yogurt",
 		"references": {
 			"core": {
@@ -1269,7 +1269,7 @@
 			}
 		},
 		"sprite": "bottle_yogurt_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 100,
 		"weight": 0.3
@@ -1278,10 +1278,10 @@
 		"description": "A jar of pickles, a tasty preserved food.",
 		"id": "jar_pickles",
 		"image": "./Mods/Core/Items/jar_pickles_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Jar of Pickles",
 		"sprite": "jar_pickles_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 1
@@ -1290,10 +1290,10 @@
 		"description": "A can of condensed milk, a rich source of nutrition.",
 		"id": "condensed_milk",
 		"image": "./Mods/Core/Items/condensed_milk_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Condensed Milk",
 		"sprite": "condensed_milk_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 60,
 		"weight": 0.8
@@ -1302,10 +1302,10 @@
 		"description": "A vial of insulin, necessary for diabetics.",
 		"id": "insulin",
 		"image": "./Mods/Core/Items/insulin_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Insulin",
 		"sprite": "insulin_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -1314,10 +1314,10 @@
 		"description": "An epinephrine auto-injector, useful for treating severe allergic reactions.",
 		"id": "epipen",
 		"image": "./Mods/Core/Items/epipen_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "EpiPen",
 		"sprite": "epipen_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -1326,7 +1326,7 @@
 		"description": "A bag of bacon, rich in fats and proteins.",
 		"id": "bag_bacon",
 		"image": "./Mods/Core/Items/bag_bacon_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Bag of Bacon",
 		"references": {
 			"core": {
@@ -1336,7 +1336,7 @@
 			}
 		},
 		"sprite": "bag_bacon_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 30,
 		"weight": 0.5
@@ -1345,10 +1345,10 @@
 		"description": "A bottle of wine, useful for bartering or a morale boost.",
 		"id": "wine_bottle",
 		"image": "./Mods/Core/Items/wine_bottle_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Wine Bottle",
 		"sprite": "wine_bottle_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 90,
 		"weight": 1.5
@@ -1357,10 +1357,10 @@
 		"description": "A loaf of bread, a staple food item.",
 		"id": "bread",
 		"image": "./Mods/Core/Items/bread_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Bread",
 		"sprite": "bread_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 90,
 		"weight": 0.5
@@ -1369,10 +1369,10 @@
 		"description": "A syringe, useful for administering medical treatments.",
 		"id": "syringe",
 		"image": "./Mods/Core/Items/syringe_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Syringe",
 		"sprite": "syringe_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.05
@@ -1381,7 +1381,7 @@
 		"description": "A slice of pizza, not very fresh but still edible.",
 		"id": "slice_of_pizza",
 		"image": "./Mods/Core/Items/slice_of_pizza_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Slice of Pizza",
 		"references": {
 			"core": {
@@ -1391,7 +1391,7 @@
 			}
 		},
 		"sprite": "slice_of_pizza_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.3
@@ -1400,7 +1400,7 @@
 		"description": "A package of vacuum-sealed fish, preserved for longer storage.",
 		"id": "vacuum_sealed_fish",
 		"image": "./Mods/Core/Items/vacuum_sealed_fish_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Vacuum Sealed Fish",
 		"references": {
 			"core": {
@@ -1410,7 +1410,7 @@
 			}
 		},
 		"sprite": "vacuum_sealed_fish_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.8
@@ -1419,7 +1419,7 @@
 		"description": "A ripe tomato, still fresh and edible.",
 		"id": "tomato",
 		"image": "./Mods/Core/Items/tomato_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Tomato",
 		"references": {
 			"core": {
@@ -1429,7 +1429,7 @@
 			}
 		},
 		"sprite": "tomato_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.2
@@ -1438,7 +1438,7 @@
 		"description": "A head of lettuce, slightly wilted but still usable.",
 		"id": "lettuce",
 		"image": "./Mods/Core/Items/lettuce_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Lettuce",
 		"references": {
 			"core": {
@@ -1448,7 +1448,7 @@
 			}
 		},
 		"sprite": "lettuce_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 90,
 		"weight": 0.3
@@ -1457,10 +1457,10 @@
 		"description": "A container of protein powder, useful for maintaining nutrition.",
 		"id": "protein_powder",
 		"image": "./Mods/Core/Items/protein_powder_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Protein Powder",
 		"sprite": "protein_powder_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 1
@@ -1469,10 +1469,10 @@
 		"description": "A bar of chocolate, a morale booster and energy source.",
 		"id": "chocolate",
 		"image": "./Mods/Core/Items/chocolate_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Chocolate",
 		"sprite": "chocolate_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 25,
 		"weight": 0.2
@@ -1481,10 +1481,10 @@
 		"description": "A jar of olives, preserved and ready to eat.",
 		"id": "jar_olives",
 		"image": "./Mods/Core/Items/jar_olives_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Jar of Olives",
 		"sprite": "jar_olives_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 40,
 		"weight": 0.5
@@ -1493,10 +1493,10 @@
 		"description": "A jar of preserved basil, useful for seasoning.",
 		"id": "jar_basil",
 		"image": "./Mods/Core/Items/jar_basil_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Jar of Basil",
 		"sprite": "jar_basil_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 25,
 		"weight": 0.5
@@ -1505,10 +1505,10 @@
 		"description": "A jar of mustard, adds flavor to meals.",
 		"id": "jar_mustard",
 		"image": "./Mods/Core/Items/jar_mustard_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Jar of Mustard",
 		"sprite": "jar_mustard_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 25,
 		"weight": 0.3
@@ -1517,10 +1517,10 @@
 		"description": "A bottle of ketchup, a common condiment.",
 		"id": "bottle_ketchup",
 		"image": "./Mods/Core/Items/bottle_ketchup_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Bottle of Ketchup",
 		"sprite": "bottle_ketchup_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 60,
 		"weight": 0.3
@@ -1529,10 +1529,10 @@
 		"description": "A loaf of bread that has gone stale, but still edible in a pinch.",
 		"id": "stale_bread",
 		"image": "./Mods/Core/Items/stale_bread_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Stale Bread",
 		"sprite": "stale_bread_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 90,
 		"weight": 0.5
@@ -1541,10 +1541,10 @@
 		"description": "Pain relief medication, useful for treating injuries.",
 		"id": "painkiller",
 		"image": "./Mods/Core/Items/painkiller_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Painkiller",
 		"sprite": "painkiller_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 5,
 		"weight": 0.1
@@ -1553,10 +1553,10 @@
 		"description": "A fresh orange, a good source of vitamin C.",
 		"id": "orange",
 		"image": "./Mods/Core/Items/orange_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Orange",
 		"sprite": "orange_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.2
@@ -1565,7 +1565,7 @@
 		"description": "A fresh apple, a healthy snack.",
 		"id": "apple",
 		"image": "./Mods/Core/Items/apple_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Apple",
 		"references": {
 			"core": {
@@ -1575,7 +1575,7 @@
 			}
 		},
 		"sprite": "apple_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.2
@@ -1584,10 +1584,10 @@
 		"description": "A raw potato, versatile in many recipes.",
 		"id": "potato",
 		"image": "./Mods/Core/Items/potato_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Potato",
 		"sprite": "potato_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 15,
 		"weight": 0.3
@@ -1596,7 +1596,7 @@
 		"description": "A fresh carrot, good for nutrition.",
 		"id": "carrot",
 		"image": "./Mods/Core/Items/carrot_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Carrot",
 		"references": {
 			"core": {
@@ -1606,7 +1606,7 @@
 			}
 		},
 		"sprite": "carrot_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 10,
 		"weight": 0.2
@@ -1615,7 +1615,7 @@
 		"description": "A carton of eggs, a versatile food item.",
 		"id": "eggs",
 		"image": "./Mods/Core/Items/eggs_32.png",
-		"max_stack_size": "5",
+		"max_stack_size": 5,
 		"name": "Eggs",
 		"references": {
 			"core": {
@@ -1625,7 +1625,7 @@
 			}
 		},
 		"sprite": "eggs_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.6
@@ -1634,7 +1634,7 @@
 		"description": "A stick of butter, useful for cooking and baking.",
 		"id": "butter",
 		"image": "./Mods/Core/Items/butter_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Butter",
 		"references": {
 			"core": {
@@ -1644,7 +1644,7 @@
 			}
 		},
 		"sprite": "butter_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 20,
 		"weight": 0.4
@@ -1653,7 +1653,7 @@
 		"description": "A can of energy drink, boosts stamina temporarily.",
 		"id": "can_energydrink",
 		"image": "./Mods/Core/Items/can_energydrink_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Energy Drink",
 		"references": {
 			"core": {
@@ -1663,7 +1663,7 @@
 			}
 		},
 		"sprite": "can_energydrink_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.3
@@ -1672,7 +1672,7 @@
 		"description": "A can of soda, a refreshing beverage.",
 		"id": "can_soda",
 		"image": "./Mods/Core/Items/can_soda_32.png",
-		"max_stack_size": "20",
+		"max_stack_size": 20,
 		"name": "Soda",
 		"references": {
 			"core": {
@@ -1682,7 +1682,7 @@
 			}
 		},
 		"sprite": "can_soda_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 50,
 		"weight": 0.3
@@ -1691,7 +1691,7 @@
 		"description": "A block of cheese, a versatile food item.",
 		"id": "cheese",
 		"image": "./Mods/Core/Items/cheese_32.png",
-		"max_stack_size": "10",
+		"max_stack_size": 10,
 		"name": "Cheese",
 		"references": {
 			"core": {
@@ -1701,7 +1701,7 @@
 			}
 		},
 		"sprite": "cheese_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
 		"volume": 40,
 		"weight": 0.5

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -3,7 +3,7 @@
 		"description": "A wooden plank that could be used for all kinds of crafting and construction",
 		"id": "plank_2x4",
 		"image": "./Mods/Core/Items/plank.png",
-		"max_stack_size": "3",
+		"max_stack_size": 3,
 		"name": "Plank 2x4",
 		"references": {
 			"core": {
@@ -19,16 +19,16 @@
 			}
 		},
 		"sprite": "plank.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
-		"volume": "300",
-		"weight": "2"
+		"volume": 300,
+		"weight": 2
 	},
 	{
 		"description": "Some metal bits and pieces. Useful for something, right?",
 		"id": "steel_scrap",
 		"image": "./Mods/Core/Items/steel_scrap.png",
-		"max_stack_size": "100",
+		"max_stack_size": 100,
 		"name": "Steel scrap",
 		"references": {
 			"core": {
@@ -45,10 +45,10 @@
 			}
 		},
 		"sprite": "steel_scrap.png",
-		"stack_size": "2",
+		"stack_size": 2,
 		"two_handed": false,
-		"volume": "15",
-		"weight": "0.25"
+		"volume": 15,
+		"weight": 0.25
 	},
 	{
 		"Ammo": {
@@ -57,7 +57,7 @@
 		"description": "Standard type of ammunition. Very common.",
 		"id": "bullet_9mm",
 		"image": "./Mods/Core/Items/9mm.png",
-		"max_stack_size": "100",
+		"max_stack_size": 100,
 		"name": "bullet 9mm",
 		"references": {
 			"core": {
@@ -71,10 +71,10 @@
 			}
 		},
 		"sprite": "9mm.png",
-		"stack_size": "20",
+		"stack_size": 20,
 		"two_handed": false,
-		"volume": "0.1",
-		"weight": "0.01"
+		"volume": 0.1,
+		"weight": 0.01
 	},
 	{
 		"Craft": [
@@ -112,7 +112,7 @@
 		"description": "In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets",
 		"id": "pistol_magazine",
 		"image": "./Mods/Core/Items/pistol_magazine.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Pistol magazine",
 		"references": {
 			"core": {
@@ -123,10 +123,10 @@
 			}
 		},
 		"sprite": "pistol_magazine.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
-		"volume": "10",
-		"weight": "0.25"
+		"volume": 10,
+		"weight": 0.25
 	},
 	{
 		"Ranged": {
@@ -146,7 +146,7 @@
 		"description": "A standard issue pistol that uses 9mm ammunition",
 		"id": "pistol_9mm",
 		"image": "./Mods/Core/Items/pistol_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Pistol 9mm",
 		"references": {
 			"core": {
@@ -156,10 +156,10 @@
 			}
 		},
 		"sprite": "pistol_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
-		"volume": "150",
-		"weight": "2"
+		"volume": 150,
+		"weight": 2
 	},
 	{
 		"Ranged": {
@@ -597,13 +597,13 @@
 		"description": "A device that shows your orientation relative to the earth's poles",
 		"id": "compass",
 		"image": "./Mods/Core/Items/compass_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Compass",
 		"sprite": "compass_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
-		"volume": "6",
-		"weight": "0.1"
+		"volume": 6,
+		"weight": 0.1
 	},
 	{
 		"description": "A very common type of battery that fits most battery-powered devices",
@@ -833,13 +833,13 @@
 		"description": "A sturdy cutting board, ideal for preparing food safely and efficiently.",
 		"id": "cutting_board",
 		"image": "./Mods/Core/Items/cutting_board_64_32.png",
-		"max_stack_size": "1",
+		"max_stack_size": 1,
 		"name": "Cutting Board",
 		"sprite": "cutting_board_64_32.png",
-		"stack_size": "1",
+		"stack_size": 1,
 		"two_handed": false,
-		"volume": "200",
-		"weight": "1"
+		"volume": 200,
+		"weight": 1
 	},
 	{
 		"description": "A large bowl used for mixing ingredients, indispensable for any cooking or baking tasks.",

--- a/Scenes/ContentManager/ModMaintenance/Scripts/changepropertytypescript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/changepropertytypescript.gd
@@ -1,0 +1,127 @@
+extends Control
+
+# This script is meant to be used with the mod maintenance interface
+# This script allows the user to change the selected property on the selected type
+# of entity from one type to another type. For example, change "volume" from string to int
+
+@export var propertiesOptionButton: OptionButton
+@export var typesOptionButton: OptionButton
+@export var outputTextEdit: TextEdit
+@export var from_option_button: OptionButton
+@export var to_option_button: OptionButton
+@export var change_property_type_button: Button
+
+
+
+# fills the propertiesOptionButton with all top-level properties of the selected entity type
+# 1. Check if a type has been selected and return if not
+# 2. check if the type_data array contains anything and return if not
+# 3. Loop over all entities in type_data
+# 4. For each yop-level property in the entity's property dictionary, add the property
+# to propertiesOptionButton if it's not already there
+func _on_get_properties_button_button_up():
+	propertiesOptionButton.clear()  # Clear existing items
+	var game_data = get_type_data()
+	var type_data = game_data.data
+	if not type_data or type_data.is_empty():
+		outputTextEdit.text = "No data available or type not selected."
+		return
+
+	var properties_set = {}  # Using a dictionary to track unique properties
+	for entity in type_data:
+		for property in entity.keys():
+			properties_set[property] = true
+
+	for property in properties_set.keys():
+		propertiesOptionButton.add_item(property)
+
+	if propertiesOptionButton.get_item_count() == 0:
+		outputTextEdit.text = "No properties found for selected type."
+	else:
+		outputTextEdit.text = "Properties loaded for selected type."
+
+
+func get_type_data() -> Variant:
+	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
+	if selected_type == "Item":
+		return Gamedata.data.items
+	elif selected_type == "Furniture":
+		return Gamedata.data.furniture
+	elif selected_type == "Itemgroup":
+		return Gamedata.data.itemgroups
+	elif selected_type == "Mob":
+		return Gamedata.data.mobs
+	return null
+
+
+# The user selects a type to change to. The type can be int or string
+# This function needs to enable change_property_type_button if 
+# from_option_button also has a value selected
+func _on_to_option_button_item_selected(_index):
+	if from_option_button.selected != -1:
+		change_property_type_button.disabled = false
+
+
+# The user selects a type to change from. The type can be int or string
+# This function needs to enable change_property_type_button if 
+# to_option_button also has a value selected
+func _on_from_option_button_item_selected(_index):
+	if to_option_button.selected != -1:
+		change_property_type_button.disabled = false
+
+
+# Changes the selected property on all entities of the selected type from one
+# type to another. For example, change the type of the "volume" property
+# from a string to an int
+# 1. Check if a type has been selected in typesOptionButton and return if not
+# 2. Check if a property has been selected in typesOptionButton and return if not
+# 3. Get the data of the selected type and check if it contains data. Return if not
+# 4. Loop over the entities in the data of the selected type
+# 4.1. For each entity, check if the selected property exists
+# 4.2. If the property exists, check if the type matches the type selected in from_option_button
+# 4.3. If it matches, change the property type form the current type to the 
+# type selected in to_option_button. This can be an int or a string
+# 4.4 print the changed entity id and property to the output
+# 5. Save the data to file
+func _on_change_property_type_button_button_up():
+	if typesOptionButton.selected == -1:
+		outputTextEdit.text = "No type selected."
+		return
+	if propertiesOptionButton.selected == -1:
+		outputTextEdit.text = "No property selected."
+		return
+
+	var game_data = get_type_data()
+	var type_data = game_data.data
+	if type_data.is_empty():
+		outputTextEdit.text = "No data available for the selected type."
+		return
+
+	var property_name = propertiesOptionButton.get_item_text(propertiesOptionButton.selected)
+	var from_type = from_option_button.get_item_text(from_option_button.selected)
+	var to_type = to_option_button.get_item_text(to_option_button.selected)
+	
+	if from_type == to_type:
+		outputTextEdit.text = "From type and to type are the same. No changes made."
+		return
+	
+	var changes = []
+	
+	for entity in type_data:
+		if property_name in entity:
+			var value = entity[property_name]
+			var value_type = typeof(value)
+			if (from_type == "int" and value_type == TYPE_INT) or (from_type == "string" and value_type == TYPE_STRING) or (from_type == "float" and value_type == TYPE_FLOAT):
+				if to_type == "int":
+					entity[property_name] = int(value)
+				elif to_type == "string":
+					entity[property_name] = str(value)
+				elif to_type == "float":
+					entity[property_name] = float(value)
+				changes.append("Changed property '" + property_name + "' of entity with ID " + str(entity.get("id", "Unknown ID")) + " to " + to_type)
+
+	if changes.is_empty():
+		outputTextEdit.text = "No changes made. Property '" + property_name + "' not found in any entities or type mismatch."
+	else:
+		outputTextEdit.text = "Changes made:\n" + "\n".join(changes)
+		Gamedata.save_data_to_file(game_data)

--- a/Scenes/ContentManager/ModMaintenance/changepropertytypescript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/changepropertytypescript.tscn
@@ -1,0 +1,129 @@
+[gd_scene load_steps=3 format=3 uid="uid://bnf41ptw7dxpn"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/ModMaintenance/Scripts/changepropertytypescript.gd" id="1_804mc"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_avegi"]
+font_size = 36
+
+[node name="changepropertytype" type="Control" node_paths=PackedStringArray("propertiesOptionButton", "typesOptionButton", "outputTextEdit", "from_option_button", "to_option_button", "change_property_type_button")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_804mc")
+propertiesOptionButton = NodePath("VBoxContainer/PropertiesHBoxContainer/PropertiesOptionButton")
+typesOptionButton = NodePath("VBoxContainer/TypesHBoxContainer/TypesOptionButton")
+outputTextEdit = NodePath("VBoxContainer/OutputTextEdit")
+from_option_button = NodePath("VBoxContainer/PropertiesHBoxContainer/FromOptionButton")
+to_option_button = NodePath("VBoxContainer/PropertiesHBoxContainer/ToOptionButton")
+change_property_type_button = NodePath("VBoxContainer/PropertiesHBoxContainer/ChangePropertyTypeButton")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="modmaintenanceLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Change property type"
+label_settings = SubResource("LabelSettings_avegi")
+
+[node name="explainationLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Create a backup before using this script! Changes the type for a property to another type. For example a string to an integer. 
+All entities of the selected type will be checked for the property and it will be changed if the entity has it.
+1. Select the type of entity you want to change the property type of.
+2. Select the property to be changed
+3. Press change property to change the property type on all entities of the selected type"
+
+[node name="TypesHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="TypesLabel" type="Label" parent="VBoxContainer/TypesHBoxContainer"]
+layout_mode = 2
+text = "Selected type:"
+
+[node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
+layout_mode = 2
+item_count = 4
+selected = 0
+popup/item_0/text = "Item"
+popup/item_0/id = 0
+popup/item_1/text = "Furniture"
+popup/item_1/id = 1
+popup/item_2/text = "Itemgroup"
+popup/item_2/id = 3
+popup/item_3/text = "Mob"
+popup/item_3/id = 2
+
+[node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
+layout_mode = 2
+text = "Get properties"
+
+[node name="PropertiesHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="PropertiesLabel" type="Label" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+text = "Selected property:"
+
+[node name="PropertiesOptionButton" type="OptionButton" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+tooltip_text = "The property of this type of entity. If the property you want to change isn't listed here, it does not exist in the json and can't be changed."
+
+[node name="FromLabel" type="Label" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+text = "From:"
+
+[node name="FromOptionButton" type="OptionButton" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+tooltip_text = "Select the type to change the property from. If the type is not present in the list, the type is not supported by this script (yet)."
+item_count = 3
+popup/item_0/text = "int"
+popup/item_0/id = 0
+popup/item_1/text = "string"
+popup/item_1/id = 1
+popup/item_2/text = "float"
+popup/item_2/id = 2
+
+[node name="ToLabel" type="Label" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+text = "To:"
+
+[node name="ToOptionButton" type="OptionButton" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+tooltip_text = "Select the type to change the property to. If the type is not present in the list, the type is not supported by this script (yet)."
+item_count = 3
+popup/item_0/text = "int"
+popup/item_0/id = 0
+popup/item_1/text = "string"
+popup/item_1/id = 1
+popup/item_2/text = "float"
+popup/item_2/id = 2
+
+[node name="ChangePropertyTypeButton" type="Button" parent="VBoxContainer/PropertiesHBoxContainer"]
+layout_mode = 2
+tooltip_text = "Applies the changes to the selected property of the selected type. Make sure you
+ do not have the json file of the selected type opened and you made a backup."
+disabled = true
+text = "Change property type"
+
+[node name="outputLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Output:"
+
+[node name="OutputTextEdit" type="TextEdit" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[connection signal="button_up" from="VBoxContainer/TypesHBoxContainer/GetPropertiesButton" to="." method="_on_get_properties_button_button_up"]
+[connection signal="item_selected" from="VBoxContainer/PropertiesHBoxContainer/FromOptionButton" to="." method="_on_from_option_button_item_selected"]
+[connection signal="item_selected" from="VBoxContainer/PropertiesHBoxContainer/ToOptionButton" to="." method="_on_to_option_button_item_selected"]
+[connection signal="button_up" from="VBoxContainer/PropertiesHBoxContainer/ChangePropertyTypeButton" to="." method="_on_change_property_type_button_button_up"]

--- a/Scenes/ContentManager/ModMaintenance/modmaintenance.tscn
+++ b/Scenes/ContentManager/ModMaintenance/modmaintenance.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=4 format=3 uid="uid://6d7nhwfk088o"]
+[gd_scene load_steps=5 format=3 uid="uid://6d7nhwfk088o"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/modmaintenance.gd" id="1_qyerb"]
 [ext_resource type="PackedScene" uid="uid://cycrhylvmdoo1" path="res://Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn" id="2_flc2r"]
+[ext_resource type="PackedScene" uid="uid://bnf41ptw7dxpn" path="res://Scenes/ContentManager/ModMaintenance/changepropertytypescript.tscn" id="3_2oqe6"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_avegi"]
 font_size = 42
 
-[node name="modmaintenance" type="Control"]
+[node name="modmaintenance" type="Control" node_paths=PackedStringArray("scriptOptionButton", "removePropertyScript", "changepropertytype")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -14,6 +15,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_qyerb")
+scriptOptionButton = NodePath("VBoxContainer/ScriptHBoxContainer/ScriptOptionButton")
+removePropertyScript = NodePath("VBoxContainer/removeproperty")
+changepropertytype = NodePath("VBoxContainer/changepropertytype")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -53,12 +57,18 @@ text = "Selected script:"
 
 [node name="ScriptOptionButton" type="OptionButton" parent="VBoxContainer/ScriptHBoxContainer"]
 layout_mode = 2
-item_count = 1
+item_count = 2
 selected = 0
 popup/item_0/text = "Remove property"
 popup/item_0/id = 0
+popup/item_1/text = "Change property type"
+popup/item_1/id = 1
 
 [node name="removeproperty" parent="VBoxContainer" instance=ExtResource("2_flc2r")]
+layout_mode = 2
+
+[node name="changepropertytype" parent="VBoxContainer" instance=ExtResource("3_2oqe6")]
+visible = false
 layout_mode = 2
 
 [connection signal="button_up" from="VBoxContainer/HeaderHBoxContainer/BackButton" to="." method="_on_back_button_button_up"]

--- a/Scenes/ContentManager/Scripts/modmaintenance.gd
+++ b/Scenes/ContentManager/Scripts/modmaintenance.gd
@@ -6,6 +6,7 @@ extends Control
 
 @export var scriptOptionButton: OptionButton
 @export var removePropertyScript: Control
+@export var changepropertytype: Control
 
 
 func _on_back_button_button_up():
@@ -16,7 +17,10 @@ func _on_script_option_button_item_selected(index):
 	hide_scripts()
 	if index == 0:
 		removePropertyScript.visible = true
+	if index == 1:
+		changepropertytype.visible = true
 
 
 func hide_scripts():
 	removePropertyScript.visible = false
+	changepropertytype.visible = false

--- a/Scenes/UI/CraftingMenu.tscn
+++ b/Scenes/UI/CraftingMenu.tscn
@@ -6,7 +6,7 @@
 
 [sub_resource type="LabelSettings" id="LabelSettings_myv0w"]
 
-[node name="CraftingMenu" type="Panel" node_paths=PackedStringArray("item_button_container", "description", "required_items", "skill_progression_label", "recipeVBoxContainer", "start_crafting_button") groups=["CraftingMenu"]]
+[node name="CraftingMenu" type="Panel" node_paths=PackedStringArray("item_button_container", "description", "required_items", "skill_progression_label", "recipeVBoxContainer", "feedback_label", "start_crafting_button") groups=["CraftingMenu"]]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -27,6 +27,7 @@ description = NodePath("Panel/VBoxContainer/Description")
 required_items = NodePath("Panel/VBoxContainer/RequiredItems")
 skill_progression_label = NodePath("Panel/VBoxContainer/SkillProgressionLabel")
 recipeVBoxContainer = NodePath("Panel/VBoxContainer/RecipeVBoxContainer")
+feedback_label = NodePath("Panel/VBoxContainer/FeedbackLabel")
 start_crafting_button = NodePath("Panel/VBoxContainer/StartCraftingButton")
 hud = NodePath("..")
 
@@ -85,6 +86,12 @@ layout_mode = 2
 custom_minimum_size = Vector2(200, 200)
 layout_mode = 2
 size_flags_vertical = 6
+
+[node name="FeedbackLabel" type="Label" parent="Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+text = "Not enough space to craft!"
+horizontal_alignment = 1
 
 [node name="StartCraftingButton" type="Button" parent="Panel/VBoxContainer"]
 layout_mode = 2

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -7,6 +7,7 @@ extends Panel
 @export var required_items : VBoxContainer
 @export var skill_progression_label : Label
 @export var recipeVBoxContainer : VBoxContainer
+@export var feedback_label : Label
 
 @export var start_crafting_button : Button
 
@@ -24,6 +25,8 @@ func _ready():
 	start_craft.connect(ItemManager.on_crafting_menu_start_craft)
 	ItemManager.allAccessibleItems_changed.connect(_on_allAccessibleItems_changed)
 	Helper.signal_broker.player_skill_changed.connect(_on_player_skill_changed)
+	ItemManager.craft_succesful.connect(_on_craft_succesful)
+	ItemManager.craft_failed.connect(_on_craft_failed)
 	create_item_buttons()
 
 
@@ -193,5 +196,33 @@ func refresh_item_buttons():
 
 
 # The player's skill has changed so new recipes might be unlocked. Refresh the list
-func _on_player_skill_changed(playernode: CharacterBody3D):
+func _on_player_skill_changed(_playernode: CharacterBody3D):
 	refresh_item_buttons()
+
+
+# Function to display feedback message temporarily
+func display_feedback(message: String, color: Color):
+	feedback_label.text = message
+	feedback_label.modulate = color  # Set the text color
+	feedback_label.visible = true
+	
+	# Create a timer to hide the feedback label after 0.5 seconds
+	var timer = Timer.new()
+	timer.wait_time = 0.5
+	timer.one_shot = true
+	timer.timeout.connect(func():
+		feedback_label.visible = false
+		timer.queue_free()  # Properly free the timer node
+	)
+	add_child(timer)  # Add the timer to the scene tree
+	timer.start()
+
+
+func _on_craft_succesful(_item: Dictionary, _recipe: Dictionary):
+	var color = Color(0.4, 1, 0.4)  # Brighter green color with more white
+	display_feedback("craft succesful!", color)
+
+
+func _on_craft_failed(_item: Dictionary, _recipe: Dictionary, reason: String):
+	var color = Color(1, 0, 0)  # Red color
+	display_feedback(reason, color)

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -74,7 +74,7 @@ func initialize_list():
 # Initialize these in _ready function or similar initialization function
 func _ready():
 	add_child(tooltip_timer)
-	tooltip_timer.wait_time = 0.7  # 0.5 seconds delay
+	tooltip_timer.wait_time = 0.7  # 0.7 seconds delay
 	tooltip_timer.one_shot = true  # Only trigger once per hover
 	tooltip_timer.timeout.connect(_on_tooltip_timer_timeout)
 	Helper.signal_broker.inventory_operation_started.connect(_on_inventory_operation_started)
@@ -416,10 +416,13 @@ func _update_bars(changedItem: InventoryItem, action: String):
 			total_weight += item.get_property("weight", 0) 
 			total_volume += item.get_property("volume", 0)
 
-	WeightBar.value = total_weight
 	WeightBar.max_value = max_weight
+	WeightBar.value = total_weight
+	if myInventory == ItemManager.playerInventory:
+		VolumeBar.max_value = ItemManager.player_max_inventory_volume
+	else:
+		VolumeBar.max_value = max_volume
 	VolumeBar.value = total_volume
-	VolumeBar.max_value = max_volume
 
 
 func _sort_items(a, b):
@@ -778,8 +781,10 @@ func get_used_volume() -> float:
 
 
 func get_remaining_volume() -> float:
-	return max_volume - get_used_volume()
-
+	if myInventory == ItemManager.playerInventory:
+		return ItemManager.player_max_inventory_volume - get_used_volume()
+	else:
+		return max_volume - get_used_volume()
 
 func get_items() -> Array:
 	return myInventory.get_children()

--- a/Scripts/ItemEditor.gd
+++ b/Scripts/ItemEditor.gd
@@ -100,10 +100,10 @@ func _on_save_button_button_up() -> void:
 	contentData["image"] = Gamedata.data.items.spritePath + PathTextLabel.text
 	contentData["name"] = NameTextEdit.text
 	contentData["description"] = DescriptionTextEdit.text
-	contentData["volume"] = VolumeNumberBox.get_line_edit().text
-	contentData["weight"] = WeightNumberBox.get_line_edit().text
-	contentData["stack_size"] = StackSizeNumberBox.get_line_edit().text
-	contentData["max_stack_size"] = MaxStackSizeNumberBox.get_line_edit().text
+	contentData["volume"] = VolumeNumberBox.value
+	contentData["weight"] = WeightNumberBox.value
+	contentData["stack_size"] = StackSizeNumberBox.value
+	contentData["max_stack_size"] = MaxStackSizeNumberBox.value
 	contentData["two_handed"] = TwoHandedCheckBox.button_pressed
 	
 	# Loop through typesContainer children to save additional properties


### PR DESCRIPTION
Fixes #202 but does some more stuff

- Changed stack_size, max_stack_size, weight and volume to be numbers instead of strings. This was needed for volume calculations and consistency
- Added a mod maintenance script to change the type of a property to another type
- The item_manager now checks if the item fits in the inventory when crafting
- The crafting menu now gives feedback on a successful or a failed craft
- The volume bar in the player inventory wasn't updated when the game starts, but it updates now.

The feedback in the crafting menu is a label above the craft button that shows for 0.5 seconds after pressing the craft button

Craft fails because of low resources:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/f177ce39-f310-4ebe-8f18-736b19238fcb)


Craft fails because of low inventory space:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/9570e155-b617-4414-a19a-cdfda7a275d8)


Craft succeeded:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/ddfb4348-7b43-49e0-a8b6-00efb3614af8)


There is another feedback message that is harder to get, where some items can't be removed from the inventory somehow

The volume calculations are simple. It only checks if the item fits in the inventory. This is a bit limited, since more space is created when items are removed from the inventory during crafting. But it's a start.
