### PR TITLE
Container sprite update

### DIFF
--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -36,7 +36,7 @@ func _ready():
 # Function to create and start a timer that will generate chunks every 1 second if applicable
 func start_timer():
 	var my_timer = Timer.new() # Create a new Timer instance
-	my_timer.wait_time = 1 # Timer will tick every 1 second
+	my_timer.wait_time = 0.5 # Timer will tick every 0.5 second
 	my_timer.one_shot = false # False means the timer will repeat
 	add_child(my_timer) # Add the Timer to the scene as a child of this node
 	my_timer.timeout.connect(_on_Timer_timeout) # Connect the timeout signal

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -18,7 +18,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -44,7 +46,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -80,7 +84,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -114,7 +120,9 @@
 					"urbanroad_corner",
 					"generichouse_corner",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -180,7 +188,9 @@
 					"urbanroad_corner",
 					"generichouse_corner",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -245,7 +255,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -272,7 +284,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -310,7 +324,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -343,7 +359,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -381,7 +399,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -414,7 +434,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -450,7 +472,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -72,8 +72,8 @@
 		"items": [
 			{
 				"id": "bullet_9mm",
-				"max": 1,
-				"min": 1,
+				"max": 20,
+				"min": 10,
 				"probability": 20
 			},
 			{
@@ -118,8 +118,8 @@
 			},
 			{
 				"id": "bullet_9mm",
-				"max": 1,
-				"min": 1,
+				"max": 20,
+				"min": 10,
 				"probability": 20
 			},
 			{

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -506,6 +506,13 @@
 		],
 		"mode": "Collection",
 		"name": "Electronics store (medium appliances)",
+		"references": {
+			"core": {
+				"maps": [
+					"store_electronic_clothing"
+				]
+			}
+		},
 		"sprite": "microwave_oven_32.png"
 	},
 	{
@@ -551,6 +558,13 @@
 		],
 		"mode": "Collection",
 		"name": "Electronics store (small products)",
+		"references": {
+			"core": {
+				"maps": [
+					"store_electronic_clothing"
+				]
+			}
+		},
 		"sprite": "screwdriver_32.png"
 	},
 	{
@@ -632,6 +646,13 @@
 		],
 		"mode": "Collection",
 		"name": "Electronics store (mixed products)",
+		"references": {
+			"core": {
+				"maps": [
+					"store_electronic_clothing"
+				]
+			}
+		},
 		"sprite": "electrical_components_32.png"
 	},
 	{
@@ -665,6 +686,13 @@
 		],
 		"mode": "Collection",
 		"name": "Vending machine (drinks)",
+		"references": {
+			"core": {
+				"maps": [
+					"store_electronic_clothing"
+				]
+			}
+		},
 		"sprite": "can_beer_32.png"
 	},
 	{

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -97,6 +97,13 @@
 		],
 		"mode": "Collection",
 		"name": "Mob loot",
+		"references": {
+			"core": {
+				"mobs": [
+					"rust_sentinel"
+				]
+			}
+		},
 		"sprite": "machete_32.png"
 	},
 	{

--- a/Mods/Core/Maps/Generichouse.json
+++ b/Mods/Core/Maps/Generichouse.json
@@ -1,10 +1,31 @@
 {
+	"areas": [
+		{
+			"entities": [
+				{
+					"count": 1,
+					"id": "scrapwalker",
+					"type": "mob"
+				}
+			],
+			"id": "mob_spawn",
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1000,
+					"id": "null"
+				}
+			]
+		}
+	],
 	"categories": [
 		"House",
 		"Urban",
 		"City"
 	],
 	"description": "A standard house layout suitable for various scenarios.",
