### PR TITLE
Overmap save load

### DIFF
--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -95,7 +95,7 @@ func initialize_map_data():
 		Helper.overmap_manager.loaded_chunk_data.mapwidth = tacticalMapJSON.mapwidth
 	else:
 		# In this case we load the map json from disk
-		Helper.overmap_manager.update_player_position_and_manage_segments()
+		Helper.overmap_manager.update_player_position_and_manage_segments(true)
 
 
 # Return an array of chunks that fall inside the creation radius

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -19,7 +19,7 @@ var previous_visible_tile: Control = null
 # We will emit this signal when the position_coords change
 # Which happens when the user has panned the overmap
 signal position_coord_changed(delta: Vector2)
-#Fires when the player has pressed the travel button
+# Fires when the player has pressed the travel button
 signal change_level_pressed()
 
 func _ready():
@@ -57,18 +57,12 @@ func update_chunks():
 			# At 0,0 we will have positions -64,-64 and -64, -32 and -64, 0 etc.
 			var chunk_grid_position: Vector2 = grid_position + Vector2(x, y) * chunk_size
 			print_debug("Creating chunk in overmap at " + str(chunk_grid_position))
-			
-			# Use the separate Dictionary for retrieving the noise data
-			if not Helper.chunks.has(chunk_grid_position):
-				generate_chunk(chunk_grid_position)
-			# Retrieve the chunk data for the specific position.
-			var chunk_data = Helper.chunks[chunk_grid_position]
 
 			if not grid_chunks.has(chunk_grid_position):
-				# Use chunk data to create and fill the GridContainer.
-				var localized_x: float = chunk_grid_position.x*tile_size - Helper.position_coord.x * tile_size
-				var localized_y: float = chunk_grid_position.y*tile_size - Helper.position_coord.y * tile_size
-				var new_grid_container = create_and_fill_grid_container(chunk_data, Vector2(localized_x, localized_y))
+				# Directly create and fill the GridContainer with chunk data.
+				var localized_x: float = chunk_grid_position.x * tile_size - Helper.position_coord.x * tile_size
+				var localized_y: float = chunk_grid_position.y * tile_size - Helper.position_coord.y * tile_size
+				var new_grid_container = create_and_fill_grid_container(chunk_grid_position, Vector2(localized_x, localized_y))
 				tilesContainer.call_deferred("add_child", new_grid_container)
 				# Store the GridContainer using the grid position as the key.
 				grid_chunks[chunk_grid_position] = new_grid_container
@@ -77,29 +71,9 @@ func update_chunks():
 	unload_chunks()
 
 
-# This function creates terrain for a specific area on the overmap. It uses a grid_position 
-# to determine where to generate the terrain. The function employs a noise algorithm 
-# to select tile types from a predefined list, creating a chunk of terrain data. 
-# This data is stored in a global dictionary for later use in rendering the overmap.
-func generate_chunk(grid_position: Vector2) -> void:
-	var chunk = []
-	for y in range(chunk_size):  # x goes from 0 to chunk_size - 1
-		for x in range(chunk_size):  # y goes from 0 to chunk_size - 1
-			# We calculate global coordinates by 
-			# offsetting the local coordinates by the grid_position
-			var global_x = grid_position.x + x # at 0,0 it will be between 0 and 15
-			var global_y = grid_position.y + y
-			if global_x == 0 and global_y == 0:
-				chunk.append({"global_x": global_x, "global_y": global_y})
-			else:
-				chunk.append({"global_x": global_x, "global_y": global_y})
-	# Store the chunk using the grid_position as the key.
-	Helper.chunks[grid_position] = chunk
-
-
 # The user will leave chunks behind as the map is panned around
 # Chunks that are too far from the current position will be destroyed
-# This will only destroy the visual representation of the data stored in Helper.chunks
+# This will only destroy the visual representation of the data.
 func unload_chunks():
 	# Lowering this number 5 will cause newly created chunks 
 	# to be instantly deleted and recreated
