### PR TITLE
Allow placing itemgroups on the ground in maps

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1209,7 +1209,8 @@ json_data = "[
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"tree_destroyed\"
+					\"tree_destroyed\",
+					\"generic_field_finds\"
 				]
 			}
 		},
@@ -1276,7 +1277,8 @@ json_data = "[
 		\"references\": {
 			\"core\": {
 				\"itemgroups\": [
-					\"tree_destroyed\"
+					\"tree_destroyed\",
+					\"generic_field_finds\"
 				]
 			}
 		},
@@ -2268,6 +2270,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/flower_wild_32.png\",
 		\"max_stack_size\": 10,
 		\"name\": \"Wild Flower\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"generic_field_finds\"
+				]
+			}
+		},
 		\"sprite\": \"flower_wild_32.png\",
 		\"stack_size\": 1,
 		\"two_handed\": false,
@@ -2292,6 +2301,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/pebble_32.png\",
 		\"max_stack_size\": 100,
 		\"name\": \"Pebble\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"generic_field_finds\"
+				]
+			}
+		},
 		\"sprite\": \"pebble_32.png\",
 		\"stack_size\": 1,
 		\"two_handed\": false,
@@ -2328,6 +2344,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/rock_medium_32.png\",
 		\"max_stack_size\": 10,
 		\"name\": \"Medium Rock\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"generic_field_finds\"
+				]
+			}
+		},
 		\"sprite\": \"rock_medium_32.png\",
 		\"stack_size\": 1,
 		\"two_handed\": false,
@@ -2340,6 +2363,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/rock_small_32.png\",
 		\"max_stack_size\": 20,
 		\"name\": \"Small Rock\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"generic_field_finds\"
+				]
+			}
+		},
 		\"sprite\": \"rock_small_32.png\",
 		\"stack_size\": 1,
 		\"two_handed\": false,
@@ -2401,6 +2431,9 @@ json_data = "[
 		\"name\": \"Sharp Stone\",
 		\"references\": {
 			\"core\": {
+				\"itemgroups\": [
+					\"generic_field_finds\"
+				],
 				\"items\": [
 					\"stone_spear\"
 				]

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -729,5 +729,56 @@
 			}
 		},
 		"sprite": "log_32.png"
+	},
+	{
+		"description": "Items you can find in any field of grass",
+		"id": "generic_field_finds",
+		"items": [
+			{
+				"id": "sharp_stone",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "small_rock",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "medium_rock",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "pebble",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "flower_wild",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "leaf",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "plant_remnants",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			}
+		],
+		"mode": "Collection",
+		"name": "Generic field items",
+		"sprite": "leaves_32.png"
 	}
 ]

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -1203,7 +1203,8 @@
 		"references": {
 			"core": {
 				"itemgroups": [
-					"tree_destroyed"
+					"tree_destroyed",
+					"generic_field_finds"
 				]
 			}
 		},
@@ -1270,7 +1271,8 @@
 		"references": {
 			"core": {
 				"itemgroups": [
-					"tree_destroyed"
+					"tree_destroyed",
+					"generic_field_finds"
 				]
 			}
 		},
@@ -2262,6 +2264,13 @@
 		"image": "./Mods/Core/Items/flower_wild_32.png",
 		"max_stack_size": 10,
 		"name": "Wild Flower",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"generic_field_finds"
+				]
+			}
+		},
 		"sprite": "flower_wild_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2286,6 +2295,13 @@
 		"image": "./Mods/Core/Items/pebble_32.png",
 		"max_stack_size": 100,
 		"name": "Pebble",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"generic_field_finds"
+				]
+			}
+		},
 		"sprite": "pebble_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2322,6 +2338,13 @@
 		"image": "./Mods/Core/Items/rock_medium_32.png",
 		"max_stack_size": 10,
 		"name": "Medium Rock",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"generic_field_finds"