+	"id": "Generichouse",
 	"levels": [
 		[],
 		[],
@@ -1792,803 +1813,2339 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -1,10 +1,36 @@
 {
+	"areas": [
+		{
+			"entities": [
+				{
+					"count": 2,
+					"id": "scrapwalker",
+					"type": "mob"
+				},
+				{
+					"count": 1,
+					"id": "rust_sentinel",
+					"type": "mob"
+				}
+			],
+			"id": "mob_spawn",
+			"rotate_random": false,
+			"spawn_chance": 75,
+			"tiles": [
+				{
+					"count": 1500,
+					"id": "null"
+				}
+			]
+		}
+	],
 	"categories": [
 		"House",
 		"Urban",
 		"City"
 	],
 	"description": "A slight variation of the standard house, with minor changes in design.",
+	"id": "Generichouse_00",
 	"levels": [
 		[],
 		[],
@@ -4921,803 +4947,2339 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{

--- a/Mods/Core/Maps/forest_basic_00.json
+++ b/Mods/Core/Maps/forest_basic_00.json
@@ -3,17 +3,17 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 11,
 					"id": "Tree_00",
 					"type": "furniture"
 				},
 				{
-					"count": 1,
+					"count": 11,
 					"id": "PineTree_00",
 					"type": "furniture"
 				},
 				{
-					"count": 1,
+					"count": 11,
 					"id": "WillowTree_00",
 					"type": "furniture"
 				}
@@ -23,7 +23,7 @@
 			"spawn_chance": 100,
 			"tiles": [
 				{
-					"count": 10,
+					"count": 100,
 					"id": "null"
 				}
 			]
@@ -92,12 +92,12 @@
 					"type": "itemgroup"
 				}
 			],
-			"id": "generic_field_finds",
+			"id": "generic_forest_finds",
 			"rotate_random": false,
 			"spawn_chance": 100,
 			"tiles": [
 				{
-					"count": 300,
+					"count": 250,
 					"id": "null"
 				}
 			]
@@ -131,7 +131,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -149,7 +149,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -167,7 +167,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -185,7 +185,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -203,7 +203,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -220,7 +220,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -238,7 +238,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -256,7 +256,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -273,7 +273,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -290,7 +290,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -308,7 +308,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -326,7 +326,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -344,7 +344,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -361,7 +361,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -378,7 +378,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -395,7 +395,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -413,7 +413,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -431,7 +431,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -449,7 +449,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -466,7 +466,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -484,7 +484,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -502,7 +502,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -520,7 +520,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -538,7 +538,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -556,7 +556,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -574,7 +574,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -592,7 +592,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -610,7 +610,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -628,7 +628,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -646,7 +646,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -663,7 +663,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -681,7 +681,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -699,7 +699,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -717,7 +717,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -735,7 +735,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -753,7 +753,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -771,7 +771,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -788,7 +788,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -806,7 +806,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -824,7 +824,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -841,7 +841,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -859,7 +859,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -877,7 +877,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -894,7 +894,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -912,7 +912,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -930,7 +930,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -948,7 +948,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -966,7 +966,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -984,7 +984,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1002,7 +1002,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1020,7 +1020,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1038,7 +1038,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1056,7 +1056,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1074,7 +1074,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1092,7 +1092,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1110,7 +1110,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1128,7 +1128,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1146,7 +1146,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1164,7 +1164,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1182,7 +1182,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1200,7 +1200,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1218,7 +1218,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1236,7 +1236,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1254,7 +1254,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1272,7 +1272,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1289,7 +1289,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1306,7 +1306,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1324,7 +1324,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1342,7 +1342,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1360,7 +1360,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1378,7 +1378,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1395,7 +1395,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1412,7 +1412,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1430,7 +1430,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1448,7 +1448,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1466,7 +1466,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1484,7 +1484,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1502,7 +1502,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1520,7 +1520,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1538,7 +1538,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1556,7 +1556,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1574,7 +1574,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1592,7 +1592,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1610,7 +1610,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1628,7 +1628,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1646,7 +1646,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1664,7 +1664,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1682,7 +1682,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1700,7 +1700,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1718,7 +1718,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1736,7 +1736,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1754,7 +1754,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1772,7 +1772,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1790,7 +1790,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1808,7 +1808,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1826,7 +1826,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1844,7 +1844,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1861,7 +1861,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1879,7 +1879,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1897,7 +1897,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1915,7 +1915,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1933,7 +1933,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1951,7 +1951,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1969,7 +1969,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -1986,7 +1986,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2003,7 +2003,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2021,7 +2021,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2038,7 +2038,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2056,7 +2056,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2074,7 +2074,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2092,7 +2092,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2110,7 +2110,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2128,7 +2128,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2146,7 +2146,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2163,7 +2163,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2181,7 +2181,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2199,7 +2199,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2217,7 +2217,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2235,7 +2235,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2253,7 +2253,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2270,7 +2270,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2288,7 +2288,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2306,7 +2306,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2324,7 +2324,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2341,7 +2341,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2359,7 +2359,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2377,7 +2377,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2394,7 +2394,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2412,7 +2412,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2430,7 +2430,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2448,7 +2448,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2466,7 +2466,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2484,7 +2484,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2502,7 +2502,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2520,7 +2520,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2538,7 +2538,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2556,7 +2556,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2574,7 +2574,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2592,7 +2592,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2610,7 +2610,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2627,7 +2627,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2645,7 +2645,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2662,7 +2662,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2680,7 +2680,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2698,7 +2698,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2716,7 +2716,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2734,7 +2734,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2752,7 +2752,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2769,7 +2769,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2787,7 +2787,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2804,7 +2804,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2822,7 +2822,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2840,7 +2840,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2858,7 +2858,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2876,7 +2876,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2893,7 +2893,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2911,7 +2911,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2929,7 +2929,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2946,7 +2946,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2964,7 +2964,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2981,7 +2981,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -2999,7 +2999,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3016,7 +3016,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3034,7 +3034,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3052,7 +3052,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3070,7 +3070,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3087,7 +3087,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3105,7 +3105,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3123,7 +3123,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3141,7 +3141,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3159,7 +3159,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3177,7 +3177,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3194,7 +3194,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3212,7 +3212,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3230,7 +3230,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3248,7 +3248,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3265,7 +3265,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3283,7 +3283,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3300,7 +3300,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3318,7 +3318,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3336,7 +3336,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3353,7 +3353,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3371,7 +3371,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3389,7 +3389,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3406,7 +3406,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3423,7 +3423,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3441,7 +3441,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3459,7 +3459,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3477,7 +3477,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3495,7 +3495,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3512,7 +3512,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3529,7 +3529,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3547,7 +3547,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3565,7 +3565,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3583,7 +3583,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3601,7 +3601,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3618,7 +3618,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3635,7 +3635,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3652,7 +3652,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3670,7 +3670,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3688,7 +3688,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3706,7 +3706,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3724,7 +3724,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3742,7 +3742,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3760,7 +3760,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3778,7 +3778,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3795,7 +3795,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3813,7 +3813,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3830,7 +3830,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3848,7 +3848,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3866,7 +3866,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3884,7 +3884,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3902,7 +3902,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3920,7 +3920,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3938,7 +3938,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3955,7 +3955,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3973,7 +3973,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -3990,7 +3990,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4008,7 +4008,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4026,7 +4026,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4043,7 +4043,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4061,7 +4061,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4079,7 +4079,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4097,7 +4097,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4114,7 +4114,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4132,7 +4132,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4150,7 +4150,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4168,7 +4168,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4186,7 +4186,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4204,7 +4204,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4221,7 +4221,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4239,7 +4239,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4257,7 +4257,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4275,7 +4275,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4293,7 +4293,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4311,7 +4311,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4329,7 +4329,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4346,7 +4346,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4364,7 +4364,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4382,7 +4382,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4400,7 +4400,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4418,7 +4418,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4435,7 +4435,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4453,7 +4453,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4470,7 +4470,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4488,7 +4488,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4506,7 +4506,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4523,7 +4523,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4541,7 +4541,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4558,7 +4558,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4576,7 +4576,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4594,7 +4594,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4612,7 +4612,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4629,7 +4629,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4647,7 +4647,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4665,7 +4665,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4683,7 +4683,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4701,7 +4701,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4719,7 +4719,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4737,7 +4737,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4755,7 +4755,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4773,7 +4773,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4791,7 +4791,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4809,7 +4809,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4827,7 +4827,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4845,7 +4845,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4862,7 +4862,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4880,7 +4880,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4898,7 +4898,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4916,7 +4916,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4934,7 +4934,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4951,7 +4951,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4969,7 +4969,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -4987,7 +4987,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5004,7 +5004,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5022,7 +5022,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5040,7 +5040,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5058,7 +5058,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5076,7 +5076,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5094,7 +5094,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5112,7 +5112,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5130,7 +5130,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5148,7 +5148,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5166,7 +5166,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5184,7 +5184,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5202,7 +5202,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5219,7 +5219,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5237,7 +5237,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5254,7 +5254,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5272,7 +5272,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5289,7 +5289,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5307,7 +5307,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5325,7 +5325,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5343,7 +5343,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5361,7 +5361,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5379,7 +5379,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5397,7 +5397,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5415,7 +5415,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5432,7 +5432,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5450,7 +5450,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5468,7 +5468,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5486,7 +5486,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5504,7 +5504,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5521,7 +5521,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5539,7 +5539,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5556,7 +5556,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5574,7 +5574,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5592,7 +5592,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5610,7 +5610,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5628,7 +5628,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5646,7 +5646,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5664,7 +5664,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5682,7 +5682,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5700,7 +5700,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5718,7 +5718,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5736,7 +5736,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5754,7 +5754,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5772,7 +5772,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5790,7 +5790,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5807,7 +5807,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5825,7 +5825,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5843,7 +5843,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5860,7 +5860,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5878,7 +5878,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5896,7 +5896,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5914,7 +5914,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5932,7 +5932,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5950,7 +5950,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5968,7 +5968,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -5985,7 +5985,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6003,7 +6003,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6020,7 +6020,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6037,7 +6037,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6055,7 +6055,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6073,7 +6073,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6091,7 +6091,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6108,7 +6108,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6126,7 +6126,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6144,7 +6144,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6162,7 +6162,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6179,7 +6179,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6197,7 +6197,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6215,7 +6215,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6233,7 +6233,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6250,7 +6250,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6267,7 +6267,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6285,7 +6285,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6303,7 +6303,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6320,7 +6320,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6338,7 +6338,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6356,7 +6356,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6374,7 +6374,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6392,7 +6392,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6410,7 +6410,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6427,7 +6427,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6444,7 +6444,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6462,7 +6462,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6480,7 +6480,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6498,7 +6498,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6516,7 +6516,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6534,7 +6534,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6551,7 +6551,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6569,7 +6569,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6587,7 +6587,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6605,7 +6605,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6623,7 +6623,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6641,7 +6641,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6659,7 +6659,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6676,7 +6676,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6694,7 +6694,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6712,7 +6712,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6729,7 +6729,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6747,7 +6747,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6764,7 +6764,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6782,7 +6782,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6799,7 +6799,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6817,7 +6817,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6835,7 +6835,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6853,7 +6853,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6871,7 +6871,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6889,7 +6889,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6907,7 +6907,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6925,7 +6925,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6943,7 +6943,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6961,7 +6961,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6979,7 +6979,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -6997,7 +6997,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7015,7 +7015,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7032,7 +7032,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7050,7 +7050,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7068,7 +7068,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7086,7 +7086,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7104,7 +7104,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7121,7 +7121,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7139,7 +7139,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7157,7 +7157,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7175,7 +7175,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7193,7 +7193,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7211,7 +7211,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7229,7 +7229,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7247,7 +7247,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7265,7 +7265,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7282,7 +7282,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7300,7 +7300,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7317,7 +7317,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7335,7 +7335,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7353,7 +7353,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7371,7 +7371,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7389,7 +7389,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7407,7 +7407,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7425,7 +7425,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7443,7 +7443,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7461,7 +7461,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7479,7 +7479,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7497,7 +7497,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7515,7 +7515,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7532,7 +7532,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7550,7 +7550,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7568,7 +7568,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7585,7 +7585,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7603,7 +7603,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7621,7 +7621,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7639,7 +7639,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7657,7 +7657,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7675,7 +7675,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7692,7 +7692,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7710,7 +7710,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7728,7 +7728,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7746,7 +7746,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7764,7 +7764,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7781,7 +7781,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7799,7 +7799,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7817,7 +7817,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7835,7 +7835,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7853,7 +7853,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7870,7 +7870,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7888,7 +7888,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7906,7 +7906,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7923,7 +7923,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7941,7 +7941,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7958,7 +7958,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7976,7 +7976,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -7994,7 +7994,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8011,7 +8011,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8029,7 +8029,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8047,7 +8047,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8064,7 +8064,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8082,7 +8082,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8100,7 +8100,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8118,7 +8118,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8136,7 +8136,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8154,7 +8154,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8172,7 +8172,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8190,7 +8190,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8208,7 +8208,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8226,7 +8226,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8244,7 +8244,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8261,7 +8261,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8279,7 +8279,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8297,7 +8297,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8315,7 +8315,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8333,7 +8333,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8351,7 +8351,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8369,7 +8369,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8387,7 +8387,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8405,7 +8405,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8422,7 +8422,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8440,7 +8440,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8458,7 +8458,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8476,7 +8476,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8494,7 +8494,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8511,7 +8511,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8529,7 +8529,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8547,7 +8547,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8565,7 +8565,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8583,7 +8583,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8601,7 +8601,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8619,7 +8619,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8637,7 +8637,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8655,7 +8655,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8673,7 +8673,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8691,7 +8691,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8709,7 +8709,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8727,7 +8727,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8745,7 +8745,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8763,7 +8763,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8781,7 +8781,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8799,7 +8799,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8816,7 +8816,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8834,7 +8834,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8851,7 +8851,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8869,7 +8869,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8887,7 +8887,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8905,7 +8905,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8922,7 +8922,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8940,7 +8940,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8958,7 +8958,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8976,7 +8976,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -8994,7 +8994,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9011,7 +9011,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9029,7 +9029,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9047,7 +9047,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9065,7 +9065,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9083,7 +9083,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9100,7 +9100,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9118,7 +9118,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9136,7 +9136,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9154,7 +9154,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9171,7 +9171,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9189,7 +9189,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9206,7 +9206,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9223,7 +9223,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9241,7 +9241,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9259,7 +9259,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9276,7 +9276,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9293,7 +9293,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9311,7 +9311,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9329,7 +9329,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9347,7 +9347,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9365,7 +9365,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9383,7 +9383,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9401,7 +9401,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9419,7 +9419,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9437,7 +9437,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9455,7 +9455,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9473,7 +9473,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9491,7 +9491,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9509,7 +9509,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9526,7 +9526,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9544,7 +9544,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9561,7 +9561,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9578,7 +9578,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9596,7 +9596,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9613,7 +9613,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9631,7 +9631,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9649,7 +9649,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9667,7 +9667,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9685,7 +9685,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9703,7 +9703,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9721,7 +9721,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9739,7 +9739,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9757,7 +9757,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9774,7 +9774,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9792,7 +9792,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9810,7 +9810,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9828,7 +9828,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9846,7 +9846,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9864,7 +9864,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9882,7 +9882,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9900,7 +9900,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9918,7 +9918,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9936,7 +9936,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9954,7 +9954,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9972,7 +9972,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -9989,7 +9989,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10007,7 +10007,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10025,7 +10025,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10043,7 +10043,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10061,7 +10061,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10079,7 +10079,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10097,7 +10097,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10115,7 +10115,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10133,7 +10133,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10151,7 +10151,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10169,7 +10169,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10186,7 +10186,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10204,7 +10204,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10222,7 +10222,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10240,7 +10240,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10258,7 +10258,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10276,7 +10276,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10294,7 +10294,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10312,7 +10312,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10330,7 +10330,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10347,7 +10347,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10365,7 +10365,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10382,7 +10382,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10400,7 +10400,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10418,7 +10418,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10436,7 +10436,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10454,7 +10454,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10472,7 +10472,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10490,7 +10490,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10508,7 +10508,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10526,7 +10526,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10543,7 +10543,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10561,7 +10561,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10579,7 +10579,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10597,7 +10597,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10615,7 +10615,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10633,7 +10633,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10651,7 +10651,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10669,7 +10669,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10687,7 +10687,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10705,7 +10705,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10722,7 +10722,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10739,7 +10739,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10757,7 +10757,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10774,7 +10774,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10792,7 +10792,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10810,7 +10810,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10828,7 +10828,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10846,7 +10846,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10864,7 +10864,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10882,7 +10882,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10900,7 +10900,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10918,7 +10918,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10936,7 +10936,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10953,7 +10953,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10971,7 +10971,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -10988,7 +10988,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11006,7 +11006,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11024,7 +11024,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11041,7 +11041,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11059,7 +11059,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11077,7 +11077,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11095,7 +11095,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11113,7 +11113,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11131,7 +11131,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11149,7 +11149,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11166,7 +11166,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11184,7 +11184,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11201,7 +11201,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11219,7 +11219,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11237,7 +11237,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11255,7 +11255,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11272,7 +11272,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11290,7 +11290,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11308,7 +11308,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11325,7 +11325,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11342,7 +11342,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11360,7 +11360,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11377,7 +11377,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11395,7 +11395,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11413,7 +11413,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11431,7 +11431,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11449,7 +11449,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11467,7 +11467,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11485,7 +11485,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11503,7 +11503,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11521,7 +11521,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11538,7 +11538,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11555,7 +11555,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11573,7 +11573,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11591,7 +11591,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11609,7 +11609,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11627,7 +11627,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11644,7 +11644,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11661,7 +11661,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11679,7 +11679,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11696,7 +11696,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11714,7 +11714,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11732,7 +11732,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11750,7 +11750,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11767,7 +11767,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11785,7 +11785,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11802,7 +11802,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11820,7 +11820,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11838,7 +11838,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11856,7 +11856,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11874,7 +11874,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11892,7 +11892,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11910,7 +11910,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11928,7 +11928,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11946,7 +11946,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11964,7 +11964,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -11982,7 +11982,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12000,7 +12000,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12018,7 +12018,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12036,7 +12036,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12054,7 +12054,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12071,7 +12071,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12089,7 +12089,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12107,7 +12107,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12125,7 +12125,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12142,7 +12142,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12160,7 +12160,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12177,7 +12177,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12195,7 +12195,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12213,7 +12213,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12231,7 +12231,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12249,7 +12249,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12267,7 +12267,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12285,7 +12285,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12303,7 +12303,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12321,7 +12321,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12339,7 +12339,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12356,7 +12356,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12374,7 +12374,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12392,7 +12392,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12409,7 +12409,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12427,7 +12427,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12445,7 +12445,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12463,7 +12463,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12480,7 +12480,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12498,7 +12498,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12515,7 +12515,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12533,7 +12533,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12551,7 +12551,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12568,7 +12568,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12586,7 +12586,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12604,7 +12604,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12622,7 +12622,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12640,7 +12640,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12658,7 +12658,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12676,7 +12676,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12694,7 +12694,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12712,7 +12712,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12730,7 +12730,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12748,7 +12748,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12766,7 +12766,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12784,7 +12784,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12802,7 +12802,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12820,7 +12820,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12838,7 +12838,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12856,7 +12856,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12874,7 +12874,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12892,7 +12892,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12909,7 +12909,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12926,7 +12926,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12943,7 +12943,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12961,7 +12961,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12979,7 +12979,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -12997,7 +12997,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13015,7 +13015,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13033,7 +13033,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13051,7 +13051,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13068,7 +13068,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13086,7 +13086,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13104,7 +13104,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13122,7 +13122,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13139,7 +13139,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13157,7 +13157,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13174,7 +13174,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13192,7 +13192,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13209,7 +13209,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13227,7 +13227,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13245,7 +13245,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13263,7 +13263,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13280,7 +13280,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13298,7 +13298,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13315,7 +13315,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13333,7 +13333,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13351,7 +13351,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13369,7 +13369,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13387,7 +13387,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13405,7 +13405,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13422,7 +13422,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13440,7 +13440,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13458,7 +13458,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13476,7 +13476,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13494,7 +13494,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13512,7 +13512,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13530,7 +13530,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13548,7 +13548,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13565,7 +13565,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13583,7 +13583,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13600,7 +13600,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13618,7 +13618,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13636,7 +13636,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13654,7 +13654,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13672,7 +13672,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13689,7 +13689,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13707,7 +13707,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13725,7 +13725,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13743,7 +13743,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13760,7 +13760,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13777,7 +13777,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13795,7 +13795,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13813,7 +13813,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13831,7 +13831,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13849,7 +13849,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13867,7 +13867,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13885,7 +13885,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13903,7 +13903,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13920,7 +13920,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13937,7 +13937,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13955,7 +13955,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13972,7 +13972,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -13990,7 +13990,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14008,7 +14008,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14025,7 +14025,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14043,7 +14043,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14061,7 +14061,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14079,7 +14079,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14097,7 +14097,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14115,7 +14115,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14133,7 +14133,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14150,7 +14150,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14167,7 +14167,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14185,7 +14185,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14203,7 +14203,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14221,7 +14221,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14239,7 +14239,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14257,7 +14257,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14275,7 +14275,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14292,7 +14292,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14310,7 +14310,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14328,7 +14328,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14346,7 +14346,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14363,7 +14363,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14380,7 +14380,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14397,7 +14397,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14415,7 +14415,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14433,7 +14433,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14451,7 +14451,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14469,7 +14469,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14487,7 +14487,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14505,7 +14505,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14522,7 +14522,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14540,7 +14540,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14558,7 +14558,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14576,7 +14576,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14593,7 +14593,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14611,7 +14611,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14629,7 +14629,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14647,7 +14647,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14665,7 +14665,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14682,7 +14682,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14700,7 +14700,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14718,7 +14718,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14736,7 +14736,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14754,7 +14754,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14772,7 +14772,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14789,7 +14789,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14807,7 +14807,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14824,7 +14824,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14842,7 +14842,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14860,7 +14860,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14878,7 +14878,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14896,7 +14896,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14914,7 +14914,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14932,7 +14932,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14950,7 +14950,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14967,7 +14967,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -14984,7 +14984,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15001,7 +15001,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15019,7 +15019,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15037,7 +15037,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15055,7 +15055,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15073,7 +15073,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15091,7 +15091,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15109,7 +15109,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15127,7 +15127,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15145,7 +15145,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15163,7 +15163,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15180,7 +15180,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15198,7 +15198,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15216,7 +15216,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15234,7 +15234,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15252,7 +15252,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15270,7 +15270,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15288,7 +15288,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15305,7 +15305,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15322,7 +15322,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15340,7 +15340,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15358,7 +15358,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15376,7 +15376,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15393,7 +15393,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15411,7 +15411,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15429,7 +15429,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15447,7 +15447,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15465,7 +15465,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15483,7 +15483,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15500,7 +15500,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15518,7 +15518,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15536,7 +15536,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15554,7 +15554,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15572,7 +15572,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15590,7 +15590,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15608,7 +15608,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15626,7 +15626,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15644,7 +15644,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15662,7 +15662,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15680,7 +15680,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15697,7 +15697,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15715,7 +15715,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15733,7 +15733,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15751,7 +15751,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15769,7 +15769,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15787,7 +15787,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15805,7 +15805,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15823,7 +15823,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15840,7 +15840,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15858,7 +15858,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15876,7 +15876,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15894,7 +15894,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15912,7 +15912,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15930,7 +15930,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15948,7 +15948,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15966,7 +15966,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -15983,7 +15983,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16001,7 +16001,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16018,7 +16018,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16035,7 +16035,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16052,7 +16052,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16070,7 +16070,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16088,7 +16088,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16106,7 +16106,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16123,7 +16123,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16140,7 +16140,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16157,7 +16157,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16175,7 +16175,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16193,7 +16193,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16211,7 +16211,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16228,7 +16228,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16246,7 +16246,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16264,7 +16264,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16282,7 +16282,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16300,7 +16300,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16318,7 +16318,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16336,7 +16336,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16353,7 +16353,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16371,7 +16371,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16388,7 +16388,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16406,7 +16406,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16424,7 +16424,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16442,7 +16442,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16460,7 +16460,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16478,7 +16478,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16496,7 +16496,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16514,7 +16514,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16532,7 +16532,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16550,7 +16550,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16568,7 +16568,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16585,7 +16585,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16603,7 +16603,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16620,7 +16620,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16638,7 +16638,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16656,7 +16656,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16674,7 +16674,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16692,7 +16692,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16710,7 +16710,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16727,7 +16727,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16745,7 +16745,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16763,7 +16763,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16781,7 +16781,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16799,7 +16799,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16817,7 +16817,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16835,7 +16835,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16853,7 +16853,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16871,7 +16871,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16889,7 +16889,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16907,7 +16907,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16925,7 +16925,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16942,7 +16942,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16960,7 +16960,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16977,7 +16977,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -16995,7 +16995,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17013,7 +17013,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17030,7 +17030,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17048,7 +17048,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17066,7 +17066,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17084,7 +17084,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17102,7 +17102,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17120,7 +17120,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17138,7 +17138,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17156,7 +17156,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17174,7 +17174,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17192,7 +17192,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17210,7 +17210,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17228,7 +17228,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17246,7 +17246,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17264,7 +17264,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17282,7 +17282,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17300,7 +17300,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17318,7 +17318,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17336,7 +17336,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17354,7 +17354,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17372,7 +17372,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17390,7 +17390,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17407,7 +17407,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17425,7 +17425,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17442,7 +17442,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17460,7 +17460,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17477,7 +17477,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17495,7 +17495,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17513,7 +17513,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17531,7 +17531,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17548,7 +17548,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17566,7 +17566,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17584,7 +17584,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17602,7 +17602,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17620,7 +17620,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17638,7 +17638,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17655,7 +17655,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17673,7 +17673,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17691,7 +17691,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17709,7 +17709,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17727,7 +17727,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17744,7 +17744,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17762,7 +17762,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17780,7 +17780,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17798,7 +17798,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17815,7 +17815,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17832,7 +17832,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17849,7 +17849,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17867,7 +17867,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17885,7 +17885,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17902,7 +17902,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17920,7 +17920,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17937,7 +17937,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17955,7 +17955,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17973,7 +17973,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -17991,7 +17991,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18009,7 +18009,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18027,7 +18027,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18045,7 +18045,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18063,7 +18063,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18080,7 +18080,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18098,7 +18098,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18116,7 +18116,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18134,7 +18134,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18152,7 +18152,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18170,7 +18170,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18187,7 +18187,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18204,7 +18204,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18222,7 +18222,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18240,7 +18240,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18258,7 +18258,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18276,7 +18276,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18294,7 +18294,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18312,7 +18312,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],
@@ -18330,7 +18330,7 @@
 						"rotation": 270
 					},
 					{
-						"id": "generic_field_finds",
+						"id": "generic_forest_finds",
 						"rotation": 0
 					}
 				],