@@ -110,6 +84,7 @@ func unload_chunks():
 			grid_chunks[chunk_position].call_deferred("queue_free")
 			# Remove the reference to the grid
 			grid_chunks.erase(chunk_position)
+
 
 # Function to handle keyboard input for moving the overmap
 func _input(event):
@@ -157,52 +132,39 @@ func on_position_coord_changed(delta: Vector2):
 		positionLabel.text = "Position: " + str(Helper.position_coord)
 
 
-# This function creates and populates a GridContainer with tiles based on chunk data. 
-# It takes two arguments: chunk, an array containing data for each tile in the chunk, 
-# and chunk_position, a Vector2 representing the chunk's position in the world. 
-# The function generates a new GridContainer, sets its columns to chunk_width, and 
-# ensures no space between tiles. It then iterates over the chunk array, creating 
-# a tile for each entry. Each tile's metadata is set with global and local positions, 
-# and additional data like map files if available. Tiles are added as children to 
-# the GridContainer, which is positioned based on chunk_position. The function returns 
-# the populated GridContainer. This process visually represents a section of the 
-# overmap in a grid format.
-func create_and_fill_grid_container(chunk: Array, chunk_position: Vector2):
+# This function creates and populates a GridContainer with tiles based on chunk size and position.
+# The function generates a new GridContainer, sets its columns to chunk_width, and ensures no space between tiles.
+# It then generates terrain for each tile based on a noise algorithm and assigns metadata to each tile.
+# Tiles are added as children to the GridContainer, which is positioned based on chunk_position.
+# The function returns the populated GridContainer.
+func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vector2):
 	var grid_container = GridContainer.new()
 	grid_container.columns = chunk_width  # Set the number of columns to chunk_width.
 	# Make sure there is no space between the tiles
 	grid_container.set("theme_override_constants/h_separation", 0)
 	grid_container.set("theme_override_constants/v_separation", 0)
 
-	# Variables to keep track of the row and column position
-	var row: int = 0
-	var column: int = 0
+	# Iterate over the chunk size to create and add TextureRects for each tile.
+	for y in range(chunk_size):
+		for x in range(chunk_size):
 
-	# Iterate over the chunk array to create and add TextureRects for each tile.
-	for i in range(chunk.size()):
-		if i > 0 and i % chunk_width == 0:
-			row += 1
-			column = 0  # Reset column at the start of a new row
-		# Retrieve the texture based on the tile type.
-		var tile = overmapTile.instantiate()
-		var local_pos = Vector2(column * tile_size, row * tile_size)
-		var global_pos = Vector2(chunk[i].global_x, chunk[i].global_y)
-		var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(global_pos)
-		var texture: Texture = map_cell.get_sprite() if map_cell else null
-		tile.set_texture(texture)
-		# Assign the tile's row and column information
-		tile.set_meta("global_pos", global_pos)
-		tile.set_meta("local_pos", local_pos)
+			var tile = overmapTile.instantiate()
+			var local_pos = Vector2(x * tile_size, y * tile_size)
+			var global_pos = grid_position + Vector2(x, y)
 
-		if global_pos == Vector2.ZERO:
-			tile.set_color(Color(0.3, 0.3, 1))  # blue color
+			# Set the tile's metadata and texture based on global position
+			var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(global_pos)
+			var texture: Texture = map_cell.get_sprite() if map_cell else null
+			tile.set_texture(texture)
+			tile.set_meta("global_pos", global_pos)
+			tile.set_meta("local_pos", local_pos)
 
-		tile.tile_clicked.connect(_on_tile_clicked)
-		# Add the tile as a child to the grid container
-		grid_container.add_child(tile)
+			if global_pos == Vector2.ZERO:
+				tile.set_color(Color(0.3, 0.3, 1))  # blue color
 
