### PR TITLE
Improve Chunk performance: Collider reduction

### DIFF
--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -95,7 +95,7 @@ func initialize_map_data():
 		Helper.overmap_manager.loaded_chunk_data.mapwidth = tacticalMapJSON.mapwidth
 	else:
 		# In this case we load the map json from disk
-		Helper.overmap_manager.update_player_position_and_manage_segments()
+		Helper.overmap_manager.update_player_position_and_manage_segments(true)
 
 
 # Return an array of chunks that fall inside the creation radius

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -944,19 +944,38 @@ func create_colliders() -> void:
 	var delay_every_n_blocks = max(1, total_blocks / 15)
 	var block_counter = 0
 
+	# First, create colliders for slopes
 	for key in block_positions.keys():
 		var pos_array = key.split(",")
 		var block_pos = Vector3(float(pos_array[0]), float(pos_array[1]), float(pos_array[2]))
 		var block_data = block_positions[key]
 		var block_shape = block_data.get("shape", "cube")
 		var block_rotation = block_data.get("rotation", 0)
-		chunk_mesh_body.add_child.call_deferred(_create_block_collider(block_pos, block_shape, block_rotation))
+		
+		if block_shape == "slope":
+			chunk_mesh_body.add_child.call_deferred(_create_slope_collider(block_pos, block_rotation))
 