+				]
+			}
+		},
 		"sprite": "rock_medium_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2334,6 +2357,13 @@
 		"image": "./Mods/Core/Items/rock_small_32.png",
 		"max_stack_size": 20,
 		"name": "Small Rock",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"generic_field_finds"
+				]
+			}
+		},
 		"sprite": "rock_small_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2395,6 +2425,9 @@
 		"name": "Sharp Stone",
 		"references": {
 			"core": {
+				"itemgroups": [
+					"generic_field_finds"
+				],
 				"items": [
 					"stone_spear"
 				]

--- a/Mods/Core/Maps/RockyHill_NE.json
+++ b/Mods/Core/Maps/RockyHill_NE.json
@@ -675,7 +675,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_medium_dirt_02"
+				"id": "grass_medium_dirt_02",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_medium_dirt_02"

--- a/Mods/Core/Maps/RockyHill_NW.json
+++ b/Mods/Core/Maps/RockyHill_NW.json
@@ -723,7 +723,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"

--- a/Mods/Core/Maps/RockyHill_SE.json
+++ b/Mods/Core/Maps/RockyHill_SE.json
@@ -2124,7 +2124,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"furniture": {

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -2160,7 +2160,10 @@
 				"id": "forest_underbrush_03"
 			},
 			{
-				"id": "forest_underbrush_03"
+				"id": "forest_underbrush_03",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "forest_underbrush_03"
@@ -2466,7 +2469,10 @@
 				"rotation": 90
 			},
 			{
-				"id": "forest_underbrush_03"
+				"id": "forest_underbrush_03",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "rocky_earth_00",

--- a/Mods/Core/Maps/field_grass_basic_00.json
+++ b/Mods/Core/Maps/field_grass_basic_00.json
@@ -1098,7 +1098,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -1527,7 +1530,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -2562,7 +2568,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_medium_dirt_00"
+				"id": "grass_medium_dirt_00",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"

--- a/Mods/Core/Maps/field_grass_basic_01.json
+++ b/Mods/Core/Maps/field_grass_basic_01.json
@@ -372,7 +372,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -1002,7 +1005,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_medium_dirt_01"
+				"id": "grass_medium_dirt_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -2094,7 +2100,10 @@
 				"id": "grass_dirt_02"
 			},
 			{
-				"id": "grass_dirt_02"
+				"id": "grass_dirt_02",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"furniture": {

--- a/Mods/Core/Maps/field_grass_flowers_00.json
+++ b/Mods/Core/Maps/field_grass_flowers_00.json
@@ -884,7 +884,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -1559,7 +1562,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -2550,7 +2556,10 @@
 				"rotation": 90
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_flowers_01"

--- a/Mods/Core/Maps/field_grass_hill_00.json
+++ b/Mods/Core/Maps/field_grass_hill_00.json
@@ -619,7 +619,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_medium_dirt_00"
+				"id": "grass_medium_dirt_00",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -2523,7 +2526,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"

--- a/Mods/Core/Maps/field_grass_hole_00.json
+++ b/Mods/Core/Maps/field_grass_hole_00.json
@@ -1337,6 +1337,9 @@
 			},
 			{
 				"id": "grass_medium_dirt_00",
+				"itemgroups": [
+					"generic_field_finds"
+				],
 				"rotation": 270
 			},
 			{
@@ -3496,7 +3499,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"
@@ -5253,7 +5259,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"

--- a/Mods/Core/Maps/urbanroad.json
+++ b/Mods/Core/Maps/urbanroad.json
@@ -1161,7 +1161,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"

--- a/Mods/Core/Maps/urbanroad_corner.json
+++ b/Mods/Core/Maps/urbanroad_corner.json
@@ -2493,7 +2493,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_flowers_01"
+				"id": "grass_flowers_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_dirt_02"

--- a/Mods/Core/Maps/urbanroad_cross.json
+++ b/Mods/Core/Maps/urbanroad_cross.json
@@ -963,7 +963,10 @@
 				"id": "grass_plain_01"
 			},
 			{
-				"id": "grass_plain_01"
+				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				]
 			},
 			{
 				"id": "grass_plain_01"

--- a/Mods/Core/Maps/urbanroad_t.json
+++ b/Mods/Core/Maps/urbanroad_t.json
@@ -2565,6 +2565,9 @@
 			},
 			{
 				"id": "grass_plain_01",
+				"itemgroups": [
+					"generic_field_finds"
+				],
 				"rotation": 90
 			},
 			{

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -233,6 +233,8 @@ func apply_paint_to_tile(tile: Control, brush: Control, tilerotate: int):
 				tile.set_mob_id("")
 			elif brush.entityType == "furniture":
 				tile.set_furniture_id("")
+			elif brush.entityType == "itemgroup":
+				tile.set_tile_itemgroups([]) # erase by passing an empty array
 			else:
 				tile.set_tile_id("")
 				tile.set_rotation_amount(0)

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -247,11 +247,11 @@ func apply_paint_to_tile(tile: Control, brush: Control, tilerotate: int):
 		elif brush.entityType == "furniture":
 			tile.set_furniture_id(brush.entityID)
 			tile.set_furniture_rotation(tilerotation)
-			tile.set_furniture_itemgroups(brushcomposer.get_itemgroup_entity_ids())
+			tile.set_tile_itemgroups(brushcomposer.get_itemgroup_entity_ids())
 		elif brush.entityType == "itemgroup":
 			# The brushcomposer only returns a brush of this type if there are only
-			# itemgroup brushes in the brushcomposer. We apply the itemgroups to the furniture
-			tile.set_furniture_itemgroups(brushcomposer.get_itemgroup_entity_ids())
+			# itemgroup brushes in the brushcomposer. We apply the itemgroups to the tile
+			tile.set_tile_itemgroups(brushcomposer.get_itemgroup_entity_ids())
 		else:
 			tile.set_tile_id(brush.entityID)
 			tile.set_rotation_amount(tilerotation)

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -9,28 +9,30 @@ var tileData: Dictionary = defaultTileData.duplicate():
 	set(data):
 		tileData = data
 		if tileData.has("id") and tileData.id != "":
-			$TileSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.tiles,\
-			tileData.id).albedo_texture
+			$TileSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.tiles, tileData.id).albedo_texture
 			set_rotation_amount(tileData.get("rotation", 0))
-			$MobFurnitureSprite.hide()
-			$MobFurnitureSprite.rotation_degrees = 0
+			$ObjectSprite.hide()
+			$ObjectSprite.rotation_degrees = 0
 			if tileData.has("mob"):
 				if tileData.mob.has("rotation"):
-					$MobFurnitureSprite.rotation_degrees = tileData.mob.rotation
-				$MobFurnitureSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.mobs,\
-				tileData.mob.id)
-				$MobFurnitureSprite.show()
+					$ObjectSprite.rotation_degrees = tileData.mob.rotation
+				$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.mobs, tileData.mob.id)
+				$ObjectSprite.show()
 			elif tileData.has("furniture"):
 				if tileData.furniture.has("rotation"):