-		# Increase column count after placing each tile
-		column += 1
+			tile.tile_clicked.connect(_on_tile_clicked)
+			# Add the tile as a child to the grid container
+			grid_container.add_child(tile)
 
 	# Set the position of the grid container in pixel space.
 	grid_container.position = chunk_position
@@ -282,6 +244,6 @@ func get_overmap_tile_at_position(myposition: Vector2) -> Control:
 
 
 # When the player moves a coordinate on the map, i.e. when crossing the chunk border.
-# Move ment could be between (0,0) and (0,1) for example
+# Movement could be between (0,0) and (0,1) for example
 func on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
 	update_overmap_tile_visibility(new_pos)

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -56,14 +56,14 @@ func update_chunks():
 		for y in range(-1, 1):
 			# At 0,0 we will have positions -64,-64 and -64, -32 and -64, 0 etc.
 			var chunk_grid_position: Vector2 = grid_position + Vector2(x, y) * chunk_size
-			print_debug("Creating chunk in overmap at " + str(chunk_grid_position))
 
 			if not grid_chunks.has(chunk_grid_position):
+				print_debug("Creating chunk in overmap at " + str(chunk_grid_position))
 				# Directly create and fill the GridContainer with chunk data.
 				var localized_x: float = chunk_grid_position.x * tile_size - Helper.position_coord.x * tile_size
 				var localized_y: float = chunk_grid_position.y * tile_size - Helper.position_coord.y * tile_size
 				var new_grid_container = create_and_fill_grid_container(chunk_grid_position, Vector2(localized_x, localized_y))
-				tilesContainer.call_deferred("add_child", new_grid_container)
+				#tilesContainer.add_child(new_grid_container)
 				# Store the GridContainer using the grid position as the key.
 				grid_chunks[chunk_grid_position] = new_grid_container
 
@@ -81,7 +81,7 @@ func unload_chunks():
 	for chunk_position in grid_chunks.keys():
 		if chunk_position.distance_to(Helper.position_coord) > range_limit:
 			# Destroy the grid itself
-			grid_chunks[chunk_position].call_deferred("queue_free")
+			grid_chunks[chunk_position].queue_free()
 			# Remove the reference to the grid
 			grid_chunks.erase(chunk_position)
 
@@ -167,7 +167,7 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 			grid_container.add_child(tile)
 
 	# Set the position of the grid container in pixel space.
-	grid_container.position = chunk_position
+	grid_container.position = chunk_position+Vector2(200,200)
 
 	# Return the filled grid container.
 	return grid_container

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -60,7 +60,6 @@ func update_chunks():
 			var chunk_grid_position: Vector2 = grid_position + Vector2(x, y) * chunk_size
 
 			if not grid_chunks.has(chunk_grid_position):
-				print_debug("Creating chunk in overmap at " + str(chunk_grid_position))
 				# Directly create and fill the GridContainer with chunk data.
 				var localized_x: float = chunk_grid_position.x * tile_size - Helper.position_coord.x * tile_size
 				var localized_y: float = chunk_grid_position.y * tile_size - Helper.position_coord.y * tile_size

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -25,7 +25,7 @@ signal change_level_pressed()
 func _ready():
 	# Centers the view when opening the ovemap. Works with default window size.
 	# TODO: Have it calculated based on the window size
-	Helper.position_coord = Vector2(-7,-5)
+	Helper.position_coord = Vector2(-0,-0)
 	update_chunks()
 	position_coord_changed.connect(on_position_coord_changed)
 	Helper.overmap_manager.player_coord_changed.connect(on_player_coord_changed)
@@ -52,10 +52,11 @@ func update_chunks():
 	# The grid_position will be 1,0 between 32,0 and 64,31 if chunk_size = 32
 	var grid_position: Vector2 = (Helper.position_coord / chunk_size).floor() * chunk_size
 
-	for x in range(-2, 3):
-		for y in range(-2, 3):
+	for x in range(-1, 1):
+		for y in range(-1, 1):
 			# At 0,0 we will have positions -64,-64 and -64, -32 and -64, 0 etc.
 			var chunk_grid_position: Vector2 = grid_position + Vector2(x, y) * chunk_size