--- a/Mods/Core/Maps/generichouse_corner.json
+++ b/Mods/Core/Maps/generichouse_corner.json
@@ -1,10 +1,36 @@
 {
+	"areas": [
+		{
+			"entities": [
+				{
+					"count": 2,
+					"id": "scrapwalker",
+					"type": "mob"
+				},
+				{
+					"count": 1,
+					"id": "rust_sentinel",
+					"type": "mob"
+				}
+			],
+			"id": "mob_spawn",
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1500,
+					"id": "null"
+				}
+			]
+		}
+	],
 	"categories": [
 		"House",
 		"Urban",
 		"City"
 	],
 	"description": "A house designed for corner plots, providing unique architectural features.",
+	"id": "generichouse_corner",
 	"levels": [
 		[],
 		[],
@@ -54,31 +80,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -170,31 +244,79 @@
 				"id": "grass_medium_dirt_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -295,31 +417,79 @@
 				"id": "grass_medium_dirt_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -423,31 +593,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -544,31 +762,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -677,31 +943,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -812,31 +1126,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -934,31 +1296,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1073,31 +1483,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1210,31 +1668,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1343,31 +1849,79 @@
 				"id": "grass_dirt_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1469,31 +2023,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1551,67 +2153,187 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1679,67 +2401,187 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1805,67 +2647,187 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1928,82 +2890,202 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -2074,67 +3156,187 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -2199,64 +3401,184 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -2312,64 +3634,184 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -2433,63 +3875,183 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -1,10 +1,36 @@
 {
+	"areas": [
+		{
+			"entities": [
+				{
+					"count": 1,
+					"id": "rust_sentinel",
+					"type": "mob"
+				},
+				{
+					"count": 2,
+					"id": "scrapwalker",
+					"type": "mob"
+				}
+			],
+			"id": "mob_spawn",
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 2000,
+					"id": "null"
+				}
+			]
+		}
+	],
 	"categories": [
 		"House",
 		"Urban",
 		"City"
 	],
 	"description": "A house located at a crossroads, with multiple access points.",