-					$MobFurnitureSprite.rotation_degrees = tileData.furniture.rotation
-				$MobFurnitureSprite.texture = Gamedata.get_sprite_by_id(\
-				Gamedata.data.furniture, tileData.furniture.id)
-				$MobFurnitureSprite.show()
+					$ObjectSprite.rotation_degrees = tileData.furniture.rotation
+				$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture, tileData.furniture.id)
+				$ObjectSprite.show()
+			elif tileData.has("itemgroups"):
+				var random_itemgroup: String = tileData.itemgroups.pick_random()
+				$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.itemgroups, random_itemgroup)
+				$ObjectSprite.show()
 		else:
 			$TileSprite.texture = load(defaultTexture)
-			$MobFurnitureSprite.texture = null
-			$MobFurnitureSprite.hide()
+			$ObjectSprite.texture = null
+			$ObjectSprite.hide()
 		set_tooltip()
+
 
 signal tile_clicked(clicked_tile: Control)
 
@@ -71,37 +73,41 @@ func set_tile_id(id: String) -> void:
 	set_tooltip()
 
 
+# Place a mob on this tile. We erase furniture and itemgroups since they can't exist on the same tile
 func set_mob_id(id: String) -> void:
 	if id == "":
 		tileData.erase("mob")
-		if !tileData.has("furniture"):
-			$MobFurnitureSprite.hide()
+		if not tileData.has("furniture") and not tileData.has("itemgroups"):
+			$ObjectSprite.hide()
 	else:
-		# A tile can either have a mob or furniture. If we add a mob, remove furniture
+		# A tile can either have a mob or furniture. If we add a mob, remove furniture and itemgroups
 		tileData.erase("furniture")
+		tileData.erase("itemgroups")
 		if tileData.has("mob"):
 			tileData.mob.id = id
 		else:
 			tileData.mob = {"id": id}
-		$MobFurnitureSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.mobs, id)
-		$MobFurnitureSprite.show()
+		$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.mobs, id)
+		$ObjectSprite.show()
 	set_tooltip()
 
 
+# Place a furniture on this tile. We erase mob and itemgroups since they can't exist on the same tile
 func set_furniture_id(id: String) -> void:
 	if id == "":
 		tileData.erase("furniture")
-		if !tileData.has("mob"):
-			$MobFurnitureSprite.hide()
+		if not tileData.has("mob") and not tileData.has("itemgroups"):
+			$ObjectSprite.hide()
 	else:
-		# A tile can either have a mob or furniture. If we add furniture, remove the mob
+		# A tile can either have a mob or furniture. If we add furniture, remove the mob and itemgroups
 		tileData.erase("mob")
+		tileData.erase("itemgroups")
 		if tileData.has("furniture"):
 			tileData.furniture.id = id
 		else:
 			tileData.furniture = {"id": id}
-		$MobFurnitureSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture, id)
-		$MobFurnitureSprite.show()
+		$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture, id)
+		$ObjectSprite.show()
 	set_tooltip()
 
 
@@ -117,7 +123,7 @@ func set_furniture_rotation(rotationDegrees: int) -> void:
 
 # Helper function to set entity rotation
 func set_entity_rotation(key: String, rotationDegrees: int) -> void:
-	$MobFurnitureSprite.rotation_degrees = rotationDegrees
+	$ObjectSprite.rotation_degrees = rotationDegrees
 	if rotationDegrees == 0:
 		tileData[key].erase("rotation")
 	else:
@@ -129,17 +135,28 @@ func set_entity_rotation(key: String, rotationDegrees: int) -> void:
 # If the "container" property exists in the "Function" property of the furniture data, 
 # it sets the tileData.furniture.itemgroups property.
 # If the "container" property or the "Function" property does not exist, it erases the "itemgroups" property.
-func set_furniture_itemgroups(itemgroups: Array) -> void:
-	if not tileData.has("furniture"):
+# If no furniture is present, it applies the itemgroup to the tile and updates the ObjectSprite with a random sprite.
+# If the tileData has the "mob" property, it returns without making any changes.
+func set_tile_itemgroups(itemgroups: Array) -> void:
+	if tileData.has("mob"):
 		return
 	
-	var furnituredata = Gamedata.get_data_by_id(Gamedata.data.furniture, tileData.furniture.id)
-	var containervalue = Helper.json_helper.get_nested_data(furnituredata, "Function.container")
-	
-	if not itemgroups.is_empty() and typeof(containervalue) == TYPE_DICTIONARY:
-		tileData.furniture.itemgroups = itemgroups
+	if not tileData.has("furniture"):
+		# Apply the itemgroup to the tile and update ObjectSprite with a random sprite
+		var random_itemgroup: String = itemgroups[randi() % itemgroups.size()]
+		$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.itemgroups, random_itemgroup)
+		$ObjectSprite.show()
+		$ObjectSprite.rotation_degrees = 0
+		tileData["itemgroups"] = itemgroups
 	else:
-		tileData.furniture.erase("itemgroups")
+		var furnituredata = Gamedata.get_data_by_id(Gamedata.data.furniture, tileData.furniture.id)
+		var containervalue = Helper.json_helper.get_nested_data(furnituredata, "Function.container")
+
+		if not itemgroups.is_empty() and typeof(containervalue) == TYPE_DICTIONARY:
+			tileData.furniture.itemgroups = itemgroups
+		else:
+			tileData.furniture.erase("itemgroups")
+	
 	set_tooltip()
 
 
@@ -149,6 +166,7 @@ func _on_texture_rect_mouse_entered() -> void:
 		tile_clicked.emit(self)
 
 
+# Resets the tiledata to the default
 func set_default() -> void:
 	tileData = defaultTileData.duplicate()
 
@@ -165,14 +183,14 @@ func set_clickable(clickable: bool):
 	if !clickable:
 		mouse_filter = MOUSE_FILTER_IGNORE
 		$TileSprite.mouse_filter = MOUSE_FILTER_IGNORE
-		$MobFurnitureSprite.mouse_filter = MOUSE_FILTER_IGNORE
+		$ObjectSprite.mouse_filter = MOUSE_FILTER_IGNORE
 
 
 #This function sets the texture to some static resource that helps the user visualize that something is above
 #If this tile has a texture in its data, set it to the above texture instead
 func set_above():
-	$MobFurnitureSprite.texture = null
-	$MobFurnitureSprite.hide()
+	$ObjectSprite.texture = null
+	$ObjectSprite.hide()
 	if tileData.has("id") and tileData.id != "":
 		$TileSprite.texture = load(aboveTexture)
 	else:
@@ -181,26 +199,30 @@ func set_above():
 
 func _on_texture_rect_resized():
 	$TileSprite.pivot_offset = size / 2
-	$MobFurnitureSprite.pivot_offset = size / 2
+	$ObjectSprite.pivot_offset = size / 2
 
 
 func get_tile_texture():
 	return $TileSprite.texture
 
 
-func set_tooltip():
+# Sets the tooltip for this tile. The user can use this to see what's on this tile.
+func set_tooltip() -> void:
 	var tooltiptext = "Tile Overview:\n"
 	
+	# Display tile ID
 	if tileData.has("id") and tileData.id != "":
 		tooltiptext += "ID: " + str(tileData.id) + "\n"
 	else:
 		tooltiptext += "ID: None\n"
 	
+	# Display tile rotation
 	if tileData.has("rotation"):
 		tooltiptext += "Rotation: " + str(tileData.rotation) + " degrees\n"
 	else:
 		tooltiptext += "Rotation: 0 degrees\n"
 	
+	# Display mob information
 	if tileData.has("mob"):
 		tooltiptext += "Mob ID: " + str(tileData.mob.id) + "\n"
 		if tileData.mob.has("rotation"):
@@ -210,6 +232,7 @@ func set_tooltip():
 	else:
 		tooltiptext += "Mob: None\n"
 	
+	# Display furniture information
 	if tileData.has("furniture"):
 		tooltiptext += "Furniture ID: " + str(tileData.furniture.id) + "\n"
 		if tileData.furniture.has("rotation"):
@@ -221,6 +244,11 @@ func set_tooltip():
 	else:
 		tooltiptext += "Furniture: None\n"
 	