+			print_debug("Creating chunk in overmap at " + str(chunk_grid_position))
 			
 			# Use the separate Dictionary for retrieving the noise data
 			if not Helper.chunks.has(chunk_grid_position):
@@ -89,16 +90,11 @@ func generate_chunk(grid_position: Vector2) -> void:
 			var global_x = grid_position.x + x # at 0,0 it will be between 0 and 15
 			var global_y = grid_position.y + y
 			if global_x == 0 and global_y == 0:
-				chunk.append({"global_x": global_x, "global_y": global_y, "tacticalmap": Gamedata.data.tacticalmaps.data[0]})
+				chunk.append({"global_x": global_x, "global_y": global_y})
 			else:
-				chunk.append({"global_x": global_x, "global_y": global_y, "tacticalmap": get_random_mapname_1_in_100()})
+				chunk.append({"global_x": global_x, "global_y": global_y})
 	# Store the chunk using the grid_position as the key.
 	Helper.chunks[grid_position] = chunk
-	
-func get_random_mapname_1_in_100() -> String:
-	if randi_range(0, 100) < 1:
-		return Gamedata.data.tacticalmaps.data.pick_random()
-	return ""
 
 
 # The user will leave chunks behind as the map is panned around

--- a/Scripts/CharacterWindow.gd
+++ b/Scripts/CharacterWindow.gd
@@ -12,6 +12,7 @@ func _ready():
 	playerInstance = get_tree().get_first_node_in_group("Players")
 	_on_player_stat_changed(playerInstance)
 	_on_player_skill_changed(playerInstance)
+	visibility_changed.connect(_on_visibility_changed)
 
 
 # Utility function to clear all children in a container
@@ -33,6 +34,8 @@ func _on_player_stat_changed(player_node: CharacterBody3D):
 
 # Handles the update of the skills display when player skills change
 func _on_player_skill_changed(player_node: CharacterBody3D):
+	if not visible:
+		return
 	clear_container(skillsContainer)  # Clear existing content
 	for skill_id in player_node.skills:
 		var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, skill_id)
@@ -61,3 +64,10 @@ func create_stat_or_skill_entry(data: Dictionary, value: Variant, type: String) 
 	hbox.add_child(label)
 
 	return hbox
+
+
+# New function to refresh stats and skills when the window becomes visible
+func _on_visibility_changed():
+	if visible:
+		_on_player_stat_changed(playerInstance)
+		_on_player_skill_changed(playerInstance)

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -78,12 +78,14 @@ func _ready():
 
 
 func start_loading():
+	print_debug("Chunk started loading at " + str(mypos))
 	load_state = LoadStates.LOADING
 
 func start_unloading():
 	load_state = LoadStates.UNLOADING
 
 func reset_state():
+	print_debug("Chunk reset state at " + str(mypos))
 	load_state = LoadStates.NEITHER
 
 

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -32,11 +32,30 @@ func _physics_process(_delta) -> void:
 	# We only care about x and z. A changed y only means it's moving up or down.
 	var x_changed = not global_transform.origin.x == furnitureposition.x 
 	var z_changed = not global_transform.origin.z == furnitureposition.z
-	if x_changed or z_changed:
+	# HACK Sometimes when it calls set_position in _ready() it will say it moved when it didn't,
+	# or set_position is too late and it's differs from furnitureposition because it's still 0,0
+	# So we add in extra checks to handle those edge cases. There's probably a better way
+	var is_zero = global_transform.origin.x == 0 and global_transform.origin.z == 0
+	if (x_changed or z_changed) and not is_in_current_chunk() and not is_zero:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:
 		last_rotation = current_rotation