+	"id": "generichouse_cross",
 	"levels": [
 		[],
 		[],
@@ -57,31 +83,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -160,31 +234,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -297,31 +419,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -438,31 +608,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -573,31 +791,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -716,31 +982,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -849,31 +1163,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -989,31 +1351,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1111,31 +1521,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1251,31 +1709,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1383,31 +1889,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1515,31 +2069,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -1598,830 +2200,2366 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -2480,32 +4618,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -2622,32 +4808,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -2771,32 +5005,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -2928,32 +5210,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3065,32 +5395,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3222,32 +5600,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3371,32 +5797,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3527,32 +6001,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3676,32 +6198,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3837,32 +6407,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -3994,32 +6612,80 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
@@ -4123,32 +6789,80 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 90
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{

--- a/Mods/Core/Maps/generichouse_t.json
+++ b/Mods/Core/Maps/generichouse_t.json
@@ -1,10 +1,36 @@
 {
+	"areas": [
+		{
+			"entities": [
+				{
+					"count": 2,
+					"id": "scrapwalker",
+					"type": "mob"
+				},
+				{
+					"count": 1,
+					"id": "rust_sentinel",
+					"type": "mob"
+				}
+			],
+			"id": "mob_spawn",
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1500,
+					"id": "null"
+				}
+			]
+		}
+	],
 	"categories": [
 		"House",
 		"Urban",
 		"City"
 	],
 	"description": "A house situated at a T-junction, offering strategic entry and exit points.",
+	"id": "generichouse_t",
 	"levels": [
 		[],
 		[],
@@ -54,32 +80,80 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -175,32 +249,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -309,32 +431,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -446,32 +616,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -593,32 +811,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -735,32 +1001,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -872,32 +1186,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -997,32 +1359,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -1127,32 +1537,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -1256,32 +1714,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -1399,32 +1905,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -1533,32 +2087,80 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -1615,84 +2217,210 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -1741,71 +2469,197 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -1857,71 +2711,197 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -1974,86 +2954,212 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -2102,71 +3208,197 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -2215,70 +3447,196 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -2331,70 +3689,196 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -2447,83 +3931,209 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "concrete_00",
 				"rotation": 180
 			},
@@ -2614,31 +4224,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -2756,31 +4414,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -2908,31 +4614,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3041,31 +4795,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3186,31 +4988,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3319,31 +5169,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3461,31 +5359,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3610,31 +5556,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3764,31 +5758,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -3927,31 +5969,79 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -4072,30 +6162,78 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
@@ -4190,31 +6328,79 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00",
 				"rotation": 180
 			},

