### PR TITLE
save load player skills

### DIFF
--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -172,7 +172,7 @@ func load_player_equipment() -> void:
 		print_debug("Failed to load player equipment from: " + load_path)
 
 
-# Function to save the player's state to a JSON file.
+# This function saves the player's state to a JSON file, including skills.
 func save_player_state(player: CharacterBody3D) -> void:
 	if !player:
 		return
@@ -189,12 +189,13 @@ func save_player_state(player: CharacterBody3D) -> void:
 		"hunger": player.current_hunger,
 		"thirst": player.current_thirst,
 		"nutrition": player.current_nutrition,
-		"pain": player.current_pain
+		"pain": player.current_pain,
+		"skills": player.skills  # Add skills dictionary
 	}
 	Helper.json_helper.write_json_file(save_path, JSON.stringify(player_state))
 
 
-# Function to load the player's state from a JSON file.
+# This function loads the player's state from a JSON file, including skills.
 func load_player_state(player: CharacterBody3D) -> void:
 	var load_path = current_save_folder + "/player_state.json"
 	var player_state = Helper.json_helper.load_json_dictionary_file(load_path)
@@ -212,6 +213,8 @@ func load_player_state(player: CharacterBody3D) -> void:
 		player.current_thirst = player_state["thirst"]
 		player.current_nutrition = player_state["nutrition"]
 		player.current_pain = player_state["pain"]
+		player.skills = player_state["skills"]  # Load skills dictionary
+
 		# Emit signals to update the HUD
 		player.update_doll.emit(player.current_head_health, player.current_right_arm_health, player.current_left_arm_health, player.current_torso_health, player.current_right_leg_health, player.current_left_leg_health)
 		player.update_stamina_HUD.emit(player.current_stamina)


### PR DESCRIPTION
Fixes #214 

It does what was suggested in the issue.
THe json that was saved looks like this:

```json
{
	"head_health": 100,
	"hunger": 0,
	"is_alive": true,
	"left_arm_health": 100,
	"left_leg_health": 100,
	"nutrition": 100,
	"pain": null,
	"right_arm_health": 100,
	"right_leg_health": 100,
	"skills": {
		"archery": {
			"level": 1,
			"xp": 0
		},
		"athletics": {
			"level": 1,
			"xp": 0
		},
		"bashing": {
			"level": 1,
			"xp": 0
		},
		"chemistry": {
			"level": 1,
			"xp": 0
		},
		"computer": {
			"level": 1,
			"xp": 0
		},
		"cooking": {
			"level": 1,
			"xp": 0
		},
		"cutting": {
			"level": 1,
			"xp": 0
		},
		"dodge": {
			"level": 1,
			"xp": 0
		},
		"driving": {
			"level": 1,
			"xp": 0
		},
		"electronics": {
			"level": 1,
			"xp": 0
		},
		"fabrication": {
			"level": 1,
			"xp": 0
		},
		"firstaid": {
			"level": 1,
			"xp": 0
		},
		"gun": {
			"level": 1,
			"xp": 0
		},
		"handguns": {
			"level": 1,
			"xp": 0
		},
		"launcher": {
			"level": 1,
			"xp": 0
		},
		"mechanics": {
			"level": 1,
			"xp": 0
		},
		"melee": {
			"level": 1,
			"xp": 0
		},
		"rifle": {
			"level": 2,
			"xp": 16
		},
		"shotgun": {
			"level": 1,
			"xp": 0
		},
		"smg": {
			"level": 1,
			"xp": 0
		},
		"speech": {
			"level": 1,
			"xp": 0
		},
		"survival": {
			"level": 1,
			"xp": 0
		},
		"swimming": {
			"level": 1,
			"xp": 0
		},
		"tailoring": {
			"level": 1,
			"xp": 0
		},
		"throw": {
			"level": 1,
			"xp": 0
		},
		"trapping": {
			"level": 1,
			"xp": 0
		},
		"unarmed": {
			"level": 1,
			"xp": 0
		}
	},
	"stamina": 100,
	"thirst": 0,
	"torso_health": 100
}
```

You can see that the rifle skill is at level 2 and 16 xp and it is also loaded as such.