+
+
+# Returns if the current position is inside the current chunk
+func is_in_current_chunk() -> bool:
+	var chunk_pos: Vector3 = current_chunk.mypos
+	var chunk_range: Vector3 = chunk_pos + Vector3(32, 0, 32)
+
+	var position: Vector3 = global_transform.origin
+
+	# Check if position is within chunk bounds in the x and z axes
+	var in_x_range: bool = (position.x >= chunk_pos.x) and (position.x <= chunk_range.x)
+	var in_z_range: bool = (position.z >= chunk_pos.z) and (position.z <= chunk_range.z)
+
+	return in_x_range and in_z_range
+
 
 
 func set_new_rotation(amount: int) -> void:

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -76,7 +76,7 @@ func free_group_nodes(group_name: String):
 # Save game state
 func save_game():
 	save_helper.save_current_level(current_level_pos)
-	save_helper.save_overmap_state()
+	#save_helper.save_overmap_state()
 	save_helper.save_player_inventory()
 	save_helper.save_player_equipment()
 	save_helper.save_player_state(get_tree().get_first_node_in_group("Players"))

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -8,7 +8,6 @@ var ready_to_switch_level: Dictionary = {"save_ready": false, "chunks_unloaded":
 var chunk_navigation_maps: Dictionary = {}
 
 # Overmap data
-var chunks: Dictionary = {}
 var current_level_pos: Vector2 = Vector2(0.1, 0.1) #Stores references to tilegrids representing the overmap
 var current_map_seed: int = 0
 var position_coord: Vector2 = Vector2(0, 0)
@@ -56,7 +55,6 @@ func _process(_delta: float) -> void:
 
 # Called when the game is over and everything will need to be reset to default
 func reset():
-	chunks.clear() # Stores references to tilegrids representing the overmap
 	overmap_manager.loaded_chunk_data = {"chunks": {}}
 	current_level_pos = Vector2(0.1, 0.1)
 	current_map_seed = 0

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -11,6 +11,7 @@ var chunk_navigation_maps: Dictionary = {}
 var current_level_pos: Vector2 = Vector2(0.1, 0.1) #Stores references to tilegrids representing the overmap
 var current_map_seed: int = 0
 var position_coord: Vector2 = Vector2(0, 0)
+var mapseed: int # Is generated once per game. Defines the unique map!
 
 # Dictionary to store meshes for each block ID
 var navigationmap: RID

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -117,7 +117,8 @@ class map_grid:
 		return mydata
 
 	func set_data(mydata: Dictionary) -> void:
-		pos = mydata.get("pos", Vector2.ZERO)
+		var newpos = mydata.get("pos", "0,0")
+		pos = Vector2(newpos.split(",")[0].to_int(), newpos.split(",")[1].to_int())
 		cells.clear()
 		for cell_key in mydata["cells"].keys():
 			var cell = map_cell.new()

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -42,6 +42,8 @@ var segment_load_distance: int = 16
 var segment_unload_distance: int = 28
 
 # Dictionary to hold data of chunks that are unloaded
+# These chunks are the actual 32x32x21 collection of blocks, furniture, mobs and items
+# That makes up the map that the player is walking on.
 var loaded_chunk_data: Dictionary = {"chunks": {}}
 
 var player
@@ -77,7 +79,8 @@ class map_cell:
 			"coordinate_x": coordinate_x,
 			"coordinate_y": coordinate_y,
 			"map_id": map_id,
-			"tacticalmapname": tacticalmapname
+			"tacticalmapname": tacticalmapname,
+			"revealed": revealed
 		}
 
 	func set_data(newdata: Dictionary):
@@ -88,6 +91,7 @@ class map_cell:
 		coordinate_y = newdata.get("coordinate_y", 0)
 		map_id = newdata.get("map_id", "field_grass_basic_00.json")
 		tacticalmapname = newdata.get("tacticalmapname", "town_00.json")
+		revealed = newdata.get("revealed", false)
 
 	func get_sprite() -> Texture:
 		return Gamedata.maps.by_id(map_id).sprite