--- a/Mods/Core/Maps/store_electronic_clothing.json
+++ b/Mods/Core/Maps/store_electronic_clothing.json
@@ -1,4 +1,29 @@
 {
+	"areas": [
+		{
+			"entities": [
+				{
+					"count": 2,
+					"id": "scrapwalker",
+					"type": "mob"
+				},
+				{
+					"count": 1,
+					"id": "rust_sentinel",
+					"type": "mob"
+				}
+			],
+			"id": "mob_spawn",
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 2000,
+					"id": "null"
+				}
+			]
+		}
+	],
 	"categories": [
 		"Commercial",
 		"Store",
@@ -6,6 +31,7 @@
 		"City"
 	],
 	"description": "A commercial store offering a variety of electronics and clothing items.",
+	"id": "store_electronic_clothing",
 	"levels": [
 		[],
 		[],
@@ -1644,803 +1670,2339 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_horizontal_top"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "road_asphalt_basic"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "mob_spawn",
+						"rotation": 0
+					}
+				],
 				"id": "sidewalk_00"
 			},
 			{

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -14,7 +14,11 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner",
+					"generichouse_cross",
+					"generichouse_t",
+					"store_electronic_clothing"
 				]
 			}
 		},
@@ -35,7 +39,11 @@
 		"references": {
 			"core": {
 				"maps": [
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner",
+					"generichouse_cross",
+					"generichouse_t",
+					"store_electronic_clothing"
 				]
 			}
 		},

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -1,14 +1,14 @@
 [
 	{
 		"description": "A small robot",
-		"health": "80",
-		"hearing_range": "1000",
+		"health": 80,
+		"hearing_range": 1000,
 		"id": "scrapwalker",
-		"idle_move_speed": "0.5",
+		"idle_move_speed": 0.5,
 		"loot_group": "mob_loot",
-		"melee_damage": "20",
-		"melee_range": "1.5",
-		"move_speed": "1.1",
+		"melee_damage": 20,
+		"melee_range": 1.5,
+		"move_speed": 2.1,
 		"name": "Scrap walker",
 		"references": {
 			"core": {
@@ -22,19 +22,20 @@
 				]
 			}
 		},
-		"sense_range": "50",
-		"sight_range": "200",
+		"sense_range": 50,
+		"sight_range": 200,
 		"sprite": "scrapwalker64.png"
 	},
 	{
 		"description": "A slightly more advanced robot but still considered a weaker enemy in the robot faction. The Rust Sentinel stands tall and imposing, with a sturdy build. Its design incorporates rusted and recycled metal parts, giving it a rugged, battle-worn appearance.\n\nThe Rust Sentinel features a broad, slightly dome-shaped head with glowing red eyes that serve as visual sensors. Its torso is bulkier, reinforced with scrap metal plates, and it has two powerful arms ending in claws. The legs are designed for stability and power rather than speed. Its color scheme is a mix of rusted orange, steel gray, and hints of worn-out blue paint, suggesting it was once part of a larger machinery or vehicle.\n\nThe Rust Sentinel moves with deliberate, heavy steps, making it slower but more resilient. It's equipped with basic tools and weaponry, which it uses to scavenges and patrol.",
-		"health": "120",
-		"hearing_range": "1000",
+		"health": 120,
+		"hearing_range": 1000,
 		"id": "rust_sentinel",
-		"idle_move_speed": "0.4",
-		"melee_damage": "20",
-		"melee_range": "1.5",
-		"move_speed": "0.8",
+		"idle_move_speed": 0.4,
+		"loot_group": "mob_loot",
+		"melee_damage": 20,
+		"melee_range": 1.5,
+		"move_speed": 1.8,
 		"name": "Rust sentinel",
 		"references": {
 			"core": {
@@ -47,8 +48,8 @@
 				]
 			}
 		},