-		block_counter += 1
-		# Check if it's time to delay. We need to delay because the call_deferred
-		# will add the child on the main thread and we weant to spread it out
-		if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
-			OS.delay_msec(100) # Adjust delay time as needed
+			block_counter += 1
+			if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
+				OS.delay_msec(100) # Adjust delay time as needed
+
+	# Reset counter for cubes
+	block_counter = 0
+
+	# Then, create colliders for cubes
+	for key in block_positions.keys():
+		var pos_array = key.split(",")
+		var block_pos = Vector3(float(pos_array[0]), float(pos_array[1]), float(pos_array[2]))
+		var block_data = block_positions[key]
+		var block_shape = block_data.get("shape", "cube")
+		var block_rotation = block_data.get("rotation", 0)
+
+		if block_shape == "cube":
+			chunk_mesh_body.add_child.call_deferred(_create_cube_collider(block_pos))
+
+			block_counter += 1
+			if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
+				OS.delay_msec(100) # Adjust delay time as needed
 
 
 # Creates a collider for either a slope or a cube and puts it at the right place and rotation

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -974,15 +974,12 @@ func create_cube_colliders(block_positions_copy: Dictionary, total_blocks: int, 
 	for key in block_positions_copy.keys():
 		var pos_array = key.split(",")
 		var block_pos = Vector3(float(pos_array[0]), float(pos_array[1]), float(pos_array[2]))
-		var block_data = block_positions_copy[key]
-		var block_shape = block_data.get("shape", "cube")
 
-		if block_shape == "cube":
-			chunk_mesh_body.add_child.call_deferred(_create_cube_collider(block_pos))
+		chunk_mesh_body.add_child.call_deferred(_create_cube_collider(block_pos))
 
-			block_counter += 1
-			if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
-				OS.delay_msec(100) # Adjust delay time as needed
+		block_counter += 1
+		if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
+			OS.delay_msec(100) # Adjust delay time as needed
 
 
 

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -989,7 +989,26 @@ func create_cube_colliders(block_positions_copy: Dictionary, total_blocks: int, 
 			else:
 				break
 		
-		_create_combined_cube_collider(start_pos, end_pos)
+		# Now attempt to combine along the z-axis
+		var z_end_pos = end_pos
+		
+		while true:
+			var can_extend_z = true
+			# Check if the entire x-range can be extended along the z-axis
+			for x in range(start_pos.x, end_pos.x + 1):
+				var check_key = str(x) + "," + str(start_pos.y) + "," + str(z_end_pos.z + 1)
+				if check_key not in block_positions_copy or check_key in processed_positions:
+					can_extend_z = false
+					break
+			if can_extend_z:
+				for x in range(start_pos.x, end_pos.x + 1):
+					var extend_key = str(x) + "," + str(start_pos.y) + "," + str(z_end_pos.z + 1)
+					processed_positions[extend_key] = true
+				z_end_pos.z += 1
+			else:
+				break
+		
+		_create_combined_cube_collider(start_pos, Vector3(end_pos.x, end_pos.y, z_end_pos.z))
 		
 		block_counter += 1
 		if block_counter % delay_every_n_blocks == 0 and block_counter < total_blocks:
@@ -1002,7 +1021,7 @@ func _create_combined_cube_collider(start_pos: Vector3, end_pos: Vector3) -> voi
 	var shape = BoxShape3D.new()
 	
 	# Calculate the size of the combined collider
-	var size = Vector3(end_pos.x - start_pos.x + 1, 1, 1)
+	var size = Vector3(end_pos.x - start_pos.x + 1, 1, end_pos.z - start_pos.z + 1)
 	shape.extents = size / 2
 	
 	collider.shape = shape

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -961,26 +961,36 @@ func create_colliders() -> void:
 
 # Creates a collider for either a slope or a cube and puts it at the right place and rotation
 func _create_block_collider(block_sub_position, shape: String, block_rotation: int) -> CollisionShape3D:
-	var collider = CollisionShape3D.new()
 	if shape == "cube":
-		collider.shape = BoxShape3D.new()
-		collider.set_transform.call_deferred(Transform3D(Basis(), block_sub_position))
+		return _create_cube_collider(block_sub_position)
 	else: # It's a slope
-		collider.shape = ConvexPolygonShape3D.new()
-		collider.shape.points = [
-			Vector3(0.5, 0.5, 0.5),
-			Vector3(0.5, 0.5, -0.5),
-			Vector3(-0.5, -0.5, 0.5),
-			Vector3(0.5, -0.5, 0.5),
-			Vector3(0.5, -0.5, -0.5),
-			Vector3(-0.5, -0.5, -0.5)
-		]
-		# Apply rotation only for slopes
-		# Set the rotation part of the Transform3D
-		var rotation_transform = Transform3D(Basis().rotated(Vector3.UP, deg_to_rad(block_rotation)), Vector3.ZERO)
-		# Now combine rotation and translation in the transform
-		collider.set_transform.call_deferred(rotation_transform.translated(block_sub_position))
+		return _create_slope_collider(block_sub_position, block_rotation)
+
+# Creates a collider for a cube and puts it at the right place
+func _create_cube_collider(block_sub_position: Vector3) -> CollisionShape3D:
+	var collider = CollisionShape3D.new()
+	collider.shape = BoxShape3D.new()
+	collider.set_transform.call_deferred(Transform3D(Basis(), block_sub_position))
 	return collider
+
+# Creates a collider for a slope and puts it at the right place and rotation
+func _create_slope_collider(block_sub_position: Vector3, block_rotation: int) -> CollisionShape3D:
+	var collider = CollisionShape3D.new()
+	collider.shape = ConvexPolygonShape3D.new()
+	collider.shape.points = [
+		Vector3(0.5, 0.5, 0.5),
+		Vector3(0.5, 0.5, -0.5),
+		Vector3(-0.5, -0.5, 0.5),
+		Vector3(0.5, -0.5, 0.5),
+		Vector3(0.5, -0.5, -0.5),
+		Vector3(-0.5, -0.5, -0.5)
+	]
+	# Apply rotation for slopes
+	var rotation_transform = Transform3D(Basis().rotated(Vector3.UP, deg_to_rad(block_rotation)), Vector3.ZERO)
+	# Combine rotation and translation in the transform
+	collider.set_transform.call_deferred(rotation_transform.translated(block_sub_position))
+	return collider
+
 
 
 # Rotates a 3D vertex around the Y-axis

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -32,11 +32,30 @@ func _physics_process(_delta) -> void:
 	# We only care about x and z. A changed y only means it's moving up or down.
 	var x_changed = not global_transform.origin.x == furnitureposition.x 
 	var z_changed = not global_transform.origin.z == furnitureposition.z
-	if x_changed or z_changed:
+	# HACK Sometimes when it calls set_position in _ready() it will say it moved when it didn't,
+	# or set_position is too late and it's differs from furnitureposition because it's still 0,0
+	# So we add in extra checks to handle those edge cases. There's probably a better way
+	var is_zero = global_transform.origin.x == 0 and global_transform.origin.z == 0
+	if (x_changed or z_changed) and not is_in_current_chunk() and not is_zero:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:
 		last_rotation = current_rotation
+
+
+# Returns if the current position is inside the current chunk
+func is_in_current_chunk() -> bool:
+	var chunk_pos: Vector3 = current_chunk.mypos
+	var chunk_range: Vector3 = chunk_pos + Vector3(32, 0, 32)
+
+	var position: Vector3 = global_transform.origin
+
+	# Check if position is within chunk bounds in the x and z axes
+	var in_x_range: bool = (position.x >= chunk_pos.x) and (position.x <= chunk_range.x)
+	var in_z_range: bool = (position.z >= chunk_pos.z) and (position.z <= chunk_range.z)
+
+	return in_x_range and in_z_range
+
 
 
 func set_new_rotation(amount: int) -> void:

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -11,6 +11,7 @@ var chunk_navigation_maps: Dictionary = {}
 var current_level_pos: Vector2 = Vector2(0.1, 0.1) #Stores references to tilegrids representing the overmap
 var current_map_seed: int = 0
 var position_coord: Vector2 = Vector2(0, 0)
+var mapseed: int # Is generated once per game. Defines the unique map!
 
 # Dictionary to store meshes for each block ID
 var navigationmap: RID

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -117,7 +117,8 @@ class map_grid:
 		return mydata
 
 	func set_data(mydata: Dictionary) -> void:
-		pos = mydata.get("pos", Vector2.ZERO)
+		var newpos = mydata.get("pos", "0,0")
+		pos = Vector2(newpos.split(",")[0].to_int(), newpos.split(",")[1].to_int())
 		cells.clear()
 		for cell_key in mydata["cells"].keys():
 			var cell = map_cell.new()

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -42,6 +42,8 @@ var segment_load_distance: int = 16
 var segment_unload_distance: int = 28
 
 # Dictionary to hold data of chunks that are unloaded
+# These chunks are the actual 32x32x21 collection of blocks, furniture, mobs and items
+# That makes up the map that the player is walking on.
 var loaded_chunk_data: Dictionary = {"chunks": {}}
 
 var player
@@ -77,7 +79,8 @@ class map_cell:
 			"coordinate_x": coordinate_x,
 			"coordinate_y": coordinate_y,
 			"map_id": map_id,
-			"tacticalmapname": tacticalmapname
+			"tacticalmapname": tacticalmapname,
+			"revealed": revealed
 		}
 
 	func set_data(newdata: Dictionary):
@@ -88,6 +91,7 @@ class map_cell:
 		coordinate_y = newdata.get("coordinate_y", 0)
 		map_id = newdata.get("map_id", "field_grass_basic_00.json")
 		tacticalmapname = newdata.get("tacticalmapname", "town_00.json")
+		revealed = newdata.get("revealed", false)
 
 	func get_sprite() -> Texture:
 		return Gamedata.maps.by_id(map_id).sprite
@@ -302,6 +306,11 @@ func get_cell_pos_from_global_pos(coord: Vector2) -> Vector2:
 
 
 # Function to get a map_cell by local coordinate within a specific grid
+# A local coord will start at (0,0), the next cell will be (0,1) and so on
+# It will return the map cell from the grid. 
+# The grid can contain grid_width x grid_height amount of cells
+# If the grid's position is in the negative range, for example (-1,-1) it will
+# contain cells from (-100,100) up to (-1,-1)
 func get_map_cell_by_local_coordinate(local_coord: Vector2) -> map_cell:
 	var grid_key = get_grid_pos_from_local_pos(local_coord)
 	var cell_key = Vector2(local_coord.x, local_coord.y)

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -514,11 +514,16 @@ func save_grid_to_file(grid_data: Dictionary, grid_key: Vector2) -> void:
 
 # Function to load the state of the grid
 func load_grid_from_file(grid_key: Vector2) -> void:
-	var grid_data = Helper.save_helper.load_overmap_grid_from_file(grid_key)
+	var grid_data: Dictionary = Helper.save_helper.load_overmap_grid_from_file(grid_key)
+	process_loaded_grid_data(grid_data)
+
+
+# Creates a new grid from grid data loaded from disk 
+func process_loaded_grid_data(grid_data: Dictionary):
 	if grid_data:
 		var grid = map_grid.new()
 		grid.set_data(grid_data)
-		loaded_grids[grid_key] = grid
+		loaded_grids[grid.pos] = grid
 		print_debug("Grid loaded from file")
 	else:
 		print_debug("Failed to parse grid file")
@@ -526,4 +531,11 @@ func load_grid_from_file(grid_key: Vector2) -> void:
 
 # Function to save all remaining grids
 func save_all_grids() -> void:
-	save_grid_to_file(loaded_grids[grid_key].get_data(), grid_key)
+	for gridkey in loaded_grids.keys():
+		save_grid_to_file(loaded_grids[gridkey].get_data(), gridkey)
+
+
+func load_all_grids():
+	var loaded_grids_array: Array = Helper.save_helper.load_all_overmap_grids_from_file()
+	for loadedgrid: Dictionary in loaded_grids_array:
+		process_loaded_grid_data(loadedgrid)

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -226,7 +226,19 @@ func save_overmap_grid_to_file(grid_data: Dictionary, grid_key: Vector2) -> void
 	var save_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
 	Helper.json_helper.write_json_file(save_path, JSON.stringify(grid_data))
 
+
 # Function to load the state of the grid
 func load_overmap_grid_from_file(grid_key: Vector2) -> Dictionary:
 	var load_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
 	return Helper.json_helper.load_json_dictionary_file(load_path)
+
+
+# Loads all files in the /overmap folder and returns the contents as an array
+func load_all_overmap_grids_from_file() -> Array:
+	var loaded_overmap_grids: Array = []
+	var load_path = current_save_folder + "/overmap"
+	var overmap_grid_files: Array = Helper.json_helper.file_names_in_dir(load_path)
+	for overmap in overmap_grid_files:
+		var file_path = load_path + "/" + overmap
+		loaded_overmap_grids.append(Helper.json_helper.load_json_dictionary_file(file_path))
+	return loaded_overmap_grids

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -218,3 +218,15 @@ func load_player_state(player: CharacterBody3D) -> void:
 		player.update_stamina_HUD.emit(player.current_stamina)
 	else:
 		print_debug("Failed to load player state from: ", load_path)
+
+
+
+# Function to save the current state of the grid
+func save_overmap_grid_to_file(grid_data: Dictionary, grid_key: Vector2) -> void:
+	var save_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
+	Helper.json_helper.write_json_file(save_path, JSON.stringify(grid_data))
+
+# Function to load the state of the grid
+func load_overmap_grid_from_file(grid_key: Vector2) -> Dictionary:
+	var load_path = current_save_folder + "/overmap/grid_" + str(grid_key.x) + "_" + str(grid_key.y) + ".json"
+	return Helper.json_helper.load_json_dictionary_file(load_path)

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -33,7 +33,7 @@ func create_new_save():
 	if dir.make_dir_recursive(sanitized_path) == OK:
 		current_save_folder = "user://" + sanitized_path
 		Helper.json_helper.write_json_file(current_save_folder + "/game.json",\
-		JSON.stringify({"mapseed": randi()}))
+		JSON.stringify({"mapseed": Helper.mapseed}))
 	else:
 		print_debug("Failed to create a unique folder for the demo.")
 
