### PR TITLE
Implement kill mob quest, add quest rewards

### DIFF
--- a/Mods/Core/Quests/Quests.json
+++ b/Mods/Core/Quests/Quests.json
@@ -11,5 +11,24 @@
 				"type": "collect"
 			}
 		]
+	},
+	{
+		"description": "You are tasked with killing two scrapwalkers",
+		"id": "kill_2_scrapwalkers",
+		"name": "Kill scrapwalkers",
+		"rewards": [
+			{
+				"amount": 15,
+				"item_id": "bullet_9mm"
+			}
+		],
+		"sprite": "pistol_32.png",
+		"steps": [
+			{
+				"amount": 2,
+				"mob": "scrapwalker",
+				"type": "kill"
+			}
+		]
 	}
 ]

--- a/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
@@ -188,7 +188,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
-columns = 6
+columns = 3
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_2twbp")]
 visible = false

--- a/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
@@ -172,6 +172,8 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_0aygx")
 
 [node name="StepsVBoxContainer" type="VBoxContainer" parent="VBoxContainer/FormGrid/StepsPanelContainer"]
 layout_mode = 2
+tooltip_text = "Press the \"+ Add\" button above to add a step. You can 
+re-order and delete steps using the controls of each step."
 
 [node name="RewardssLabel" type="Label" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
@@ -180,6 +182,8 @@ text = "Rewards"
 [node name="RewardsPanelContainer" type="PanelContainer" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
 size_flags_vertical = 3
+tooltip_text = "Drag items from the left menu here to add rewards. You can set the amount 
+of each reward. The item amounts are limted to the item's max stack size."
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_6fqvj")
 
@@ -187,7 +191,6 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_6fqvj")
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
 columns = 3
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_2twbp")]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
@@ -32,7 +32,9 @@ var contentData: Dictionary = {}:
 		olddata = contentData.duplicate(true)
 
 func _ready():
-	data_changed.connect(Gamedata.on_data_changed)
+	data_changed.connect(Gamedata.on_data_changed)	
+	# Set custom can_drop_func and drop_func for the brushcontainer, use default drag_func
+	rewards_item_list.set_drag_forwarding(Callable(), _can_drop_reward, _drop_reward_data)
 
 
 #The editor is closed, destroy the instance
@@ -59,6 +61,15 @@ func load_quest_data() -> void:
 		if contentData.has("steps"):
 			for step in contentData["steps"]:
 				add_step_from_data(step)
+
+	# Load rewards
+	if rewards_item_list:
+		for child in rewards_item_list.get_children():
+			child.queue_free()
+		if contentData.has("rewards"):
+			for reward in contentData["rewards"]:
+				add_reward_entry(reward["item_id"], reward["amount"])
+
 
 # Function to add a step based on the step type selected
 func _on_add_step_button_button_up():
@@ -110,6 +121,18 @@ func _on_save_button_button_up() -> void:
 			step["mob"] = (hbox.get_child(1)).get_text()
 			step["amount"] = (hbox.get_child(2) as SpinBox).value
 		contentData["steps"].append(step)
+
+	# Save rewards
+	contentData["rewards"] = []
+	for i in range(0, rewards_item_list.get_child_count(), 3):
+		var label = rewards_item_list.get_child(i) as Label
+		var spinbox = rewards_item_list.get_child(i + 1) as SpinBox
+		var reward = {
+			"item_id": label.text,
+			"amount": spinbox.value
+		}
+		contentData["rewards"].append(reward)
+
 	data_changed.emit(Gamedata.data.quests, contentData, olddata)
 	olddata = contentData.duplicate(true)
 
@@ -281,3 +304,85 @@ func can_entity_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -
 func set_drop_functions(mydropabletextedit):
 	mydropabletextedit.drop_function = entity_drop.bind(mydropabletextedit)
 	mydropabletextedit.can_drop_function = can_entity_drop.bind(mydropabletextedit)
+
+
+# This function should return true if the dragged data can be dropped here
+func _can_drop_reward(_newpos, data: Dictionary) -> bool:
+	# Check if the data dictionary has the 'id' property
+	if not data or not data.has("id"):
+		return false
+
+	# Fetch skill data by ID from the Gamedata to ensure it exists and is valid
+	var item_data = Gamedata.get_data_by_id(Gamedata.data.items, data["id"])
+	if item_data.is_empty():
+		return false
+
+	# Check if the item ID already exists in the resources grid
+	var children = rewards_item_list.get_children()
+	for i in range(0, children.size(), 3):  # Step by 3 to handle label-spinbox-deleteButton triples
+		var label = children[i] as Label
+		if label.text == data["id"]:
+			# Return false if this item ID already exists in the resources grid
+			return false
+
+	# If all checks pass, return true
+	return true
+
+
+# This function handles the data being dropped
+func _drop_reward_data(newpos, data: Dictionary) -> void:
+	if _can_drop_reward(newpos, data):
+		_handle_reward_drop(data, newpos)
+
+
+# Called when the user has successfully dropped data onto the rewards_item_list
+# We have to check the dropped_data for the id property
+func _handle_reward_drop(dropped_data: Dictionary, _newpos: Vector2) -> void:
+	# Dropped_data is a Dictionary that includes an 'id'
+	if dropped_data and "id" in dropped_data:
+		var item_id = dropped_data["id"]
+		var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
+		if item_data.is_empty():
+			print_debug("No item data found for ID: " + item_id)
+			return
+		
+		# Add the reward entry using the new function
+		add_reward_entry(item_id, 1)
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+
+# Adds UI elements to control the rewards
+# Parameters:
+# - item_id: The ID of the item being added as a reward
+# - amount: The initial amount of the item
+func add_reward_entry(item_id: String, amount: int = 1):
+	# Get item data using the item ID
+	var item_data = Gamedata.get_data_by_id(Gamedata.data.items, item_id)
+	if item_data.is_empty():
+		print_debug("No item data found for ID: " + item_id)
+		return
+
+	# Create UI elements for the reward
+	var label = Label.new()
+	label.text = item_id
+	rewards_item_list.add_child(label)
+
+	# Create and configure the amount SpinBox
+	var amountSpinBox = SpinBox.new()
+	amountSpinBox.value = item_data["stack_size"]
+	amountSpinBox.max_value = item_data["max_stack_size"]
+	rewards_item_list.add_child(amountSpinBox)
+
+	# Create and configure the delete button
+	var deleteButton = Button.new()
+	deleteButton.text = "X"
+	deleteButton.pressed.connect(_delete_reward.bind([label, amountSpinBox, deleteButton]))
+	rewards_item_list.add_child(deleteButton)
+
+
+# Deleting a reward UI element
+func _delete_reward(elements_to_remove: Array) -> void:
+	for element in elements_to_remove:
+		rewards_item_list.remove_child(element)
+		element.queue_free()  # Properly free the node to avoid memory leaks

--- a/Scenes/UI/QuestWindow.tscn
+++ b/Scenes/UI/QuestWindow.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bu1vc"]
 
-[node name="QuestWindow" type="Control" node_paths=PackedStringArray("quest_overview_tabs", "current_quests_list", "completed_quests_list", "failed_quests_list", "quest_details_section", "step_details_text_edit", "abandon_quest_button")]
+[node name="QuestWindow" type="Control" node_paths=PackedStringArray("quest_overview_tabs", "current_quests_list", "completed_quests_list", "failed_quests_list", "quest_details_section", "quest_rewards", "step_details_text_edit", "abandon_quest_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -17,7 +17,8 @@ current_quests_list = NodePath("PanelContainer/HBoxContainer/QuestOverviewTabs/C
 completed_quests_list = NodePath("PanelContainer/HBoxContainer/QuestOverviewTabs/Completed/CompletedQuestList")
 failed_quests_list = NodePath("PanelContainer/HBoxContainer/QuestOverviewTabs/Failed/FailedQuestList")
 quest_details_section = NodePath("PanelContainer/HBoxContainer/QuestDetailsSection")
-step_details_text_edit = NodePath("PanelContainer/HBoxContainer/QuestDetailsSection/QuestStatus/StepDetailsTextEdit")
+quest_rewards = NodePath("PanelContainer/HBoxContainer/QuestDetailsSection/QuestRewards")
+step_details_text_edit = NodePath("PanelContainer/HBoxContainer/QuestDetailsSection/StepDetailsTextEdit")
 abandon_quest_button = NodePath("PanelContainer/HBoxContainer/QuestDetailsSection/ButtonsContainer/AbandonQuestButton")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
@@ -78,15 +79,15 @@ text = "Description for the quest"
 editable = false
 wrap_mode = 1
 
-[node name="QuestStatus" type="VBoxContainer" parent="PanelContainer/HBoxContainer/QuestDetailsSection"]
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="StepDetailsTextEdit" type="TextEdit" parent="PanelContainer/HBoxContainer/QuestDetailsSection/QuestStatus"]
+[node name="StepDetailsTextEdit" type="TextEdit" parent="PanelContainer/HBoxContainer/QuestDetailsSection"]
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_colors/font_readonly_color = Color(1, 1, 1, 1)
 editable = false
+
+[node name="RewardsLabel" type="Label" parent="PanelContainer/HBoxContainer/QuestDetailsSection"]
+layout_mode = 2
+text = "Rewards:"
 
 [node name="QuestRewards" type="VBoxContainer" parent="PanelContainer/HBoxContainer/QuestDetailsSection"]
 layout_mode = 2

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -25,7 +25,7 @@ func _ready():
 	start_craft.connect(ItemManager.on_crafting_menu_start_craft)
 	ItemManager.allAccessibleItems_changed.connect(_on_allAccessibleItems_changed)
 	Helper.signal_broker.player_skill_changed.connect(_on_player_skill_changed)
-	ItemManager.craft_succesful.connect(_on_craft_succesful)
+	ItemManager.craft_successful.connect(_on_craft_successful)
 	ItemManager.craft_failed.connect(_on_craft_failed)
 	create_item_buttons()
 
@@ -218,7 +218,7 @@ func display_feedback(message: String, color: Color):
 	timer.start()
 
 
-func _on_craft_succesful(_item: Dictionary, _recipe: Dictionary):
+func _on_craft_successful(_item: Dictionary, _recipe: Dictionary):
 	var color = Color(0.4, 1, 0.4)  # Brighter green color with more white
 	display_feedback("craft succesful!", color)
 

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -11,6 +11,9 @@ func _ready():
 	# Connect to the Helper.signal_broker.game_loaded signal
 	Helper.signal_broker.game_loaded.connect(_on_game_loaded)
 	
+	# Connect to the mob killed signal
+	Helper.signal_broker.mob_killed.connect(_on_mob_killed)
+	
 	# Connect to the QuestManager signals
 	QuestManager.quest_completed.connect(_on_quest_complete)
 	QuestManager.quest_failed.connect(_on_quest_failed)
@@ -40,9 +43,12 @@ func _on_game_loaded():
 
 
 # Function to handle quest completion
-func _on_quest_complete(_quest: Dictionary):
-	# To be developed later
-	pass
+func _on_quest_complete(quest: Dictionary):
+	var rewards: Array = quest.get("quest_rewards").get("rewards", [])
+	for reward in rewards:
+		var item_id: String = reward.get("item_id")
+		var amount: int = reward.get("amount")
+		var newitem = ItemManager.add_item_by_id_and_amount(item_id, amount)
 
 
 # Function to handle quest failure
@@ -87,6 +93,8 @@ func initialize_quests():
 		create_quest_from_data(quest)
 
 
+# Takes a quest as defined by json (created in the contenteditor)
+# Create an instance of a ScriptQuest and adds it to the QuestManager
 func create_quest_from_data(quest_data: Dictionary):
 	if quest_data.steps.size() < 1:
 		return # The quest has no steps
@@ -96,11 +104,16 @@ func create_quest_from_data(quest_data: Dictionary):
 	for step in steps:
 		if step.type == "collect":
 			# Add an incremental step
-			Quest.add_incremental_step("Gather items", step.item, step.amount)
+			Quest.add_incremental_step("Gather items", step.item, step.amount, {"type": "collect"})
+			steps_added = true
+		if step.type == "kill":
+			# Add an incremental step
+			Quest.add_incremental_step("Kill mob", step.mob, step.amount, {"type": "kill"})
 			steps_added = true
 
 	if steps_added:
 		Quest.set_quest_meta_data(quest_data) # The json data that defines the quest
+		Quest.set_rewards({"rewards": quest_data.get("rewards", [])})
 		# Finalize
 		Quest.finalize_quest()
 		# Add quest to player quests
@@ -149,17 +162,45 @@ func update_quest_by_inventory(item: InventoryItem):
 		var myquest = quests_in_progress[quest]
 		var myquestname = myquest.quest_name
 		for item_id in item_counts.keys():
-			var step = QuestManager.get_current_step(myquestname)
-			match step.step_type:
-				QuestManager.INCREMENTAL_STEP:
-					if step.item_name == item_id:
-						# Update the quest step items with the collected count
-						# Since progress_quest adds the amount, we have to set it to 0 first
-						QuestManager.set_quest_step_items(myquestname, item_id, 0)
-						# see https://github.com/Chevifier/QuestManager/issues/20
-						step["complete"] = false 
-						QuestManager.progress_quest(myquestname, item_id, item_counts[item_id])
-				QuestManager.ITEMS_STEP:
-					# Update the quest step items with the collected count
-					QuestManager.set_quest_step_items(myquestname, item_id, 0, true)
-					QuestManager.progress_quest(myquestname, item_id)
+			# Call the extracted function to update the quest step
+			update_quest_step(myquestname, item_id, item_counts[item_id])
+
+
+# This function updates a specific quest step based on the item counts
+# Parameters:
+# - myquestname: The name of the quest being updated
+# - step: The current step of the quest
+# - item_id: The ID of the item being processed
+# - item_count: The count of the item in the player's inventory
+func update_quest_step(myquestname: String, item_id: String, item_count: int, add: bool = false) -> void:
+	var step = QuestManager.get_current_step(myquestname)
+	match step.step_type:
+		QuestManager.INCREMENTAL_STEP:
+			if step.item_name == item_id:
+				# Update the quest step items with the collected count
+				# Since progress_quest adds the amount, we have to set it to 0 first
+				if not add:
+					QuestManager.set_quest_step_items(myquestname, item_id, 0)
+				# Mark the step as incomplete
+				step["complete"] = false
+				# Progress the quest with the collected item count
+				QuestManager.progress_quest(myquestname, item_id, item_count)
+		QuestManager.ITEMS_STEP:
+			# Update the quest step items with the collected count
+			QuestManager.set_quest_step_items(myquestname, item_id, 0, true)
+			# Progress the quest
+			QuestManager.progress_quest(myquestname, item_id)
+
+
+# A mob has been killed. TODO: Add who or what killed it so we know if it was the player
+func _on_mob_killed(mobinstance: Mob):
+	var mob_id: String = mobinstance.mobJSON.id
+	# Get the current quests in progress
+	var quests_in_progress = QuestManager.get_quests_in_progress()
+	# Update each of the current quests with the collected item information
+	for quest in quests_in_progress.keys():
+		var myquest = quests_in_progress[quest]
+		var myquestname = myquest.quest_name
+		# The quest will be progressed by 1 kill of this mob id
+		# But only it's current step and only if it has the mob id
+		update_quest_step(myquestname, mob_id, 1, true)

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -48,7 +48,7 @@ func _on_quest_complete(quest: Dictionary):
 	for reward in rewards:
 		var item_id: String = reward.get("item_id")
 		var amount: int = reward.get("amount")
-		var newitem = ItemManager.add_item_by_id_and_amount(item_id, amount)
+		ItemManager.add_item_by_id_and_amount(item_id, amount)
 
 
 # Function to handle quest failure
@@ -86,6 +86,7 @@ func _on_quest_reset(_quest_name: String):
 	pass
 
 
+# Initialize quests by wiping player data and loading quest data
 func initialize_quests():
 	QuestManager.wipe_player_data()
 	var quest_data = Gamedata.data.quests.data
@@ -98,26 +99,26 @@ func initialize_quests():
 func create_quest_from_data(quest_data: Dictionary):
 	if quest_data.steps.size() < 1:
 		return # The quest has no steps
-	var Quest = ScriptQuest.new(quest_data.id, quest_data.description)
+	var quest = ScriptQuest.new(quest_data.id, quest_data.description)
 	var steps_added: bool = false
 	var steps = quest_data.steps
 	for step in steps:
 		if step.type == "collect":
 			# Add an incremental step
-			Quest.add_incremental_step("Gather items", step.item, step.amount, {"type": "collect"})
+			quest.add_incremental_step("Gather items", step.item, step.amount, {"type": "collect"})
 			steps_added = true
 		if step.type == "kill":
 			# Add an incremental step
-			Quest.add_incremental_step("Kill mob", step.mob, step.amount, {"type": "kill"})
+			quest.add_incremental_step("Kill mob", step.mob, step.amount, {"type": "kill"})
 			steps_added = true
 
 	if steps_added:
-		Quest.set_quest_meta_data(quest_data) # The json data that defines the quest
-		Quest.set_rewards({"rewards": quest_data.get("rewards", [])})
+		quest.set_quest_meta_data(quest_data) # The json data that defines the quest
+		quest.set_rewards({"rewards": quest_data.get("rewards", [])})
 		# Finalize
-		Quest.finalize_quest()
+		quest.finalize_quest()
 		# Add quest to player quests
-		QuestManager.add_scripted_quest(Quest)
+		QuestManager.add_scripted_quest(quest)
 
 
 # An item is added to the player inventory. Now we need to update the quests
@@ -198,9 +199,5 @@ func _on_mob_killed(mobinstance: Mob):
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the collected item information
-	for quest in quests_in_progress.keys():
-		var myquest = quests_in_progress[quest]
-		var myquestname = myquest.quest_name
-		# The quest will be progressed by 1 kill of this mob id
-		# But only it's current step and only if it has the mob id
-		update_quest_step(myquestname, mob_id, 1, true)
+	for quest in quests_in_progress.values():
+		update_quest_step(quest.quest_name, mob_id, 1, true)

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -59,6 +59,9 @@ signal game_loaded() # When the user presses 'load game' on the main menu
 # When sprites have been added or removed from gamedata
 signal data_sprites_changed(contentData: Dictionary, spriteid: String)
 
+# When a mob was killed
+signal mob_killed(mobinstance: Mob)
+
 # We signal to the hud to start a progressbar
 func on_start_timer_progressbar(time_left: float):
 	hud_start_progressbar.emit(time_left)

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -71,6 +71,7 @@ func get_hit(damage):
 			start_blinking()
 	
 func _die():
+	Helper.signal_broker.mob_killed.emit(self)
 	add_corpse.call_deferred(global_position)
 	queue_free()
 

--- a/Scripts/QuestWindow.gd
+++ b/Scripts/QuestWindow.gd
@@ -20,12 +20,24 @@ extends Control
 var selected_quest: String # Will be the quest ID
 
 func _ready():
+	# Connect tab and quest list item selection signals
+	connect_ui_signals()
+	# Connect QuestManager signals
+	connect_quest_signals()
+	# Initialize quests if any are already present
+	initialize_quests()
+
+
+# Connect UI signals
+func connect_ui_signals():
 	quest_overview_tabs.tab_changed.connect(_on_tab_changed)
 	current_quests_list.item_selected.connect(_on_quest_selected.bind(current_quests_list))
 	completed_quests_list.item_selected.connect(_on_quest_selected.bind(completed_quests_list))
 	failed_quests_list.item_selected.connect(_on_quest_selected.bind(failed_quests_list))
-	
-	# Connect to the QuestManager signals
+
+
+# Connect QuestManager signals
+func connect_quest_signals():
 	QuestManager.quest_completed.connect(_on_quest_complete)
 	QuestManager.quest_failed.connect(_on_quest_failed)
 	QuestManager.step_complete.connect(_on_step_complete)
@@ -33,8 +45,7 @@ func _ready():
 	QuestManager.step_updated.connect(_on_step_updated)
 	QuestManager.new_quest_added.connect(_on_new_quest_added)
 	QuestManager.quest_reset.connect(_on_quest_reset)
-	
-	initialize_quests()
+
 
 # If any quests are already present, we add them to the quest journal
 func initialize_quests():

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -435,7 +435,11 @@ func _on_inventory_item_added(_item, _inventory):
 func _on_inventory_item_removed(_item, _inventory):
 	update_accessible_items_list()
 
+
 func _on_inventory_item_modified(_item, _inventory):
 	update_accessible_items_list()
 
 
+func add_item_by_id_and_amount(itemid: String, amount: int):
+	var newitem = playerInventory.create_and_add_item(itemid)
+	InventoryStacked.set_item_stack_size(newitem, amount)

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -16,11 +16,12 @@ var player_max_inventory_volume: int = 1000
 
 
 signal allAccessibleItems_changed(items_added: Array, items_removed: Array)
-signal craft_succesful(item: Dictionary, recipe: Dictionary)
+signal craft_successful(item: Dictionary, recipe: Dictionary)
 signal craft_failed(item: Dictionary, recipe: Dictionary, reason: String)
 
 
 func _ready():
+	# Initialize inventories and connect signals
 	playerInventory = initialize_inventory()
 	proximityInventory = initialize_inventory()
 	connect_inventory_signals(playerInventory)
@@ -124,8 +125,8 @@ func execute_reloading(item: InventoryItem, magazine: InventoryItem):
 # We pass reload_weapon as a function that will be executed when the action is done
 func start_reload(item: InventoryItem, reload_time: float, specific_magazine: InventoryItem = null):
 	var reload_callable = Callable(self, "reload_weapon").bind(item, specific_magazine)
-	# Assuming there's a mechanism to track reloading state for each item
-	# This could be a property in InventoryItem or managed externally
+	# There's a mechanism to track reloading state for each item using
+	# a property in InventoryItem
 	item.set_property("is_reloading", true)
 	General.start_action(reload_time, reload_callable)
 
@@ -322,9 +323,10 @@ func on_crafting_menu_start_craft(item: Dictionary, recipe: Dictionary):
 			return
 		var newitem = playerInventory.create_and_add_item(item_id)
 		InventoryStacked.set_item_stack_size(newitem, recipe["craft_amount"])
-		craft_succesful.emit(item, recipe)
+		craft_successful.emit(item, recipe)
 
 
+# Get the used volume of the player inventory
 func get_used_volume() -> float:
 	var total_current_volume = 0.0
 	# Calculate the total current volume in the inventory
@@ -333,11 +335,12 @@ func get_used_volume() -> float:
 	return total_current_volume
 
 
+# Get the remaining volume in the player inventory
 func get_remaining_volume() -> float:
 	return player_max_inventory_volume - get_used_volume()
 
 
-# Checks if there is a sufficient amount of a given item ID across all accessible items.
+# Check if there is a sufficient amount of a given item ID across all accessible items
 func has_sufficient_item_amount(item_id: String, required_amount: int) -> bool:
 	var total_amount = 0
 

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -76,7 +76,7 @@ func _ready():
 	initialize_stats_and_skills()
 	Helper.save_helper.load_player_state(self)
 	Helper.signal_broker.health_item_used.connect(_on_health_item_used)
-	ItemManager.craft_succesful.connect(_on_craft_succesful)
+	ItemManager.craft_successful.connect(_on_craft_successful)
 	# Connect signals for collisionDetector to detect furniture
 	collisionDetector.body_entered.connect(_on_body_entered)
 	collisionDetector.body_exited.connect(_on_body_exited)
@@ -445,7 +445,7 @@ func add_skill_xp(skill_id: String, xp: float) -> void:
 
 # The player has succesfully crafted an item. Get the skill id and xp from
 # the recipe and add it to the player's skill xp
-func _on_craft_succesful(_item: Dictionary, recipe: Dictionary):
+func _on_craft_successful(_item: Dictionary, recipe: Dictionary):
 	var skill_id = Helper.json_helper.get_nested_data(recipe, "skill_progression.id")
 	var xp = Helper.json_helper.get_nested_data(recipe, "skill_progression.xp")
 	if skill_id and xp:


### PR DESCRIPTION
- You can now define a kill mob step in your quest
- You can drag items from the left menu in the content editor to add them as rewards. Stack sizes will be respected.
- Rewards show in the quest journal in-game
- Rewards are added to the player inventory when the quest completes
- The quest_helper responds to the signal that is emitted when a mob is killed.

I haven't tested if the 'collect' step and the 'kill' step work if you put them in one quest.

The new quest in the quest journal:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/9e38674b-17a7-40fd-aa59-b4c52aa1a01a)