-		"sense_range": "50",
-		"sight_range": "200",
+		"sense_range": 50,
+		"sight_range": 200,
 		"sprite": "rust_sentinel_72.png"
 	}
 ]

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -10,6 +10,14 @@
 		"melee_range": "1.5",
 		"move_speed": "1.1",
 		"name": "Scrap walker",
+		"references": {
+			"core": {
+				"maps": [
+					"Generichouse",
+					"Generichouse_00"
+				]
+			}
+		},
 		"sense_range": "50",
 		"sight_range": "200",
 		"sprite": "scrapwalker64.png"
@@ -24,6 +32,13 @@
 		"melee_range": "1.5",
 		"move_speed": "0.8",
 		"name": "Rust sentinel",
+		"references": {
+			"core": {
+				"maps": [
+					"Generichouse_00"
+				]
+			}
+		},
 		"sense_range": "50",
 		"sight_range": "200",
 		"sprite": "rust_sentinel_72.png"

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -79,7 +79,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -140,7 +142,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -159,7 +163,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -177,7 +183,8 @@
 		"references": {
 			"core": {
 				"maps": [
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse"
 				]
 			}
 		},
@@ -198,7 +205,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -218,7 +227,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -238,7 +249,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -259,7 +272,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -279,7 +294,8 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -317,7 +333,9 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -337,7 +355,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -356,7 +376,9 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -376,7 +398,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -391,6 +415,14 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_06",
 		"name": "Wooden floor boards",