@@ -302,6 +306,11 @@ func get_cell_pos_from_global_pos(coord: Vector2) -> Vector2:
 
 
 # Function to get a map_cell by local coordinate within a specific grid
+# A local coord will start at (0,0), the next cell will be (0,1) and so on
+# It will return the map cell from the grid. 
+# The grid can contain grid_width x grid_height amount of cells
+# If the grid's position is in the negative range, for example (-1,-1) it will
+# contain cells from (-100,100) up to (-1,-1)
 func get_map_cell_by_local_coordinate(local_coord: Vector2) -> map_cell:
 	var grid_key = get_grid_pos_from_local_pos(local_coord)
 	var cell_key = Vector2(local_coord.x, local_coord.y)

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -514,11 +514,16 @@ func save_grid_to_file(grid_data: Dictionary, grid_key: Vector2) -> void:
 
 # Function to load the state of the grid
 func load_grid_from_file(grid_key: Vector2) -> void:
-	var grid_data = Helper.save_helper.load_overmap_grid_from_file(grid_key)
+	var grid_data: Dictionary = Helper.save_helper.load_overmap_grid_from_file(grid_key)
+	process_loaded_grid_data(grid_data)
+
+
+# Creates a new grid from grid data loaded from disk 
+func process_loaded_grid_data(grid_data: Dictionary):
 	if grid_data:
 		var grid = map_grid.new()
 		grid.set_data(grid_data)
-		loaded_grids[grid_key] = grid
+		loaded_grids[grid.pos] = grid
 		print_debug("Grid loaded from file")
 	else:
 		print_debug("Failed to parse grid file")
@@ -526,4 +531,11 @@ func load_grid_from_file(grid_key: Vector2) -> void:
 
 # Function to save all remaining grids
 func save_all_grids() -> void:
-	save_grid_to_file(loaded_grids[grid_key].get_data(), grid_key)
+	for gridkey in loaded_grids.keys():
+		save_grid_to_file(loaded_grids[gridkey].get_data(), gridkey)
+
+
+func load_all_grids():
+	var loaded_grids_array: Array = Helper.save_helper.load_all_overmap_grids_from_file()
+	for loadedgrid: Dictionary in loaded_grids_array:
+		process_loaded_grid_data(loadedgrid)

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -226,7 +226,19 @@ func save_overmap_grid_to_file(grid_data: Dictionary, grid_key: Vector2) -> void
 	var save_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
 	Helper.json_helper.write_json_file(save_path, JSON.stringify(grid_data))
 
+
 # Function to load the state of the grid
 func load_overmap_grid_from_file(grid_key: Vector2) -> Dictionary:
 	var load_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
 	return Helper.json_helper.load_json_dictionary_file(load_path)
+
+
+# Loads all files in the /overmap folder and returns the contents as an array
+func load_all_overmap_grids_from_file() -> Array:
+	var loaded_overmap_grids: Array = []
+	var load_path = current_save_folder + "/overmap"
+	var overmap_grid_files: Array = Helper.json_helper.file_names_in_dir(load_path)
+	for overmap in overmap_grid_files:
+		var file_path = load_path + "/" + overmap
+		loaded_overmap_grids.append(Helper.json_helper.load_json_dictionary_file(file_path))
+	return loaded_overmap_grids

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -123,43 +123,43 @@ func load_game_from_folder(save_folder_name: String) -> void:
 
 
 # Function to save the current state of the overmap