+	# Display itemgroups information
+	if tileData.has("itemgroups"):
+		tooltiptext += "Tile Item Groups: " + str(tileData.itemgroups) + "\n"
+	else:
+		tooltiptext += "Tile Item Groups: None\n"
+	
 	# Set the tooltip
 	self.tooltip_text = tooltiptext
-

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -141,23 +141,32 @@ func set_tile_itemgroups(itemgroups: Array) -> void:
 	if tileData.has("mob"):
 		return
 	
+	# If the tile doesn't have furniture
 	if not tileData.has("furniture"):
-		# Apply the itemgroup to the tile and update ObjectSprite with a random sprite
-		var random_itemgroup: String = itemgroups[randi() % itemgroups.size()]
-		$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.itemgroups, random_itemgroup)
-		$ObjectSprite.show()
-		$ObjectSprite.rotation_degrees = 0
-		tileData["itemgroups"] = itemgroups
-	else:
-		var furnituredata = Gamedata.get_data_by_id(Gamedata.data.furniture, tileData.furniture.id)
-		var containervalue = Helper.json_helper.get_nested_data(furnituredata, "Function.container")
-
-		if not itemgroups.is_empty() and typeof(containervalue) == TYPE_DICTIONARY:
-			tileData.furniture.itemgroups = itemgroups
+		if itemgroups.is_empty(): # Erase the itemgroups property if the itemgroups array is empty
+			tileData.erase("itemgroups")
+			$ObjectSprite.hide()
 		else:
+			# Apply the itemgroup to the tile and update ObjectSprite with a random sprite
+			var random_itemgroup: String = itemgroups.pick_random()
+			$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.itemgroups, random_itemgroup)
+			$ObjectSprite.show()
+			$ObjectSprite.rotation_degrees = 0
+			tileData["itemgroups"] = itemgroups
+	else:
+		if itemgroups.is_empty(): # Only erase the itemgroups property from furniture
 			tileData.furniture.erase("itemgroups")
+		else:
+			var furnituredata = Gamedata.get_data_by_id(Gamedata.data.furniture, tileData.furniture.id)
+			var containervalue = Helper.json_helper.get_nested_data(furnituredata, "Function.container")
+
+			if not itemgroups.is_empty() and typeof(containervalue) == TYPE_DICTIONARY:
+				tileData.furniture.itemgroups = itemgroups
+			else:
+				tileData.furniture.erase("itemgroups")
 	
 	set_tooltip()
+
 
 
 # If the user holds the mouse button while entering this tile, we consider it clicked

--- a/Scenes/ContentManager/Mapeditor/mapeditortile.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditortile.tscn
@@ -23,7 +23,7 @@ grow_vertical = 2
 texture = ExtResource("2_rued1")
 expand_mode = 3
 
-[node name="MobFurnitureSprite" type="TextureRect" parent="."]
+[node name="ObjectSprite" type="TextureRect" parent="."]
 visible = false
 layout_mode = 1
 anchors_preset = 15
@@ -37,5 +37,5 @@ stretch_mode = 4
 [connection signal="gui_input" from="TileSprite" to="." method="_on_texture_rect_gui_input"]
 [connection signal="mouse_entered" from="TileSprite" to="." method="_on_texture_rect_mouse_entered"]
 [connection signal="resized" from="TileSprite" to="." method="_on_texture_rect_resized"]
-[connection signal="gui_input" from="MobFurnitureSprite" to="." method="_on_texture_rect_gui_input"]
-[connection signal="mouse_entered" from="MobFurnitureSprite" to="." method="_on_texture_rect_mouse_entered"]
+[connection signal="gui_input" from="ObjectSprite" to="." method="_on_texture_rect_gui_input"]
+[connection signal="mouse_entered" from="ObjectSprite" to="." method="_on_texture_rect_mouse_entered"]

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -347,8 +347,6 @@ func populate_container_from_itemgroup():
 func deserialize_container_data():
 	if "items" in furnitureJSON["Function"]["container"]:
 		container.deserialize_and_apply_items(furnitureJSON["Function"]["container"]["items"])