+		"references": {
+			"core": {
+				"maps": [
+					"Generichouse",
+					"Generichouse_00"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "woodboards7.png"
 	},
@@ -408,7 +440,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -427,7 +461,9 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -661,6 +697,13 @@
 		"description": "A rocky surface that doesn't leave any footprints",
 		"id": "rocky_earth_00",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"Generichouse_00"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyearth.png"
 	},
@@ -772,7 +815,9 @@
 			"core": {
 				"maps": [
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -793,7 +838,8 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse"
 				]
 			}
 		},
@@ -812,7 +858,8 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse"
 				]
 			}
 		},
@@ -869,7 +916,8 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -936,7 +984,8 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -957,7 +1006,8 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1065,7 +1115,8 @@
 					"urbanroad_corner",
 					"generichouse_corner",
 					"generichouse_t",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1115,7 +1166,8 @@
 					"generichouse_corner",
 					"generichouse_t",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1141,7 +1193,8 @@
 					"generichouse_cross",
 					"generichouse_t",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1165,7 +1218,8 @@
 					"urbanroad_corner",
 					"generichouse_corner",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse"
 				]
 			}
 		},
@@ -1237,7 +1291,9 @@
 					"urbanroad_t",
 					"urbanroad_corner",
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1283,7 +1339,9 @@
 					"urbanroad_t",
 					"urbanroad_corner",
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1454,7 +1512,9 @@
 					"generichouse_cross",
 					"generichouse_t",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1473,7 +1533,8 @@
 				"maps": [
 					"field_grass_hill_00",
 					"generichouse_corner",
-					"forest_basic_00"
+					"forest_basic_00",
+					"Generichouse"
 				]
 			}
 		},
@@ -1609,6 +1670,13 @@
 		"description": "A tiled floor with colorful stones",
 		"id": "cobblestone_00",
 		"name": "Cobblestone",
+		"references": {
+			"core": {
+				"maps": [
+					"Generichouse"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "cobblestone.png"
 	},
@@ -1640,7 +1708,8 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse"
 				]
 			}
 		},