-func save_overmap_state() -> void:
-	var save_path = current_save_folder + "/overmap_state.json"
-	var save_data: Dictionary = {
-		"position_coord_x": Helper.position_coord.x,
-		"position_coord_y": Helper.position_coord.y,
-		"chunk_data": {}
-	}
-
-	# Convert Vector2 keys to strings
-	for key in Helper.chunks:
-		var key_str = str(key.x) + "," + str(key.y)
-		save_data["chunk_data"][key_str] = Helper.chunks[key]
-
-	Helper.json_helper.write_json_file(save_path, JSON.stringify(save_data))
+#func save_overmap_state() -> void:
+	#var save_path = current_save_folder + "/overmap_state.json"
+	#var save_data: Dictionary = {
+		#"position_coord_x": Helper.position_coord.x,
+		#"position_coord_y": Helper.position_coord.y,
+		#"chunk_data": {}
+	#}
+#
+	## Convert Vector2 keys to strings
+	#for key in Helper.chunks:
+		#var key_str = str(key.x) + "," + str(key.y)
+		#save_data["chunk_data"][key_str] = Helper.chunks[key]
+#
+	#Helper.json_helper.write_json_file(save_path, JSON.stringify(save_data))
 
 
 # Function to load the saved state of the overmap
-func load_overmap_state() -> void:
-	var overmap_path = current_save_folder + "/overmap_state.json"
-	var overmap_state_data = Helper.json_helper.load_json_dictionary_file(overmap_path)
-
-	if overmap_state_data:
-		Helper.position_coord = Vector2(overmap_state_data["position_coord_x"],\
-		overmap_state_data["position_coord_y"])
-		Helper.chunks.clear()
-
-		# Convert string keys back to Vector2
-		var chunk_data = overmap_state_data["chunk_data"]
-		for key_str in chunk_data:
-			var key_parts = key_str.split(",")
-			if key_parts.size() == 2:
-				var key = Vector2(float(key_parts[0]), float(key_parts[1]))
-				Helper.chunks[key] = chunk_data[key_str]
-
-		print_debug("Overmap state loaded from: ", overmap_path)
-	else:
-		print_debug("Failed to parse overmap state file: ", overmap_path)
+#func load_overmap_state() -> void:
+	#var overmap_path = current_save_folder + "/overmap_state.json"
+	#var overmap_state_data = Helper.json_helper.load_json_dictionary_file(overmap_path)
+#
+	#if overmap_state_data:
+		#Helper.position_coord = Vector2(overmap_state_data["position_coord_x"],\
+		#overmap_state_data["position_coord_y"])
+		#Helper.chunks.clear()
+#
+		## Convert string keys back to Vector2
+		#var chunk_data = overmap_state_data["chunk_data"]
+		#for key_str in chunk_data:
+			#var key_parts = key_str.split(",")
+			#if key_parts.size() == 2:
+				#var key = Vector2(float(key_parts[0]), float(key_parts[1]))
+				#Helper.chunks[key] = chunk_data[key_str]
+#
+		#print_debug("Overmap state loaded from: ", overmap_path)
+	#else:
+		#print_debug("Failed to parse overmap state file: ", overmap_path)
 
 
 # Function to save the player's inventory to a JSON file.

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -218,3 +218,15 @@ func load_player_state(player: CharacterBody3D) -> void:
 		player.update_stamina_HUD.emit(player.current_stamina)
 	else:
 		print_debug("Failed to load player state from: ", load_path)
+
+
+
+# Function to save the current state of the grid
+func save_overmap_grid_to_file(grid_data: Dictionary, grid_key: Vector2) -> void:
+	var save_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
+	Helper.json_helper.write_json_file(save_path, JSON.stringify(grid_data))
+
+# Function to load the state of the grid
+func load_overmap_grid_from_file(grid_key: Vector2) -> Dictionary:
+	var load_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
+	return Helper.json_helper.load_json_dictionary_file(load_path)

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -122,46 +122,6 @@ func load_game_from_folder(save_folder_name: String) -> void:
 	current_save_folder = "user://save/" + save_folder_name
 
 