-	else:
-		print_debug("No items to deserialize in container for furniture ID: " + str(furnitureJSON.id))
 
 
 # Only previously saved furniture will have the global_position_x key.

--- a/Scripts/Gamedata/map_references.gd
+++ b/Scripts/Gamedata/map_references.gd
@@ -121,6 +121,12 @@ func add_entities_to_set(level: Array, entity_set: Dictionary):
 						entity_set["itemgroups"].append(itemgroup)
 		if entity.has("id") and not entity_set["tiles"].has(entity["id"]):
 			entity_set["tiles"].append(entity["id"])
+		# Add unique itemgroups directly from the entity
+		if entity.has("itemgroups"):
+			for itemgroup in entity["itemgroups"]:
+				if not entity_set["itemgroups"].has(itemgroup):
+					entity_set["itemgroups"].append(itemgroup)
+
 
 
 # Removes all instances of the provided entity from the provided map
@@ -168,6 +174,11 @@ func remove_entity_from_map(map_id: String, entity_type: String, entity_id: Stri
 						var itemgroups = entity["furniture"]["itemgroups"]
 						if itemgroups.has(entity_id):
 							itemgroups.erase(entity_id)
+					# Also, check and remove itemgroups from the entity itself if present
+					if entity.has("itemgroups"):
+						var entity_itemgroups = entity["itemgroups"]
+						if entity_itemgroups.has(entity_id):
+							entity_itemgroups.erase(entity_id)
 
 		# Update the level in the mapdata after modifications
 		levels[level_index] = level

--- a/Scripts/Gamedata/map_references.gd
+++ b/Scripts/Gamedata/map_references.gd
@@ -128,7 +128,6 @@ func add_entities_to_set(level: Array, entity_set: Dictionary):
 					entity_set["itemgroups"].append(itemgroup)
 
 
-
 # Removes all instances of the provided entity from the provided map
 # map_id is the id of one of the maps. It will be loaded from json to manipulate it.
 # entity_type can be "tile", "furniture", "itemgroup" or "mob"
@@ -174,11 +173,15 @@ func remove_entity_from_map(map_id: String, entity_type: String, entity_id: Stri
 						var itemgroups = entity["furniture"]["itemgroups"]
 						if itemgroups.has(entity_id):
 							itemgroups.erase(entity_id)
+							if itemgroups.size() == 0:
+								entity["furniture"].erase("itemgroups")
 					# Also, check and remove itemgroups from the entity itself if present
 					if entity.has("itemgroups"):
 						var entity_itemgroups = entity["itemgroups"]
 						if entity_itemgroups.has(entity_id):
 							entity_itemgroups.erase(entity_id)
+							if entity_itemgroups.size() == 0:
+								entity.erase("itemgroups")
 
 		# Update the level in the mapdata after modifications
 		levels[level_index] = level


### PR DESCRIPTION
Requires #238 

Besides adding itemgroups to furniture on the map, you can now also place the itemgroups on the ground. The idea is the same as in CDDA, you walk around in a field and find a stone here and there.
- Map tiles now accept itemgroup data. You can assign more then 1 itemgroup. If more then 1 itemgroup is assigned, a random one will be picked on spawn
- Containers will spawn on maps and have their sprite set to a random item inside the container. When an item is removed, the sprite will update to another random item. This will also happen with containers that were spawned from destroyed furniture. If a furniture is destroyed, it will first use it's wreck sprite. When an item is removed, it will update to a random item sprite.
- Created a new `field_generic_finds` group and added it to a few maps. 

A minor issue that's still there is when you have the container open in the inventory menu and remove an item from the container and it's sprite updates, the inventorywindow doesn't reflect that change in the container selection column.

Right now the itemgroups on the map have a fixed location. So each time the map spawns, it will be in exactly the same place. In the future we might come up with a way to have it spawn somewhere random.