@@ -1680,7 +1749,9 @@
 				"maps": [
 					"generichouse_corner",
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1729,7 +1800,9 @@
 			"core": {
 				"maps": [
 					"generichouse_cross",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1748,7 +1821,9 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1769,7 +1844,9 @@
 					"generichouse_corner",
 					"generichouse_t",
 					"generichouse_cross",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1787,7 +1864,9 @@
 			"core": {
 				"maps": [
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -52,21 +52,21 @@ func load_mob_data() -> void:
 	if DescriptionTextEdit != null and contentData.has("description"):
 		DescriptionTextEdit.text = contentData["description"]
 	if melee_damage_numedit != null and contentData.has("melee_damage"):
-		melee_damage_numedit.get_line_edit().text = contentData["melee_damage"]
+		melee_damage_numedit.value = int(contentData["melee_damage"])
 	if melee_range_numedit != null and contentData.has("melee_range"):
-		melee_range_numedit.get_line_edit().text = contentData["melee_range"]
+		melee_range_numedit.value = float(contentData["melee_range"])
 	if health_numedit != null and contentData.has("health"):
-		health_numedit.get_line_edit().text = contentData["health"]
+		health_numedit.value = int(contentData["health"])
 	if moveSpeed_numedit != null and contentData.has("move_speed"):
-		moveSpeed_numedit.get_line_edit().text = contentData["move_speed"]
+		moveSpeed_numedit.value = float(contentData["move_speed"])
 	if idle_move_speed_numedit != null and contentData.has("idle_move_speed"):
-		idle_move_speed_numedit.get_line_edit().text = contentData["idle_move_speed"]
+		idle_move_speed_numedit.value = float(contentData["idle_move_speed"])
 	if sightRange_numedit != null and contentData.has("sight_range"):
-		sightRange_numedit.get_line_edit().text = contentData["sight_range"]
+		sightRange_numedit.value = int(contentData["sight_range"])
 	if senseRange_numedit != null and contentData.has("sense_range"):
-		senseRange_numedit.get_line_edit().text = contentData["sense_range"]
+		senseRange_numedit.value = int(contentData["sense_range"])
 	if hearingRange_numedit != null and contentData.has("hearing_range"):
-		hearingRange_numedit.get_line_edit().text = contentData["hearing_range"]
+		hearingRange_numedit.value = int(contentData["hearing_range"])
 	if ItemGroupTextEdit != null and contentData.has("loot_group"):
 		ItemGroupTextEdit.text = contentData["loot_group"]
 	
@@ -84,14 +84,14 @@ func _on_save_button_button_up() -> void:
 	contentData["sprite"] = PathTextLabel.text
 	contentData["name"] = NameTextEdit.text
 	contentData["description"] = DescriptionTextEdit.text
-	contentData["melee_damage"] = melee_damage_numedit.get_line_edit().text
-	contentData["melee_range"] = melee_range_numedit.get_line_edit().text
-	contentData["health"] = health_numedit.get_line_edit().text
-	contentData["move_speed"] = moveSpeed_numedit.get_line_edit().text
-	contentData["idle_move_speed"] = idle_move_speed_numedit.get_line_edit().text
-	contentData["sight_range"] = sightRange_numedit.get_line_edit().text
-	contentData["sense_range"] = senseRange_numedit.get_line_edit().text
-	contentData["hearing_range"] = hearingRange_numedit.get_line_edit().text
+	contentData["melee_damage"] = melee_damage_numedit.value
+	contentData["melee_range"] = melee_range_numedit.value
+	contentData["health"] = health_numedit.value
+	contentData["move_speed"] = moveSpeed_numedit.value
+	contentData["idle_move_speed"] = idle_move_speed_numedit.value
+	contentData["sight_range"] = sightRange_numedit.value
+	contentData["sense_range"] = senseRange_numedit.value
+	contentData["hearing_range"] = hearingRange_numedit.value
 	if ItemGroupTextEdit.text:
 		contentData["loot_group"] = ItemGroupTextEdit.text
 	else:

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -654,7 +654,7 @@ func create_atlas() -> Dictionary:
 # arrays[ArrayMesh.ARRAY_INDEX] = indices
 # This represents the data that will be used to create an arraymesh, which visualizes the blocks
 # The block_uv_map is used to map the block id to the right uv coordinates on the atlas texture
-# This function will now take a 'blocks_at_same_y' array instead of using 'block_positions.keys()'.
+# This function takes a 'blocks_at_same_y' array which represents all blocks on a level.
 func prepare_mesh_data(arrays: Array, blocks_at_same_y: Array, block_uv_map: Dictionary) -> void:
 	# Define a small margin to prevent seams, adjusted dynamically based on atlas size
 	var atlas_size = block_uv_map.size()
@@ -1243,9 +1243,9 @@ func setup_cube(pos: Vector3, block_data: Dictionary, verts, uvs, normals, indic
 	if pos.x != LEVEL_WIDTH - 1:
 		faces.append("right")
 	if pos.z != 0:
-		faces.append("back")
-	if pos.z != LEVEL_HEIGHT - 1:
 		faces.append("front")
+	if pos.z != LEVEL_HEIGHT - 1:
+		faces.append("back")
 
 	# Mapping directions to positions
 	var directions = {

--- a/Scripts/Helper/map_manager.gd
+++ b/Scripts/Helper/map_manager.gd
@@ -19,6 +19,26 @@ func process_area_data(area_data: Dictionary, original_tile_id: String) -> Dicti
 	var result = {}
 
 	# Process and assign tile ID
+	_process_tile_id(area_data, original_tile_id, result)
+
+	# Process entities data and add them to result
+	_process_entities_data(area_data, result)
+
+	return result
+
+
+# Function to get a random rotation
+func _get_random_rotation(area_data: Dictionary) -> int:
+	var rotate_random: bool = area_data.get("rotate_random", false)
+	var rotations: Array = [0, 90, 180, 270]
+	
+	if rotate_random:
+		return rotations[randi() % rotations.size()]
+	return 0  # Default rotation
+
+
+# Function to process and assign tile ID
+func _process_tile_id(area_data: Dictionary, original_tile_id: String, result: Dictionary) -> void:
 	var tiles_data = area_data.get("tiles", [])
 	if not tiles_data.is_empty():
 		var picked_tile = pick_item_based_on_count(tiles_data)
@@ -27,8 +47,15 @@ func process_area_data(area_data: Dictionary, original_tile_id: String) -> Dicti
 			result["id"] = original_tile_id  # Keep the original tile ID
 		else:
 			result["id"] = picked_tile["id"]
+	
+	# Apply the rotation to the result
+	result["rotation"] = _get_random_rotation(area_data)
 
+
+# Function to process entities data and add them to result
+func _process_entities_data(area_data: Dictionary, result: Dictionary) -> void:
 	# Calculate the total count of tiles
+	var tiles_data = area_data.get("tiles", [])
 	var total_tiles_count: int = calculate_total_count(tiles_data)
 
 	# Duplicate the entities_data and add the "None" entity
@@ -45,15 +72,14 @@ func process_area_data(area_data: Dictionary, original_tile_id: String) -> Dicti
 	if not entities_data.is_empty():
 		var selected_entity = pick_item_based_on_count(entities_data)
 		if selected_entity["type"] != "None":
+			var rotation = _get_random_rotation(area_data)
 			match selected_entity["type"]:
 				"furniture":
-					result["furniture"] = {"id":selected_entity["id"]}
+					result["furniture"] = {"id": selected_entity["id"], "rotation": rotation}
 				"mob":
-					result["mob"] = {"id":selected_entity["id"]}
+					result["mob"] = {"id": selected_entity["id"], "rotation": rotation}
 				"itemgroup":
 					result["itemgroups"] = [selected_entity["id"]]
-
-	return result
 
 
 # Function to pick an item based on its count property

--- a/Scripts/Helper/map_manager.gd
+++ b/Scripts/Helper/map_manager.gd
@@ -47,9 +47,8 @@ func _process_tile_id(area_data: Dictionary, original_tile_id: String, result: D
 			result["id"] = original_tile_id  # Keep the original tile ID
 		else:
 			result["id"] = picked_tile["id"]
-	
-	# Apply the rotation to the result
-	result["rotation"] = _get_random_rotation(area_data)
+			# Apply the rotation to the result
+			result["rotation"] = _get_random_rotation(area_data)
 
 
 # Function to process entities data and add them to result

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -187,7 +187,7 @@ func update_quest_by_inventory(item: InventoryItem):
 # - item_count: The count of the item in the player's inventory
 func update_quest_step(myquestname: String, item_id: String, item_count: int, add: bool = false) -> void:
 	var step = QuestManager.get_current_step(myquestname)
-	match step.step_type:
+	match step.get("step_type", ""):	
 		QuestManager.INCREMENTAL_STEP:
 			if step.item_name == item_id:
 				# Update the quest step items with the collected count

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -21,11 +21,13 @@ func _ready():
 	if texture_id:
 		set_texture(texture_id)
 
+
 # Called when a function creates this class using ContainerItem.new(container_json)
 # Basic setup for this container. Should be called before adding it to the scene tree
 func _init(item: Dictionary):
 	_initialize_container(item)
 	create_loot()
+
 
 func _initialize_container(item: Dictionary):
 	containerpos = Vector3(item.global_position_x, item.global_position_y, item.global_position_z)
@@ -85,6 +87,7 @@ func _add_items_to_inventory(items: Array) -> bool:
 			var quantity = randi_range(item_object["min"], item_object["max"])
 			_add_item_to_inventory(item_id, quantity)
 	return item_added
+
 
 # Takes an item_id and quantity and adds it to the inventory
 func _add_item_to_inventory(item_id: String, quantity: int):
@@ -232,15 +235,13 @@ func _on_item_removed(_item: InventoryItem):
 			
 	else: # There are still items in the container
 		if is_inside_tree():
-			# Check if this ContainerItem is a direct child of the tree root
-			if get_parent() == get_tree().get_root():
-				set_random_inventory_item_texture() # Update to a new sprite
+			set_random_inventory_item_texture() # Update to a new sprite
 
 
 func _on_item_added(_item: InventoryItem):
 	# Check if this ContainerItem is a direct child of the tree root
 	if is_inside_tree() and not get_parent() == get_tree().get_root():
-		sprite_3d.texture = load("res://Textures/container_filled_32.png")
+		set_random_inventory_item_texture() # Update to a new sprite
 
 
 func add_item(item_id: String):

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -470,8 +470,8 @@ func get_property_by_path(mydata: Dictionary, property_path: String, entity_id: 
 
 # A mob has been changed.
 func on_mob_changed(newdata: Dictionary, olddata: Dictionary):
-	var old_loot_group: String = olddata.get("loot_group")
-	var new_loot_group: String = newdata.get("loot_group")
+	var old_loot_group: String = olddata.get("loot_group", "")
+	var new_loot_group: String = newdata.get("loot_group", "")
 	var mob_id: String = newdata.get("id")
 	# Exit if old_group and new_group are the same
 	if old_loot_group == new_loot_group:

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -8,7 +8,7 @@ var is_alive = true
 
 var rng = RandomNumberGenerator.new()
 
-var speed = 1  # speed in meters/sec
+var speed = 2  # speed in meters/sec
 var current_speed
 
 var run_multiplier = 1.1


### PR DESCRIPTION
Requires #269 
Fixes #266 

Containers attached to furniture will now update it's sprite to a random item in the container when an item is removed or added. If it is empty, it will display an empty container sprite.
Previously, it would be either a full container sprite or an empty container sprite, but I think picking a random item sprite will give the player more information.