-# Function to save the current state of the overmap
-#func save_overmap_state() -> void:
-	#var save_path = current_save_folder + "/overmap_state.json"
-	#var save_data: Dictionary = {
-		#"position_coord_x": Helper.position_coord.x,
-		#"position_coord_y": Helper.position_coord.y,
-		#"chunk_data": {}
-	#}
-#
-	## Convert Vector2 keys to strings
-	#for key in Helper.chunks:
-		#var key_str = str(key.x) + "," + str(key.y)
-		#save_data["chunk_data"][key_str] = Helper.chunks[key]
-#
-	#Helper.json_helper.write_json_file(save_path, JSON.stringify(save_data))
-
-
-# Function to load the saved state of the overmap
-#func load_overmap_state() -> void:
-	#var overmap_path = current_save_folder + "/overmap_state.json"
-	#var overmap_state_data = Helper.json_helper.load_json_dictionary_file(overmap_path)
-#
-	#if overmap_state_data:
-		#Helper.position_coord = Vector2(overmap_state_data["position_coord_x"],\
-		#overmap_state_data["position_coord_y"])
-		#Helper.chunks.clear()
-#
-		## Convert string keys back to Vector2
-		#var chunk_data = overmap_state_data["chunk_data"]
-		#for key_str in chunk_data:
-			#var key_parts = key_str.split(",")
-			#if key_parts.size() == 2:
-				#var key = Vector2(float(key_parts[0]), float(key_parts[1]))
-				#Helper.chunks[key] = chunk_data[key_str]
-#
-		#print_debug("Overmap state loaded from: ", overmap_path)
-	#else:
-		#print_debug("Failed to parse overmap state file: ", overmap_path)
-
-
 # Function to save the player's inventory to a JSON file.
 func save_player_inventory() -> void:
 	var save_path = current_save_folder + "/player_inventory.json"

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -33,7 +33,7 @@ func create_new_save():
 	if dir.make_dir_recursive(sanitized_path) == OK:
 		current_save_folder = "user://" + sanitized_path
 		Helper.json_helper.write_json_file(current_save_folder + "/game.json",\
-		JSON.stringify({"mapseed": randi()}))
+		JSON.stringify({"mapseed": Helper.mapseed}))
 	else:
 		print_debug("Failed to create a unique folder for the demo.")
 
@@ -120,6 +120,10 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 # Function to load game.json from a given saved game folder
 func load_game_from_folder(save_folder_name: String) -> void:
 	current_save_folder = "user://save/" + save_folder_name
+	var gameFileJson: Dictionary = Helper.json_helper.load_json_dictionary_file(\
+	current_save_folder + "/game.json")
+	if gameFileJson:
+		Helper.mapseed = gameFileJson.mapseed
 
 
 # Function to save the player's inventory to a JSON file.

--- a/Scripts/scene_selector.gd
+++ b/Scripts/scene_selector.gd
@@ -49,7 +49,7 @@ func try_load_game(selected_id: int) -> bool:
 		return false
 	var selected_game_folder = saved_game_folders[selected_id]
 	Helper.save_helper.load_game_from_folder(selected_game_folder)
-	Helper.save_helper.load_overmap_state()
+	#Helper.save_helper.load_overmap_state()
 	Helper.save_helper.load_player_equipment()
 	return true
 

--- a/Scripts/scene_selector.gd
+++ b/Scripts/scene_selector.gd
@@ -32,6 +32,8 @@ func _on_load_game_button_pressed():
 # The name of the folder should be the current date and time so it's unique
 # This unique folder will contain save data for this game and can be loaded later
 func _on_play_demo_pressed():
+	var rng = RandomNumberGenerator.new()
+	Helper.mapseed = rng.randi()
 	Helper.save_helper.create_new_save()
 	Helper.signal_broker.game_started.emit()
 	Helper.switch_level("DefaultTacticalMap.json", Vector2(0, 0))


### PR DESCRIPTION
Requires #252 

Overmap data is now saved and loaded. Previously, you'd get the same seed and it might look the same, but it would still give you a random map per coordinate. Now, after generating the overmap and picking a map for each cell, the grid is saved to disk, so you can continue with the same map as before.

Image of the overmap:
![image](https://github.com/user-attachments/assets/26995321-11db-4c8d-8d0f-8ec2783bfed6)
