### PR TITLE
Add text label when an attack misses to inform the player

### DIFF
--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -399,15 +399,13 @@ func perform_melee_attack():
 	var melee_skill_id = melee_properties.get("used_skill", {}).get("skill_id", "")
 	var skill_level = player.get_skill_level(melee_skill_id)
 	var hit_chance = 0.65 + (skill_level / 100.0) * (1.0 - 0.65)
-	if randf() > hit_chance:
-		print_debug("Attack missed due to low hit chance ("+str(hit_chance)+").")
-		return
 
+	var attack: Dictionary = {"damage": melee_damage, "hit_chance": hit_chance}
 	# Each mob in range will get hit with the weapon
 	# TODO: Hit only one entity each swing unless the weapon has some kind of flag
 	# TODO: Check if the entity is behind an obstacle
 	for entity in entities_in_melee_range:
-		entity.get_hit(melee_damage)
+		entity.get_hit(attack)
 
 	animate_attack()
 	add_weapon_xp_on_use()

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -318,14 +318,50 @@ func _on_tween_finished():
 	is_animating_hit = false
 
 
-func get_hit(damage):
-	if can_be_destroyed():
-		current_health -= damage
-		if current_health <= 0:
-			_die()
-		else:
-			if not is_animating_hit:
-				animate_hit()
+# When the furniture gets hit by an attack
+# attack: a dictionary with the "damage" and "hit_chance" properties
+func get_hit(attack: Dictionary):
+	# Extract damage and hit_chance from the dictionary
+	var damage = attack.damage
+	var hit_chance = attack.hit_chance
+
+	# Calculate actual hit chance considering static furniture bonus
+	var actual_hit_chance = hit_chance + 0.25 # Boost hit chance by 25%
+
+	# Determine if the attack hits
+	if randf() <= actual_hit_chance:
+		# Attack hits
+		if can_be_destroyed():
+			current_health -= damage
+			if current_health <= 0:
+				_die()
+			else:
+				if not is_animating_hit:
+					animate_hit()
+	else:
+		# Attack misses, create a visual indicator
+		show_miss_indicator()
+
+
+# Function to show a miss indicator
+func show_miss_indicator():
+	var miss_label = Label3D.new()
+	miss_label.text = "Miss!"
+	miss_label.modulate = Color(1, 0, 0)
+	miss_label.font_size = 64
+	get_tree().get_root().add_child(miss_label)
+	miss_label.position = original_position
+	miss_label.position.y += 2
+	miss_label.billboard = BaseMaterial3D.BILLBOARD_ENABLED
+		
+
+	# Animate the miss indicator to disappear quickly
+	var tween = create_tween()
+	tween.tween_property(miss_label, "modulate:a", 0, 0.5).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
+	tween.finished.connect(func():
+		miss_label.queue_free()  # Properly free the miss_label node
+	)
+
 
 # Handle furniture death
 func _die():

--- a/Scripts/bullet.gd
+++ b/Scripts/bullet.gd
@@ -35,7 +35,8 @@ func set_lifetime(time: float):
 
 func _on_Projectile_body_entered(body):
 	if body.has_method("get_hit"):
-		body.get_hit(damage)
+		var attack: Dictionary = {"damage":damage, "hit_chance":100}
+		body.get_hit(attack)
 	queue_free()  # Destroy the projectile upon collision
 
 


### PR DESCRIPTION
Requires #236 

Adds a missed indicator when your melee attack misses:
![image](https://github.com/Khaligufzel/CataX/assets/50166150/83a9d4b1-edec-478a-ba10-3019e6531df0)

It looks like this on furniture:
https://github.com/Khaligufzel/CataX/assets/50166150/5dce8203-276c-4e38-819f-2b4452a1b548

The primary purpose is to boost the hit chance of furniture, since they are not moving and cannot dodge.
- Each target can now be hit or missed individually. Previously, if the attack misses, it will miss all targets
- Works only for melee attacks since bullets will always hit if they come in contact with a target
- At the lowest hit chance of 65% you can still miss furniture after the 25% hit chance boost. Raise your melee skill to increase this chance
- The player now knows when the attack missed.

We might adjust the position or rendering or size of the text to make it more visible