@@ -120,6 +120,10 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 # Function to load game.json from a given saved game folder
 func load_game_from_folder(save_folder_name: String) -> void:
 	current_save_folder = "user://save/" + save_folder_name
+	var gameFileJson: Dictionary = Helper.json_helper.load_json_dictionary_file(\
+	current_save_folder + "/game.json")
+	if gameFileJson:
+		Helper.mapseed = gameFileJson.mapseed
 
 
 # Function to save the player's inventory to a JSON file.

--- a/Scripts/scene_selector.gd
+++ b/Scripts/scene_selector.gd
@@ -32,6 +32,8 @@ func _on_load_game_button_pressed():
 # The name of the folder should be the current date and time so it's unique
 # This unique folder will contain save data for this game and can be loaded later
 func _on_play_demo_pressed():
+	var rng = RandomNumberGenerator.new()
+	Helper.mapseed = rng.randi()
 	Helper.save_helper.create_new_save()
 	Helper.signal_broker.game_started.emit()
 	Helper.switch_level("DefaultTacticalMap.json", Vector2(0, 0))


### PR DESCRIPTION
Requires #253 

Been wanting to do this for a while and now I had the algorithm to do it. Previously, each block would get it's own collider, creating a maximum of 1024 box colliders per level in a chunk. Now the box shapes are combined, creating fewer collisionshapes.

1. Slopes are separated from cubes. Slopes still have their own collision shapes and are not reduced in any way.
2. Blocks are merged horizontally over the x-axis. this creates long boxes of combined cubes
3. Blocks are merged over the z-axis if their start and end position match.

This algorithm works for our game because we often deal with flat terrain and houses on top of it. Houses have thin walls that are stretched either horizontally or vertically. I considered this when creating the algorithm. It should even work if the player starts digging round into the ground down the line.

It is essential to reduce the amount of colliders, because they can only be added to the scene on the main thread. This will cause strain on the physics server.

Here is an image with the colliders visualized:
![image](https://github.com/user-attachments/assets/e4d28441-dcae-457b-931d-654ea581f0cd)

If you look at the garage and the road, you can see there are few lines and big box collisionshapes.