### PR TITLE
Improve furniture performance

### DIFF
--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -57,8 +57,8 @@
 	},
 	{
 		"Function": {
-			"is_container":  true,
-			"container_group": "kitchen_cupboard"
+			"container_group": "kitchen_cupboard",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -97,7 +97,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 100
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -132,7 +133,8 @@
 			"radius_scale": 60,
 			"shape": "Cylinder",
 			"transparent": false
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -165,7 +167,8 @@
 			"radius_scale": 60,
 			"shape": "Cylinder",
 			"transparent": false
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -200,7 +203,8 @@
 			"radius_scale": 60,
 			"shape": "Cylinder",
 			"transparent": false
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -233,7 +237,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -242,7 +247,8 @@
 		],
 		"description": "A small pot holding a green plant, which can be placed indoors to enhance the aesthetics",
 		"destruction": {
-
+			"group": "destroyed_furniture_medium",
+			"sprite": "wreck_wood_generic_32.png"
 		},
 		"edgesnapping": "None",
 		"id": "plant_pot_00",
@@ -297,12 +303,13 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"container_group": "cabinet_general"
+			"container_group": "cabinet_general",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -336,7 +343,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -371,12 +379,13 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"container_group": "refridgerator"
+			"container_group": "refridgerator",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -385,7 +394,8 @@
 		],
 		"description": "One of the central pieces of fruniture that make up a kitchen",
 		"destruction": {
-
+			"group": "destroyed_furniture_medium",
+			"sprite": "wreck_wood_generic_32.png"
 		},
 		"edgesnapping": "North",
 		"id": "refrigerator_00",
@@ -410,7 +420,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -419,7 +430,8 @@
 		],
 		"description": "Centerpiece of the bathroom",
 		"destruction": {
-
+			"group": "destroyed_furniture_medium",
+			"sprite": "wreck_wood_generic_32.png"
 		},
 		"edgesnapping": "North",
 		"id": "toilet_00",
@@ -444,7 +456,8 @@
 			"radius_scale": 40,
 			"shape": "Cylinder",
 			"transparent": false
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
@@ -483,7 +496,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -515,12 +529,13 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"container_group": "clothing_general"
+			"container_group": "clothing_general",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -551,7 +566,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -582,7 +598,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -641,7 +658,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 80
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -700,7 +718,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -731,7 +750,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 80
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -763,7 +783,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -795,7 +816,8 @@
 			"radius_scale": 20,
 			"shape": "Cylinder",
 			"transparent": false
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -826,7 +848,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 80
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -856,7 +879,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 90
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
@@ -886,8 +910,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"container_group": "refridgerator"
+			"container_group": "refridgerator",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -916,12 +940,13 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"container_group": "refridgerator"
+			"container_group": "refridgerator",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -950,12 +975,13 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 95
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"container_group": "clothing_general"
+			"container_group": "clothing_general",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -1010,7 +1036,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 80
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
@@ -1043,11 +1070,12 @@
 			"shape": "Box",
 			"transparent": true,
 			"width_scale": 80
-		}
+		},
+		"weight": 1
 	},
 	{
 		"Function": {
-			"is_container":  true
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -1077,8 +1105,8 @@
 	},
 	{
 		"Function": {
-			"is_container":  true,
-			"container_group": "cabinet_general"
+			"container_group": "cabinet_general",
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -1107,7 +1135,8 @@
 			"shape": "Box",
 			"transparent": false,
 			"width_scale": 90
-		}
+		},
+		"weight": 1
 	},
 	{
 		"categories": [
@@ -1142,6 +1171,7 @@
 			"shape": "Box",
 			"transparent": true,
 			"width_scale": 100
-		}
+		},
+		"weight": 1
 	}
 ]

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -57,9 +57,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "kitchen_cupboard"
-			}
+			"is_container":  true,
+			"container_group": "kitchen_cupboard"
 		},
 		"categories": [
 			"Urban",
@@ -302,9 +301,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "cabinet_general"
-			}
+			"is_container": true,
+			"container_group": "cabinet_general"
 		},
 		"categories": [
 			"Urban",
@@ -377,9 +375,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "refridgerator"
-			}
+			"is_container": true,
+			"container_group": "refridgerator"
 		},
 		"categories": [
 			"Urban",
@@ -522,9 +519,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "clothing_general"
-			}
+			"is_container": true,
+			"container_group": "clothing_general"
 		},
 		"categories": [
 			"Urban",
@@ -864,9 +860,7 @@
 	},
 	{
 		"Function": {
-			"container": {
-
-			}
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -892,9 +886,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "refridgerator"
-			}
+			"is_container": true,
+			"container_group": "refridgerator"
 		},
 		"categories": [
 			"Urban",
@@ -927,9 +920,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "refridgerator"
-			}
+			"is_container": true,
+			"container_group": "refridgerator"
 		},
 		"categories": [
 			"Urban",
@@ -962,9 +954,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "clothing_general"
-			}
+			"is_container": true,
+			"container_group": "clothing_general"
 		},
 		"categories": [
 			"Urban",
@@ -990,9 +981,7 @@
 	},
 	{
 		"Function": {
-			"container": {
-
-			}
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -1058,9 +1047,7 @@
 	},
 	{
 		"Function": {
-			"container": {
-
-			}
+			"is_container":  true
 		},
 		"categories": [
 			"Urban",
@@ -1090,9 +1077,8 @@
 	},
 	{
 		"Function": {
-			"container": {
-				"itemgroup": "cabinet_general"
-			}
+			"is_container":  true,
+			"container_group": "cabinet_general"
 		},
 		"categories": [
 			"Urban",
@@ -1124,9 +1110,6 @@
 		}
 	},
 	{
-		"Function": {
-
-		},
 		"categories": [
 			"Urban"
 		],

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -130,7 +130,7 @@
 		"support_shape": {
 			"color": "653102ff",
 			"height": 0.5,
-			"radius_scale": 60,
+			"radius_scale": 50,
 			"shape": "Cylinder",
 			"transparent": false
 		},
@@ -164,7 +164,7 @@
 		"support_shape": {
 			"color": "9b522fff",
 			"height": 0.5,
-			"radius_scale": 60,
+			"radius_scale": 50,
 			"shape": "Cylinder",
 			"transparent": false
 		},
@@ -200,7 +200,7 @@
 		"support_shape": {
 			"color": "9e5137ff",
 			"height": 0.5,
-			"radius_scale": 60,
+			"radius_scale": 50,
 			"shape": "Cylinder",
 			"transparent": false
 		},

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -120,19 +120,19 @@
 				"id": "bullet_9mm",
 				"max": 20,
 				"min": 10,
-				"probability": 20
+				"probability": 10
 			},
 			{
 				"id": "pistol_magazine",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 10
 			},
 			{
 				"id": "pistol_9mm",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 10
 			},
 			{
 				"id": "bottle_plastic_water",

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -245,7 +245,8 @@
 					"cash_register",
 					"shopping_cart",
 					"display_case",
-					"vending_machine"
+					"vending_machine",
+					"toilet_00"
 				]
 			}
 		},

--- a/Mods/Core/Maps/forest_basic_00.json
+++ b/Mods/Core/Maps/forest_basic_00.json
@@ -97,7 +97,7 @@
 			"spawn_chance": 100,
 			"tiles": [
 				{
-					"count": 250,
+					"count": 200,
 					"id": "null"
 				}
 			]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -224,7 +224,7 @@ func _on_save_button_button_up():
 	handle_disassembly_option()
 	dfurniture.on_data_changed(olddata)
 	data_changed.emit()
-	olddata = dfurniture.duplicate(true)
+	olddata = DFurniture.new(dfurniture.get_data().duplicate(true))
 
 
 # Function to handle saving or erasing the support shape data

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -60,15 +60,13 @@ signal data_changed()
 
 
 var olddata: DFurniture # Remember what the value of the data was before editing
-# The data that represents this furniture
-# The data is selected from the Gamedata.data.furniture.data array
-# based on the ID that the user has selected in the content editor
+# The DFurniture that represents this furniture
 var dfurniture: DFurniture:
 	set(value):
 		dfurniture = value
 		load_furniture_data()
-		furnitureSelector.sprites_collection = Gamedata.furnitures.furnituresprites.values()
-		olddata = dfurniture.duplicate(true)
+		furnitureSelector.sprites_collection = Gamedata.furnitures.sprites
+		olddata = DFurniture.new(dfurniture.get_data().duplicate(true))
 
 
 func _ready():
@@ -106,7 +104,7 @@ func load_furniture_data():
 	if doorOptionButton:
 		update_door_option(dfurniture.function.door)
 
-	if not dfurniture.destruction.is_empty():
+	if not dfurniture.destruction.get_data().is_empty():
 		canDestroyCheckbox.button_pressed = true
 		destructionTextEdit.set_text(dfurniture.destruction.group)
 		destructionImageDisplay.texture = Gamedata.furnitures.sprite_by_file(dfurniture.destruction.sprite)
@@ -116,7 +114,7 @@ func load_furniture_data():
 		canDestroyCheckbox.button_pressed = false
 		set_visibility_for_children(destructionTextEdit, false)
 
-	if not dfurniture.disassembly.is_empty():
+	if not dfurniture.disassembly.get_data().is_empty():
 		canDisassembleCheckbox.button_pressed = true
 		disassemblyTextEdit.set_text(dfurniture.disassembly.group)
 		disassemblyImageDisplay.texture = Gamedata.furnitures.sprite_by_file(dfurniture.disassembly.sprite)
@@ -127,9 +125,9 @@ func load_furniture_data():
 		set_visibility_for_children(disassemblyTextEdit, false)
 
 	# Load container data if it exists within the 'Function' property
-	if not dfurniture.function.container.is_empty():
+	if dfurniture.function.is_container:
 		containerCheckBox.button_pressed = true  # Check the container checkbox
-		var itemgroup: String = dfurniture.function.container.get("itemgroup", "")
+		var itemgroup: String = dfurniture.function.container_group
 		if not itemgroup == "":
 			containerTextEdit.set_text(itemgroup)
 		else:
@@ -159,7 +157,7 @@ func load_support_shape_option():
 	heigth_spin_box.value = supportshape.height
 
 	if shape == "Box":
-		width_scale_spin_box.value = supportshape.height.width_scale
+		width_scale_spin_box.value = supportshape.width_scale
 		depth_scale_spin_box.value = supportshape.depth_scale
 		width_scale_spin_box.visible = true
 		depth_scale_spin_box.visible = true
@@ -208,10 +206,7 @@ func update_sprite_texture_rect(texture: Texture):
 		sprite_texture_rect.texture = texture
 
 
-# This function takes all data from the form elements and stores them in the contentData.
-# Since contentData is a reference to an item in Gamedata.data.furniture.data,
-# the central array for furnituredata is updated with the changes as well.
-# The function will signal to Gamedata that the data has changed and needs to be saved.
+# This function takes all data from the form elements and stores them in the dfurniture.
 func _on_save_button_button_up():
 	dfurniture.spriteid = imageNameStringLabel.text
 	dfurniture.name = NameTextEdit.text

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -55,7 +55,7 @@ func loadFurniture():
 	add_child(newFurnitureList)
 	newFurnitureList.is_collapsed = load_collapse_state("Furniture")
 
-	for furniture in furnitureList:
+	for furniture in furnitureList.values():
 		var texture: Texture = furniture.sprite
 		var brushInstance = tileBrush.instantiate()
 		brushInstance.set_tile_texture(texture)

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -48,25 +48,22 @@ func loadMobs():
 
 
 func loadFurniture():
-	var furnitureList: Array = Gamedata.data.furniture.data 
+	var furnitureList: Dictionary = Gamedata.furnitures.get_furnitures()
 	var newFurnitureList: Control = scrolling_Flow_Container.instantiate()
 	newFurnitureList.header = "Furniture"
 	newFurnitureList.collapse_button_pressed.connect(_on_collapse_button_pressed)
 	add_child(newFurnitureList)
 	newFurnitureList.is_collapsed = load_collapse_state("Furniture")
 
-	for item in furnitureList:
-		if item.has("sprite"):
-			var imagefileName: String = item["sprite"]
-			imagefileName = imagefileName.get_file()
-			var texture: Resource = Gamedata.data.furniture.sprites[imagefileName]
-			var brushInstance = tileBrush.instantiate()
-			brushInstance.set_tile_texture(texture)
-			brushInstance.entityID = item.id
-			brushInstance.tilebrush_clicked.connect(tilebrush_clicked)
-			brushInstance.entityType = "furniture"
-			newFurnitureList.add_content_item(brushInstance)
-			instanced_brushes.append(brushInstance)
+	for furniture in furnitureList:
+		var texture: Texture = furniture.sprite
+		var brushInstance = tileBrush.instantiate()
+		brushInstance.set_tile_texture(texture)
+		brushInstance.entityID = furniture.id
+		brushInstance.tilebrush_clicked.connect(tilebrush_clicked)
+		brushInstance.entityType = "furniture"
+		newFurnitureList.add_content_item(brushInstance)
+		instanced_brushes.append(brushInstance)
 
 
 # this function will read all files in Gamedata.data.tiles.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -391,7 +391,7 @@ func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 			"mob":
 				properties["texture"] = Gamedata.get_sprite_by_id(Gamedata.data.mobs, entity["id"])
 			"furniture":
-				properties["texture"] = Gamedata.get_sprite_by_id(Gamedata.data.furniture, entity["id"])
+				properties["texture"] = Gamedata.furnitures.sprite_by_id(entity["id"])
 			"itemgroup":
 				properties["texture"] = Gamedata.get_sprite_by_id(Gamedata.data.itemgroups, entity["id"])
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -26,7 +26,7 @@ var tileData: Dictionary = defaultTileData.duplicate():
 			elif tileData.has("furniture"):
 				if tileData.furniture.has("rotation"):
 					$ObjectSprite.rotation_degrees = tileData.furniture.rotation
-				$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture, tileData.furniture.id)
+				$ObjectSprite.texture = Gamedata.furnitures.sprite_by_id(tileData.furniture.id)
 				$ObjectSprite.show()
 			elif tileData.has("itemgroups"):
 				var random_itemgroup: String = tileData.itemgroups.pick_random()
@@ -116,7 +116,7 @@ func set_furniture_id(id: String) -> void:
 			tileData.furniture.id = id
 		else:
 			tileData.furniture = {"id": id}
-		$ObjectSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture, id)
+		$ObjectSprite.texture = Gamedata.furnitures.sprite_by_id(id)
 		$ObjectSprite.show()
 	set_tooltip()
 
@@ -167,10 +167,8 @@ func set_tile_itemgroups(itemgroups: Array) -> void:
 		if itemgroups.is_empty(): # Only erase the itemgroups property from furniture
 			tileData.furniture.erase("itemgroups")
 		else:
-			var furnituredata = Gamedata.get_data_by_id(Gamedata.data.furniture, tileData.furniture.id)
-			var containervalue = Helper.json_helper.get_nested_data(furnituredata, "Function.container")
-
-			if not itemgroups.is_empty() and typeof(containervalue) == TYPE_DICTIONARY:
+			var furniture: DFurniture = Gamedata.furnitures.by_id(tileData.furniture.id)
+			if not itemgroups.is_empty() and furniture.function.is_container:
 				tileData.furniture.itemgroups = itemgroups
 			else:
 				tileData.furniture.erase("itemgroups")
@@ -318,11 +316,11 @@ func set_tooltip() -> void:
 
 
 # Sets the visibility of the area sprite based on the provided area name and visibility flag
-func set_area_sprite_visibility(is_visible: bool, area_name: String) -> void:
+func set_area_sprite_visibility(isvisible: bool, area_name: String) -> void:
 	if tileData.has("areas"):
 		for area in tileData["areas"]:
 			if area["id"] == area_name:
-				$AreaSprite.visible = is_visible
+				$AreaSprite.visible = isvisible
 				return
 	$AreaSprite.visible = false
 

--- a/Scenes/ContentManager/ModMaintenance/Scripts/changepropertytypescript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/changepropertytypescript.gd
@@ -45,8 +45,6 @@ func get_type_data() -> Variant:
 	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
 	if selected_type == "Item":
 		return Gamedata.data.items
-	elif selected_type == "Furniture":
-		return Gamedata.data.furniture
 	elif selected_type == "Itemgroup":
 		return Gamedata.data.itemgroups
 	elif selected_type == "Mob":

--- a/Scenes/ContentManager/ModMaintenance/Scripts/exportdatascript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/exportdatascript.gd
@@ -66,8 +66,6 @@ func get_type_data() -> Variant:
 	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
 	if selected_type == "Item":
 		return Gamedata.data.items
-	elif selected_type == "Furniture":
-		return Gamedata.data.furniture
 	elif selected_type == "Itemgroup":
 		return Gamedata.data.itemgroups
 	elif selected_type == "Mob":

--- a/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
@@ -78,8 +78,6 @@ func get_type_data() -> Variant:
 	var selected_type = typesOptionButton.get_item_text(typesOptionButton.selected)
 	if selected_type == "Item":
 		return Gamedata.data.items
-	elif selected_type == "Furniture":
-		return Gamedata.data.furniture
 	elif selected_type == "Itemgroup":
 		return Gamedata.data.itemgroups
 	elif selected_type == "Mob":

--- a/Scenes/ContentManager/ModMaintenance/changepropertytypescript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/changepropertytypescript.tscn
@@ -52,16 +52,14 @@ text = "Selected type:"
 
 [node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2
-item_count = 4
+item_count = 3
 selected = 0
 popup/item_0/text = "Item"
 popup/item_0/id = 0
-popup/item_1/text = "Furniture"
-popup/item_1/id = 1
-popup/item_2/text = "Itemgroup"
-popup/item_2/id = 3
-popup/item_3/text = "Mob"
-popup/item_3/id = 2
+popup/item_1/text = "Itemgroup"
+popup/item_1/id = 3
+popup/item_2/text = "Mob"
+popup/item_2/id = 2
 
 [node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2

--- a/Scenes/ContentManager/ModMaintenance/exportdatascript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/exportdatascript.tscn
@@ -50,20 +50,18 @@ text = "Selected type:"
 [node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2
 tooltip_text = "Select the type that you want to export the data of"
-item_count = 6
+item_count = 5
 selected = 0
 popup/item_0/text = "Item"
 popup/item_0/id = 0
-popup/item_1/text = "Furniture"
-popup/item_1/id = 1
-popup/item_2/text = "Itemgroup"
-popup/item_2/id = 3
-popup/item_3/text = "Mob"
-popup/item_3/id = 2
-popup/item_4/text = "Tile"
-popup/item_4/id = 4
-popup/item_5/text = "Map"
-popup/item_5/id = 5
+popup/item_1/text = "Itemgroup"
+popup/item_1/id = 3
+popup/item_2/text = "Mob"
+popup/item_2/id = 2
+popup/item_3/text = "Tile"
+popup/item_3/id = 4
+popup/item_4/text = "Map"
+popup/item_4/id = 5
 
 [node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2

--- a/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
@@ -49,18 +49,16 @@ text = "Selected type:"
 
 [node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2
-item_count = 5
+item_count = 4
 selected = 0
 popup/item_0/text = "Item"
 popup/item_0/id = 0
-popup/item_1/text = "Furniture"
-popup/item_1/id = 1
-popup/item_2/text = "Itemgroup"
-popup/item_2/id = 3
-popup/item_3/text = "Mob"
-popup/item_3/id = 2
-popup/item_4/text = "Tile"
-popup/item_4/id = 4
+popup/item_1/text = "Itemgroup"
+popup/item_1/id = 3
+popup/item_2/text = "Mob"
+popup/item_2/id = 2
+popup/item_3/text = "Tile"
+popup/item_3/id = 4
 
 [node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -246,7 +246,13 @@ func _drop_data(newpos, data) -> void:
 # Helper function to create a preview Control for dragging
 func _create_drag_preview(item_id: String) -> Control:
 	var preview = TextureRect.new()
-	preview.texture = Gamedata.get_sprite_by_id(contentData, item_id)
+	# HACK Hacky exception for furniture, need to find a better solution
+	if contentData == {"furnitures": true}:
+		preview.texture = Gamedata.furnitures.sprite_by_id(item_id)
+	if contentData == {"maps": true}:
+		preview.texture = Gamedata.maps.by_id(item_id).sprite
+	else:
+		preview.texture = Gamedata.get_sprite_by_id(contentData, item_id)
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview
 	return preview
 
@@ -336,7 +342,7 @@ func load_map_list():
 # Load the furniture list
 func load_furnitures_list():
 	var furniturelist: Dictionary = Gamedata.furnitures.get_furnitures()
-	for furniture: DFurniture in furniturelist:
+	for furniture: DFurniture in furniturelist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(furniture.id)
 		# Add the ID as metadata which can be used to load the item data

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -25,7 +25,8 @@ func _ready():
 	load_content_list(Gamedata.data.items, "Items")
 	load_content_list(Gamedata.data.tiles, "Terrain Tiles")
 	load_content_list(Gamedata.data.mobs, "Mobs")
-	load_content_list(Gamedata.data.furniture, "Furniture")
+	# Hacky exception for furnitures, need to find a better solution
+	load_content_list({"furnitures": true}, "Furniture")
 	load_content_list(Gamedata.data.itemgroups, "Item Groups")
 	load_content_list(Gamedata.data.wearableslots, "Wearable Slots")
 	load_content_list(Gamedata.data.stats, "Stats")
@@ -62,14 +63,15 @@ func _on_content_item_activated(data: Dictionary, itemID: String):
 		return
 	if data == Gamedata.data.tiles:
 		instantiate_editor(data, itemID, terrainTileEditor)
-	if data == Gamedata.data.furniture:
+	if data == {"furnitures": true}:
+		# HACK Hacky exception for maps, need to find a better solution
 		instantiate_editor(data, itemID, furnitureEditor)
 	if data == Gamedata.data.items:
 		instantiate_editor(data, itemID, itemEditor)
 	if data == Gamedata.data.mobs:
 		instantiate_editor(data, itemID, mobEditor)
 	if data == {"maps": true}:
-		# Hacky exception for maps, need to find a better solution
+		# HACK Hacky exception for maps, need to find a better solution
 		instantiate_editor(data, itemID, mapEditor)
 	if data == Gamedata.data.tacticalmaps:
 		instantiate_editor(data, itemID, tacticalmapEditor)
@@ -107,6 +109,9 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 	
 	if data == {"maps": true}:# HACK Hacky exception for maps, need to find a better solution
 		newContentEditor.currentMap = Gamedata.maps.by_id(itemID)
+		return
+	if data == {"furnitures": true}:# HACK Hacky exception for furniture, need to find a better solution
+		newContentEditor.currentFurniture = Gamedata.furnitures.by_id(itemID)
 		return
 	if data.dataPath.ends_with(".json"):
 		var itemdata: Dictionary = data.data[Gamedata.get_array_index_by_id(data, itemID)]

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -111,7 +111,7 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 		newContentEditor.currentMap = Gamedata.maps.by_id(itemID)
 		return
 	if data == {"furnitures": true}:# HACK Hacky exception for furniture, need to find a better solution
-		newContentEditor.currentFurniture = Gamedata.furnitures.by_id(itemID)
+		newContentEditor.dfurniture = Gamedata.furnitures.by_id(itemID)
 		return
 	if data.dataPath.ends_with(".json"):
 		var itemdata: Dictionary = data.data[Gamedata.get_array_index_by_id(data, itemID)]

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -230,7 +230,7 @@ func add_furnitures_to_new_block():
 		
 		# Insert delay after every n blocks, evenly spreading the delay
 		if i % delay_every_n_furniture == 0 and i != 0: # Avoid delay at the very start
-			OS.delay_msec(10) # Adjust delay time as needed
+			OS.delay_msec(100) # Adjust delay time as needed
 
 	# Optional: One final delay after the last block if the total_blocks is not perfectly divisible by delay_every_n_blocks
 	if total_furniture % delay_every_n_furniture != 0:
@@ -337,7 +337,7 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 		
 		# Insert delay after every n furniture, evenly spreading the delay
 		if i % delay_every_n_furniture == 0 and i != 0: # Avoid delay at the very start
-			OS.delay_msec(10) # Adjust delay time as needed
+			OS.delay_msec(100) # Adjust delay time as needed
 
 	# Optional: One final delay after the last furniture if the total_furniture is not perfectly divisible by delay_every_n_furniture
 	if total_furniture % delay_every_n_furniture != 0:

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -219,14 +219,13 @@ func add_furnitures_to_new_block():
 		var furnitureJSON: Dictionary = Gamedata.get_data_by_id(\
 			Gamedata.data.furniture, furnituremapjson.id)
 		if furnitureJSON.has("moveable") and furnitureJSON.moveable:
-			newFurniture = FurniturePhysics.new()
+			newFurniture = FurniturePhysics.new(mypos+furniturepos, furnituremapjson)
 			newFurniture.current_chunk = self
 			furniturepos.y += 0.2 # Make sure it's not in a block and let it fall
 		else:
-			newFurniture = FurnitureStatic.new()
+			newFurniture = FurnitureStatic.new(mypos+furniturepos, furnituremapjson)
 		
 		add_furniture_to_chunk(newFurniture)
-		newFurniture.construct_self(mypos+furniturepos, furnituremapjson)
 		level_manager.add_child.call_deferred(newFurniture)
 		
 		# Insert delay after every n blocks, evenly spreading the delay
@@ -323,18 +322,17 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 		Gamedata.data.furniture, furnitureData.id)
 		mutex.unlock()
 
-		if furnitureJSON.has("moveable") and furnitureJSON.moveable:
-			newFurniture = FurniturePhysics.new()
-			newFurniture.current_chunk = self
-		else:
-			newFurniture = FurnitureStatic.new()
-
-		add_furniture_to_chunk(newFurniture)
-		
 		# We can't set it's position until after it's in the scene tree 
 		# so we only save the position to a variable and pass it to the furniture
 		var furniturepos: Vector3 =  Vector3(furnitureData.global_position_x,furnitureData.global_position_y,furnitureData.global_position_z)
-		newFurniture.construct_self(furniturepos,furnitureData)
+		
+		if furnitureJSON.has("moveable") and furnitureJSON.moveable:
+			newFurniture = FurniturePhysics.new(furniturepos,furnitureData)
+			newFurniture.current_chunk = self
+		else:
+			newFurniture = FurnitureStatic.new(furniturepos,furnitureData)
+
+		add_furniture_to_chunk(newFurniture)
 		level_manager.add_child.call_deferred(newFurniture)
 		
 		# Insert delay after every n furniture, evenly spreading the delay

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -216,9 +216,8 @@ func add_furnitures_to_new_block():
 		var furnituremapjson: Dictionary = furniture.json
 		var furniturepos: Vector3 = furniture.pos
 		var newFurniture: Node3D
-		var furnitureJSON: Dictionary = Gamedata.get_data_by_id(\
-			Gamedata.data.furniture, furnituremapjson.id)
-		if furnitureJSON.has("moveable") and furnitureJSON.moveable:
+		var dfurniture: DFurniture = Gamedata.furnitures.by_id(furnituremapjson.id)
+		if dfurniture.moveable:
 			newFurniture = FurniturePhysics.new(mypos+furniturepos, furnituremapjson)
 			newFurniture.current_chunk = self
 			furniturepos.y += 0.2 # Make sure it's not in a block and let it fall
@@ -318,15 +317,14 @@ func add_furnitures_to_map(furnitureDataArray: Array):
 	for i in range(total_furniture):
 		var furnitureData = furnitureDataArray[i]
 		mutex.lock()
-		var furnitureJSON: Dictionary = Gamedata.get_data_by_id(
-		Gamedata.data.furniture, furnitureData.id)
+		var dfurniture: DFurniture = Gamedata.furnitures.by_id(furnitureData.id)
 		mutex.unlock()
 
 		# We can't set it's position until after it's in the scene tree 
 		# so we only save the position to a variable and pass it to the furniture
 		var furniturepos: Vector3 =  Vector3(furnitureData.global_position_x,furnitureData.global_position_y,furnitureData.global_position_z)
 		
-		if furnitureJSON.has("moveable") and furnitureJSON.moveable:
+		if dfurniture.moveable:
 			newFurniture = FurniturePhysics.new(furniturepos,furnitureData)
 			newFurniture.current_chunk = self
 		else:

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -18,6 +18,42 @@ var corpse_scene: PackedScene = preload("res://Defaults/Mobs/mob_corpse.tscn")
 var current_health: float = 10.0
 
 
+# Function to make it's own shape and texture based on an id and position
+# This function is called by a Chunk to construct it's blocks
+func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary):
+	furnitureJSON = newFurnitureJSON
+	furnitureJSONData = Gamedata.get_data_by_id(Gamedata.data.furniture,furnitureJSON.id)
+	# Position furniture at the center of the block by default
+	furnitureposition = furniturepos
+	# Only previously saved furniture will have the global_position_x key. They do not need to be raised
+	if not newFurnitureJSON.has("global_position_x"):
+		furnitureposition.y += 0.5 # Move the furniture to slightly above the block 
+	add_to_group("furniture")
+
+	var furnitureSprite: Texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture,furnitureJSON.id)
+	set_sprite(furnitureSprite)
+	
+	furniturerotation = furnitureJSON.get("rotation", 0)
+	mass = furnitureJSONData.get("weight", 1)
+	# Set the properties we need
+	#linear_damp = 59
+	angular_damp = 59
+	axis_lock_angular_x = true
+	axis_lock_angular_z = true
+	# Set collision layer to layer 4 (moveable obstacles layer)
+	collision_layer = 1 << 3  # Layer 4 is 1 << 3
+
+	# Set collision mask to include layers 1, 2, 3, 4, 5, and 6
+	collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5)
+	# Explanation:
+	# - 1 << 0: Layer 1 (player layer)
+	# - 1 << 1: Layer 2 (enemy layer)
+	# - 1 << 2: Layer 3 (movable obstacles layer)
+	# - 1 << 3: Layer 4 (static obstacles layer)
+	# - 1 << 4: Layer 5 (friendly projectiles layer)
+	# - 1 << 5: Layer 6 (enemy projectiles layer)
+
+
 func _ready() -> void:
 	set_position(furnitureposition)
 	set_new_rotation(furniturerotation)
@@ -100,41 +136,6 @@ func get_my_rotation() -> int:
 	else:
 		return rot-0
 
-
-# Function to make it's own shape and texture based on an id and position
-# This function is called by a Chunk to construct it's blocks
-func construct_self(furniturepos: Vector3, newFurnitureJSON: Dictionary):
-	furnitureJSON = newFurnitureJSON
-	furnitureJSONData = Gamedata.get_data_by_id(Gamedata.data.furniture,furnitureJSON.id)
-	# Position furniture at the center of the block by default
-	furnitureposition = furniturepos
-	# Only previously saved furniture will have the global_position_x key. They do not need to be raised
-	if not newFurnitureJSON.has("global_position_x"):
-		furnitureposition.y += 0.5 # Move the furniture to slightly above the block 
-	add_to_group("furniture")
-
-	var furnitureSprite: Texture = Gamedata.get_sprite_by_id(Gamedata.data.furniture,furnitureJSON.id)
-	set_sprite(furnitureSprite)
-	
-	furniturerotation = furnitureJSON.get("rotation", 0)
-	mass = furnitureJSONData.get("weight", 1)
-	# Set the properties we need
-	#linear_damp = 59
-	angular_damp = 59
-	axis_lock_angular_x = true
-	axis_lock_angular_z = true
-	# Set collision layer to layer 4 (moveable obstacles layer)
-	collision_layer = 1 << 3  # Layer 4 is 1 << 3
-
-	# Set collision mask to include layers 1, 2, 3, 4, 5, and 6
-	collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5)
-	# Explanation:
-	# - 1 << 0: Layer 1 (player layer)
-	# - 1 << 1: Layer 2 (enemy layer)
-	# - 1 << 2: Layer 3 (movable obstacles layer)
-	# - 1 << 3: Layer 4 (static obstacles layer)
-	# - 1 << 4: Layer 5 (friendly projectiles layer)
-	# - 1 << 5: Layer 6 (enemy projectiles layer)
 
 
 # Check if we crossed the chunk boundary and update our association with the chunks

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -21,6 +21,7 @@ var current_health: float = 10.0
 # Function to make it's own shape and texture based on an id and position
 # This function is called by a Chunk to construct it's blocks
 func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary):
+	freeze = true # Prevent physics from occurring before it's positioned
 	furnitureJSON = newFurnitureJSON
 	furnitureJSONData = Gamedata.get_data_by_id(Gamedata.data.furniture,furnitureJSON.id)
 	# Position furniture at the center of the block by default
@@ -60,11 +61,14 @@ func _ready() -> void:
 	# Add the container as a child on the same position as this furniture
 	add_container(Vector3(0,0,0))
 	last_rotation = furniturerotation
+	freeze = false # Now that it's positioned, unfreeze it
 
 
 # Keep track of the furniture's position and rotation. It starts at 0,0,0 and the moves to it's
 # assigned position after a timer. Until that has happened, we don't need to keep track of it's position
 func _physics_process(_delta) -> void:
+	if freeze: # Don't care about the position changing when it's frozen
+		return
 	# We only care about x and z. A changed y only means it's moving up or down.
 	var x_changed = not global_transform.origin.x == furnitureposition.x 
 	var z_changed = not global_transform.origin.z == furnitureposition.z

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -11,6 +11,7 @@ var dfurniture: DFurniture # The json that defines this furniture's basics in ge
 var sprite: Sprite3D = null
 var last_rotation: int
 var current_chunk: Chunk
+var in_starting_chunk: bool = false
 var container: ContainerItem = null # Reference to the container, if this furniture acts as one
 
 var is_animating_hit: bool = false # flag to prevent multiple blink actions
@@ -60,13 +61,30 @@ func _ready() -> void:
 	# Add the container as a child on the same position as this furniture
 	add_container(Vector3(0,0,0))
 	last_rotation = furniturerotation
+
+
+func is_in_starting_chunk():
+	if global_transform.origin.x < current_chunk.mypos.x:
+		in_starting_chunk = false
+		return
+	if global_transform.origin.x > current_chunk.mypos.x+32:
+		in_starting_chunk = false
+		return
+	if global_transform.origin.z < current_chunk.mypos.z:
+		in_starting_chunk = false
+		return
+	if global_transform.origin.z > current_chunk.mypos.z+32:
+		in_starting_chunk = false
+		return
+	in_starting_chunk = true
 	freeze = false # Now that it's positioned, unfreeze it
 
 
 # Keep track of the furniture's position and rotation. It starts at 0,0,0 and the moves to it's
 # assigned position after a timer. Until that has happened, we don't need to keep track of it's position
 func _physics_process(_delta) -> void:
-	if freeze: # Don't care about the position changing when it's frozen
+	if freeze or not in_starting_chunk: # Don't care about the position changing when it's frozen
+		is_in_starting_chunk()
 		return
 	# We only care about x and z. A changed y only means it's moving up or down.
 	var x_changed = not global_transform.origin.x == furnitureposition.x 

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -46,15 +46,13 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary):
 	var spriteWidth = dfurniture.sprite.get_width() / 100.0 # Convert pixels to meters (assuming 100 pixels per meter)
 	var spriteDepth = dfurniture.sprite.get_height() / 100.0 # Convert pixels to meters
 	
-	var newRot = furnitureJSON.get("rotation", 0)
+	furniturerotation = furnitureJSON.get("rotation", 0)
 
-	# Apply edge snapping if necessary. Previously saved furniture have the global_position_x. 
-	# They do not need to apply edge snapping again
-	if edgeSnappingDirection != "None" and not newFurnitureJSON.has("global_position_x"):
+	# Apply edge snapping if necessary. Previously saved does not need to apply edge snapping again
+	if edgeSnappingDirection != "None" and is_new_furniture():
 		furnitureposition = apply_edge_snapping(furnitureposition, edgeSnappingDirection, \
-		spriteWidth, spriteDepth, newRot, furniturepos)
+		spriteWidth, spriteDepth, furniturerotation, furniturepos)
 
-	furniturerotation = newRot
 	# Set collision layer to layer 3 (static obstacles layer)
 	collision_layer = 1 << 2  # Layer 3 is 1 << 2
 

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -313,29 +313,39 @@ func get_data() -> Dictionary:
 	return newfurniturejson
 
 
+
 # If this furniture is a container, it will add a container node to the furniture.
 func add_container():
 	if dfurniture.function.is_container:
-		var height = dfurniture.support_shape.height
 		# Should be slightly above mesh so we add 0.01
-		var pos: Vector3 = Vector3(0, height + 0.01, 0) if height > 0 else Vector3(0, 0.51, 0)
 		var newcontainerjson: Dictionary = {
-			"global_position_x": pos.x,
-			"global_position_y": pos.y,
-			"global_position_z": pos.z
+			"global_position_x": 0,
+			"global_position_y": dfurniture.support_shape.height + 0.01,
+			"global_position_z": 0
 		}
-		var newfurniture: bool = is_new_furniture()
-		if newfurniture:
-			newcontainerjson["itemgroups"] = [populate_container_from_itemgroup()]
-		container = ContainerItem.new(newcontainerjson)
-		if not newfurniture:
-			deserialize_container_data()
-		add_child(container)
+		if is_new_furniture():
+			add_new_container(newcontainerjson)
+		else:
+			add_existing_container(newcontainerjson)
+
+
+# Handle the case where the furniture is new
+func add_new_container(newcontainerjson: Dictionary):
+	newcontainerjson["itemgroups"] = [populate_container_from_itemgroup()]
+	container = ContainerItem.new(newcontainerjson)
+	add_child(container)
+
+
+# Handle the case where the furniture already exists
+func add_existing_container(newcontainerjson: Dictionary):
+	container = ContainerItem.new(newcontainerjson)
+	deserialize_container_data()
+	add_child(container)
 
 
 # If there is an itemgroup assigned to the furniture, it will be added to the container.
-# It will check both furnitureJSON and furnitureJSONData for itemgroup information.
-# The container will be filled with items from the itemgroup.
+# It will check both furnitureJSON and dfurniture for itemgroup information.
+# The function will return the id of the itemgroup so that the container may use it
 func populate_container_from_itemgroup() -> String:
 	# Check if furnitureJSON contains an itemgroups array
 	if furnitureJSON.has("itemgroups"):

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -7,8 +7,8 @@ extends StaticBody3D
 
 
 # Since we can't access the scene tree in a thread, we store the position in a variable and read that
-var furnitureposition: Vector3
-var furniturerotation: int
+var furniture_position: Vector3
+var furniture_rotation: int
 var furnitureJSON: Dictionary # The json that defines this furniture on the map
 var dfurniture: DFurniture # The json that defines this furniture's basics in general
 var sprite: Sprite3D = null
@@ -30,29 +30,58 @@ var original_position: Vector3 # To return to original position after blinking
 func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary):
 	furnitureJSON = newFurnitureJSON
 	# Position furniture at the center of the block by default
-	furnitureposition = furniturepos
+	furniture_position = furniturepos
+	furniture_rotation = furnitureJSON.get("rotation", 0)
+	dfurniture = Gamedata.furnitures.by_id(furnitureJSON.id)
+	
 	# Previously saved furniture do not need to be raised
 	if is_new_furniture():
-		furnitureposition.y += 0.025 # Move the furniture to slightly above the block 
+		furniture_position.y += 0.025 # Move the furniture to slightly above the block 
 	add_to_group("furniture")
 
-	# Find out if we need to apply edge snapping
-	dfurniture = Gamedata.furnitures.by_id(furnitureJSON.id)
-	var edgeSnappingDirection = dfurniture.edgesnapping
-
 	set_sprite(dfurniture.sprite)
-	
-	# Calculate the size of the furniture based on the sprite dimensions
-	var spriteWidth = dfurniture.sprite.get_width() / 100.0 # Convert pixels to meters (assuming 100 pixels per meter)
-	var spriteDepth = dfurniture.sprite.get_height() / 100.0 # Convert pixels to meters
-	
-	furniturerotation = furnitureJSON.get("rotation", 0)
+	apply_edge_snapping_if_needed()
+	set_collision_layers()
 
-	# Apply edge snapping if necessary. Previously saved does not need to apply edge snapping again
-	if edgeSnappingDirection != "None" and is_new_furniture():
-		furnitureposition = apply_edge_snapping(furnitureposition, edgeSnappingDirection, \
-		spriteWidth, spriteDepth, furniturerotation, furniturepos)
 
+func _ready():
+	position = furniture_position
+	set_new_rotation(furniture_rotation)
+	check_door_functionality()
+	update_door_visuals()
+	adjust_sprite_and_mesh_height()
+	original_position = sprite.global_transform.origin
+
+
+# Adjust the sprite and mesh heights based on support shape
+func adjust_sprite_and_mesh_height():
+	var new_height = dfurniture.support_shape.height
+	if new_height:
+		sprite.position.y = 0.01 + new_height
+		mesh_instance.position.y = new_height / 2
+		add_container(Vector3(0, new_height + 0.01, 0)) # Should be slightly above mesh so we add 0.01
+	else:
+		# The default size is 0.5
+		sprite.position.y = 0.51 # Slightly above the default size
+		mesh_instance.position.y = 0.25 # Half the default size
+		# Add the container as a child on the same position as this furniture
+		add_container(Vector3(0, 0.51, 0)) # Slightly above default size
+
+
+# Apply edge snapping if necessary. Previously saved does not need to apply edge snapping again
+func apply_edge_snapping_if_needed():
+	if dfurniture.edgesnapping != "None" and is_new_furniture():
+		# Calculate the size of the furniture based on the sprite dimensions
+		var sprite_width = dfurniture.sprite.get_width() / 100.0 # Convert pixels to meters 
+		var sprite_depth = dfurniture.sprite.get_height() / 100.0 # (assuming 100 pixels per meter)
+		furniture_position = apply_edge_snapping(
+			furniture_position, dfurniture.edgesnapping, 
+			sprite_width, sprite_depth, furniture_rotation, furniture_position
+		)
+
+
+# Set collision layers and masks
+func set_collision_layers():
 	# Set collision layer to layer 3 (static obstacles layer)
 	collision_layer = 1 << 2  # Layer 3 is 1 << 2
 
@@ -65,27 +94,6 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary):
 	# - 1 << 3: Layer 4 (static obstacles layer)
 	# - 1 << 4: Layer 5 (friendly projectiles layer)
 	# - 1 << 5: Layer 6 (enemy projectiles layer)
-
-
-func _ready():
-	position = furnitureposition
-	set_new_rotation(furniturerotation)
-	check_door_functionality()
-	update_door_visuals()
-
-	# Raise the sprite to the height of new_y
-	var newheight = dfurniture.support_shape.height
-	if newheight:
-		sprite.position.y = 0.01 + newheight # Should be slightly above mesh so we add 0.01
-		mesh_instance.position.y = newheight/2
-		add_container(Vector3(0, newheight+0.01, 0)) # Should be slightly above mesh so we add 0.01
-	else:
-		# The default size is 0.5
-		sprite.position.y = 0.51 # Slightly above the default size
-		mesh_instance.position.y =  0.25 # Half the default size
-		# Add the container as a child on the same position as this furniture
-		add_container(Vector3(0, 0.51, 0)) # Slightly above default size
-	original_position = sprite.global_transform.origin
 
 
 # Check if this furniture acts as a door
@@ -233,7 +241,7 @@ func set_new_rotation(amount: int):
 
 
 func get_my_rotation() -> int:
-	return furniturerotation
+	return furniture_rotation
 
 
 # If edge snapping has been set in the furniture editor, we will apply it here.
@@ -285,9 +293,9 @@ func get_data() -> Dictionary:
 	var newfurniturejson = {
 		"id": furnitureJSON.id,
 		"moveable": false,
-		"global_position_x": furnitureposition.x,
-		"global_position_y": furnitureposition.y,
-		"global_position_z": furnitureposition.z,
+		"global_position_x": furniture_position.x,
+		"global_position_y": furniture_position.y,
+		"global_position_z": furniture_position.z,
 		"rotation": get_my_rotation(),
 	}
 	

--- a/Scripts/FurnitureStatic.gd
+++ b/Scripts/FurnitureStatic.gd
@@ -296,18 +296,18 @@ func get_data() -> Dictionary:
 	if is_door:
 		newfurniturejson["Function"] = {"door": door_state}
 	
-		# Check if this furniture has a container attached and if it has items
-		if container:
-			# Initialize the 'Function' sub-dictionary if not already present
-			if "Function" not in newfurniturejson:
-				newfurniturejson["Function"] = {}
-			var item_ids = container.get_item_ids()
-			if item_ids.size() > 0:
-				var containerdata = container.get_inventory().serialize()
-				newfurniturejson["Function"]["container"] = {"items": containerdata}
-			else:
-				# No items in the container, store the container as empty
-				newfurniturejson["Function"]["container"] = {}
+	# Check if this furniture has a container attached and if it has items
+	if container:
+		# Initialize the 'Function' sub-dictionary if not already present
+		if "Function" not in newfurniturejson:
+			newfurniturejson["Function"] = {}
+		var item_ids = container.get_item_ids()
+		if item_ids.size() > 0:
+			var containerdata = container.get_inventory().serialize()
+			newfurniturejson["Function"]["container"] = {"items": containerdata}
+		else:
+			# No items in the container, store the container as empty
+			newfurniturejson["Function"]["container"] = {}
 
 	return newfurniturejson
 
@@ -510,9 +510,9 @@ func add_wreck(pos: Vector3):
 
 # Check if the furniture can be destroyed
 func can_be_destroyed() -> bool:
-	return dfurniture.destruction.get_data().is_empty()
+	return not dfurniture.destruction.get_data().is_empty()
 
 
 # Check if the furniture can be disassembled
 func can_be_disassembled() -> bool:
-	return dfurniture.disassembly.get_data().is_empty()
+	return not dfurniture.disassembly.get_data().is_empty()

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -6,16 +6,17 @@ extends RefCounted
 # This script handles the data for one furniture. You can access it through Gamedata.furnitures
 
 # This class represents a piece of furniture with its properties
-var id: int
+var id: String
 var name: String
 var description: String
 var categories: Array
 var moveable: bool
 var weight: float
 var edgesnapping: String
-var sprite: String
-var function_data: Function
-var support_shape_data: SupportShape
+var sprite: Texture
+var spriteid: String
+var function: Function
+var support_shape: SupportShape
 var destruction: Destruction
 var disassembly: Disassembly
 var references: Dictionary = {}
@@ -23,22 +24,26 @@ var references: Dictionary = {}
 
 # Inner class to handle the Function property
 class Function:
-	var door: String
-	var container_itemgroup: String
+	var door: String # Can be "None", "Open" or "Closed"
+	var is_container: bool
+	var container_group: String
 
 	# Constructor to initialize function properties from a dictionary
 	func _init(data: Dictionary):
 		door = data.get("door", "None")
-		container_itemgroup = data.get("container", {}).get("itemgroup", "")
+		is_container = data.get("is_container", false)
+		container_group = data.get("container_group", "")
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		return {
-			"door": door,
-			"container": {
-				"itemgroup": container_itemgroup
-			}
-		}
+		var functiondata: Dictionary = {}
+		if is_container:
+			functiondata["is_container"] = is_container
+			if not container_group == "":
+				functiondata["container_group"] = container_group
+		if not door == "None":
+			functiondata["door"] = door
+		return functiondata # Potentially return an empty dictionary
 
 
 # Inner class to handle the Support Shape property
@@ -49,26 +54,35 @@ class SupportShape:
 	var shape: String
 	var transparent: bool
 	var width_scale: float
+	var radius_scale: float
 
 	# Constructor to initialize support shape properties from a dictionary
 	func _init(data: Dictionary):
+		set_data(data)
+
+	func set_data(data: Dictionary):
 		color = data.get("color", "ffffffff")
 		depth_scale = data.get("depth_scale", 0.0)
-		height = data.get("height", 0.0)
+		height = data.get("height", 0.5)
 		shape = data.get("shape", "Box")
 		transparent = data.get("transparent", false)
 		width_scale = data.get("width_scale", 0.0)
+		radius_scale = data.get("radius_scale", 0.0)
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		return {
+		var shapedata: Dictionary = {
 			"color": color,
-			"depth_scale": depth_scale,
 			"height": height,
 			"shape": shape,
-			"transparent": transparent,
-			"width_scale": width_scale
+			"transparent": transparent
 		}
+		if shape == "Box":
+			shapedata["width_scale"] = width_scale
+			shapedata["depth_scale"] = depth_scale
+		elif shape == "Cylinder":
+			shapedata["radius_scale"] = radius_scale
+		return shapedata
 
 
 # Inner class to handle the Destruction property
@@ -83,10 +97,12 @@ class Destruction:
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		return {
-			"group": group,
-			"sprite": sprite
-		}
+		var destructiondata: Dictionary = {}
+		if not group == "":
+			destructiondata["group"] = group
+		if not sprite == "":
+			destructiondata["sprite"] = sprite
+		return destructiondata # Potentially return an empty dictionary
 
 
 # Inner class to handle the Disassembly property
@@ -101,10 +117,12 @@ class Disassembly:
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		return {
-			"group": group,
-			"sprite": sprite
-		}
+		var disassemblydata: Dictionary = {}
+		if not group == "":
+			disassemblydata["group"] = group
+		if not sprite == "":
+			disassemblydata["sprite"] = sprite
+		return disassemblydata # Potentially return an empty dictionary
 
 
 # Constructor to initialize furniture properties from a dictionary
@@ -116,16 +134,17 @@ func _init(data: Dictionary):
 	moveable = data.get("moveable", false)
 	weight = data.get("weight", 0.0)
 	edgesnapping = data.get("edgesnapping", "")
-	sprite = data.get("sprite", "")
-	function_data = Function.new(data.get("Function", {}))  # Initialize Function inner class
-	support_shape_data = SupportShape.new(data.get("support_shape", {}))  # Initialize SupportShape inner class
+	spriteid = data.get("sprite", "")
+	function = Function.new(data.get("Function", {}))  # Initialize Function inner class
+	support_shape = SupportShape.new(data.get("support_shape", {}))  # Initialize SupportShape inner class
 	destruction = Destruction.new(data.get("destruction", {}))  # Initialize Destruction inner class
 	disassembly = Disassembly.new(data.get("disassembly", {}))  # Initialize Disassembly inner class
+	sprite = Gamedata.furnitures.sprite_by_id(id)
 
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
-	return {
+	var data: Dictionary = {
 		"id": id,
 		"name": name,
 		"description": description,
@@ -134,11 +153,26 @@ func get_data() -> Dictionary:
 		"weight": weight,
 		"edgesnapping": edgesnapping,
 		"sprite": sprite,
-		"Function": function_data.get_data(),
-		"support_shape": support_shape_data.get_data(),
 		"destruction": destruction.get_data(),
 		"disassembly": disassembly.get_data()
 	}
+	# Save the weight only if moveable true, otherwise erase it.
+	if moveable:
+		data["weight"] = weight
+		data["support_shape"] = support_shape.get_data()
+		
+	var functiondata: Dictionary = function.get_data()
+	if not functiondata.is_empty():
+		data["Function"] = functiondata
+		
+	var destructiondata: Dictionary = destruction.get_data()
+	if not destructiondata.is_empty():
+		data["destruction"] = destructiondata
+		
+	var disassemblydata: Dictionary = disassembly.get_data()
+	if not disassemblydata.is_empty():
+		data["disassembly"] = disassemblydata
+	return data
 
 
 # Removes the provided reference from references
@@ -149,7 +183,7 @@ func get_data() -> Dictionary:
 func remove_reference(module: String, type: String, refid: String):
 	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
 	if changes_made:
-		print_debug("implement sving changes")
+		Gamedata.furnitures.save_furnitures_to_disk()
 
 
 # Adds a reference to the references list
@@ -160,4 +194,49 @@ func remove_reference(module: String, type: String, refid: String):
 func add_reference(module: String, type: String, refid: String):
 	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
 	if changes_made:
-		print_debug("implement sving changes")
+		Gamedata.furnitures.save_furnitures_to_disk()
+
+
+# Returns the path of the sprite
+func get_sprite_path() -> String:
+	return Gamedata.furnitures.spritePath + spriteid
+
+
+# Handles furniture changes and updates references if necessary
+func on_data_changed(olddfurniture: DFurniture):
+	var old_container_group = olddfurniture.function.container.get("itemgroup", "")
+	var new_container_group = function.container.get("itemgroup", "")
+	var old_destruction_group = olddfurniture.destruction.group
+	var old_disassembly_group = olddfurniture.disassembly.group
+	var changes_made = false
+
+	# Handle container itemgroup changes
+	changes_made = Gamedata.dupdate_reference(references, old_container_group, new_container_group, "furniture") or changes_made
+
+	# Handle destruction group changes
+	changes_made = Gamedata.dupdate_reference(references, old_destruction_group, destruction.group, "furniture") or changes_made
+
+	# Handle disassembly group changes
+	changes_made = Gamedata.dupdate_reference(references, old_disassembly_group, disassembly.group, "furniture") or changes_made
+
+	# If any references were updated, save the changes to the data file
+	if changes_made:
+		print_debug("Furniture reference updates saved successfully.")
+		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
+
+
+# Some furniture is being deleted from the data
+# We have to remove it from everything that references it
+func delete():
+	var changes_made = false
+	var itemgroup = function.container.get("itemgroup", "")
+	changes_made = Gamedata.dremove_reference(references, "core", "furniture", itemgroup) or changes_made
+	changes_made = Gamedata.dremove_reference(references, "core", "furniture", destruction.group) or changes_made
+	changes_made = Gamedata.dremove_reference(references, "core", "furniture", disassembly.group) or changes_made
+	
+	var mapsdata = Helper.json_helper.get_nested_data(references, "core.maps")
+	Gamedata.maps.remove_entity_from_selected_maps("furniture", id, mapsdata)
+	if changes_made:
+		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
+	else:
+		print_debug("No changes needed for item", id)

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -132,13 +132,14 @@ func _init(data: Dictionary):
 	description = data.get("description", "")
 	categories = data.get("categories", [])
 	moveable = data.get("moveable", false)
-	weight = data.get("weight", 0.0)
+	weight = data.get("weight", 1.0)
 	edgesnapping = data.get("edgesnapping", "")
 	spriteid = data.get("sprite", "")
 	function = Function.new(data.get("Function", {}))  # Initialize Function inner class
 	support_shape = SupportShape.new(data.get("support_shape", {}))  # Initialize SupportShape inner class
 	destruction = Destruction.new(data.get("destruction", {}))  # Initialize Destruction inner class
 	disassembly = Disassembly.new(data.get("disassembly", {}))  # Initialize Disassembly inner class
+	references = data.get("references", {})
 
 
 # Get data function to return a dictionary with all properties
@@ -152,12 +153,12 @@ func get_data() -> Dictionary:
 		"weight": weight,
 		"edgesnapping": edgesnapping,
 		"sprite": spriteid,
-		"destruction": destruction.get_data(),
-		"disassembly": disassembly.get_data()
+		"references": references
 	}
 	# Save the weight only if moveable true, otherwise erase it.
 	if moveable:
 		data["weight"] = weight
+	else: # Support shape only applies to static furniture
 		data["support_shape"] = support_shape.get_data()
 		
 	var functiondata: Dictionary = function.get_data()
@@ -210,13 +211,13 @@ func on_data_changed(olddfurniture: DFurniture):
 	var changes_made = false
 
 	# Handle container itemgroup changes
-	changes_made = Gamedata.dupdate_reference(references, old_container_group, new_container_group, "furniture") or changes_made
+	changes_made = Gamedata.update_reference(old_container_group, new_container_group, id, "furniture") or changes_made
 
 	# Handle destruction group changes
-	changes_made = Gamedata.dupdate_reference(references, old_destruction_group, destruction.group, "furniture") or changes_made
+	changes_made = Gamedata.update_reference(old_destruction_group, destruction.group, id, "furniture") or changes_made
 
 	# Handle disassembly group changes
-	changes_made = Gamedata.dupdate_reference(references, old_disassembly_group, disassembly.group, "furniture") or changes_made
+	changes_made = Gamedata.update_reference(old_disassembly_group, disassembly.group, id, "furniture") or changes_made
 
 	# If any references were updated, save the changes to the data file
 	if changes_made:

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -18,6 +18,8 @@ var function_data: Function
 var support_shape_data: SupportShape
 var destruction: Destruction
 var disassembly: Disassembly
+var references: Dictionary = {}
+
 
 # Inner class to handle the Function property
 class Function:
@@ -28,6 +30,16 @@ class Function:
 	func _init(data: Dictionary):
 		door = data.get("door", "None")
 		container_itemgroup = data.get("container", {}).get("itemgroup", "")
+
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		return {
+			"door": door,
+			"container": {
+				"itemgroup": container_itemgroup
+			}
+		}
+
 
 # Inner class to handle the Support Shape property
 class SupportShape:
@@ -47,6 +59,18 @@ class SupportShape:
 		transparent = data.get("transparent", false)
 		width_scale = data.get("width_scale", 0.0)
 
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		return {
+			"color": color,
+			"depth_scale": depth_scale,
+			"height": height,
+			"shape": shape,
+			"transparent": transparent,
+			"width_scale": width_scale
+		}
+
+
 # Inner class to handle the Destruction property
 class Destruction:
 	var group: String
@@ -57,6 +81,14 @@ class Destruction:
 		group = data.get("group", "")
 		sprite = data.get("sprite", "")
 
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		return {
+			"group": group,
+			"sprite": sprite
+		}
+
+
 # Inner class to handle the Disassembly property
 class Disassembly:
 	var group: String
@@ -66,6 +98,14 @@ class Disassembly:
 	func _init(data: Dictionary):
 		group = data.get("group", "")
 		sprite = data.get("sprite", "")
+
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		return {
+			"group": group,
+			"sprite": sprite
+		}
+
 
 # Constructor to initialize furniture properties from a dictionary
 func _init(data: Dictionary):
@@ -81,3 +121,43 @@ func _init(data: Dictionary):
 	support_shape_data = SupportShape.new(data.get("support_shape", {}))  # Initialize SupportShape inner class
 	destruction = Destruction.new(data.get("destruction", {}))  # Initialize Destruction inner class
 	disassembly = Disassembly.new(data.get("disassembly", {}))  # Initialize Disassembly inner class
+
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	return {
+		"id": id,
+		"name": name,
+		"description": description,
+		"categories": categories,
+		"moveable": moveable,
+		"weight": weight,
+		"edgesnapping": edgesnapping,
+		"sprite": sprite,
+		"Function": function_data.get_data(),
+		"support_shape": support_shape_data.get_data(),
+		"destruction": destruction.get_data(),
+		"disassembly": disassembly.get_data()
+	}
+
+
+# Removes the provided reference from references
+# For example, remove "grass_field" to references.Core.maps
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity, for example "grass_field"
+func remove_reference(module: String, type: String, refid: String):
+	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
+	if changes_made:
+		print_debug("implement sving changes")
+
+
+# Adds a reference to the references list
+# For example, add "grass_field" to references.Core.maps
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity, for example "grass_field"
+func add_reference(module: String, type: String, refid: String):
+	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
+	if changes_made:
+		print_debug("implement sving changes")

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -1,0 +1,83 @@
+class_name DFurniture
+extends RefCounted
+
+# There's a D in front of the class name to indicate this class only handles map data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the data for one furniture. You can access it through Gamedata.furnitures
+
+# This class represents a piece of furniture with its properties
+var id: int
+var name: String
+var description: String
+var categories: Array
+var moveable: bool
+var weight: float
+var edgesnapping: String
+var sprite: String
+var function_data: Function
+var support_shape_data: SupportShape
+var destruction: Destruction
+var disassembly: Disassembly
+
+# Inner class to handle the Function property
+class Function:
+	var door: String
+	var container_itemgroup: String
+
+	# Constructor to initialize function properties from a dictionary
+	func _init(data: Dictionary):
+		door = data.get("door", "None")
+		container_itemgroup = data.get("container", {}).get("itemgroup", "")
+
+# Inner class to handle the Support Shape property
+class SupportShape:
+	var color: String
+	var depth_scale: float
+	var height: float
+	var shape: String
+	var transparent: bool
+	var width_scale: float
+
+	# Constructor to initialize support shape properties from a dictionary
+	func _init(data: Dictionary):
+		color = data.get("color", "ffffffff")
+		depth_scale = data.get("depth_scale", 0.0)
+		height = data.get("height", 0.0)
+		shape = data.get("shape", "Box")
+		transparent = data.get("transparent", false)
+		width_scale = data.get("width_scale", 0.0)
+
+# Inner class to handle the Destruction property
+class Destruction:
+	var group: String
+	var sprite: String
+
+	# Constructor to initialize destruction properties from a dictionary
+	func _init(data: Dictionary):
+		group = data.get("group", "")
+		sprite = data.get("sprite", "")
+
+# Inner class to handle the Disassembly property
+class Disassembly:
+	var group: String
+	var sprite: String
+
+	# Constructor to initialize disassembly properties from a dictionary
+	func _init(data: Dictionary):
+		group = data.get("group", "")
+		sprite = data.get("sprite", "")
+
+# Constructor to initialize furniture properties from a dictionary
+func _init(data: Dictionary):
+	id = data.get("id", 0)
+	name = data.get("name", "")
+	description = data.get("description", "")
+	categories = data.get("categories", [])
+	moveable = data.get("moveable", false)
+	weight = data.get("weight", 0.0)
+	edgesnapping = data.get("edgesnapping", "")
+	sprite = data.get("sprite", "")
+	function_data = Function.new(data.get("Function", {}))  # Initialize Function inner class
+	support_shape_data = SupportShape.new(data.get("support_shape", {}))  # Initialize SupportShape inner class
+	destruction = Destruction.new(data.get("destruction", {}))  # Initialize Destruction inner class
+	disassembly = Disassembly.new(data.get("disassembly", {}))  # Initialize Disassembly inner class

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -62,12 +62,12 @@ class SupportShape:
 
 	func set_data(data: Dictionary):
 		color = data.get("color", "ffffffff")
-		depth_scale = data.get("depth_scale", 0.0)
+		depth_scale = data.get("depth_scale", 100.0)
 		height = data.get("height", 0.5)
 		shape = data.get("shape", "Box")
 		transparent = data.get("transparent", false)
-		width_scale = data.get("width_scale", 0.0)
-		radius_scale = data.get("radius_scale", 0.0)
+		width_scale = data.get("width_scale", 100.0)
+		radius_scale = data.get("radius_scale", 100.0)
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
@@ -139,7 +139,6 @@ func _init(data: Dictionary):
 	support_shape = SupportShape.new(data.get("support_shape", {}))  # Initialize SupportShape inner class
 	destruction = Destruction.new(data.get("destruction", {}))  # Initialize Destruction inner class
 	disassembly = Disassembly.new(data.get("disassembly", {}))  # Initialize Disassembly inner class
-	sprite = Gamedata.furnitures.sprite_by_id(id)
 
 
 # Get data function to return a dictionary with all properties
@@ -152,7 +151,7 @@ func get_data() -> Dictionary:
 		"moveable": moveable,
 		"weight": weight,
 		"edgesnapping": edgesnapping,
-		"sprite": sprite,
+		"sprite": spriteid,
 		"destruction": destruction.get_data(),
 		"disassembly": disassembly.get_data()
 	}
@@ -204,8 +203,8 @@ func get_sprite_path() -> String:
 
 # Handles furniture changes and updates references if necessary
 func on_data_changed(olddfurniture: DFurniture):
-	var old_container_group = olddfurniture.function.container.get("itemgroup", "")
-	var new_container_group = function.container.get("itemgroup", "")
+	var old_container_group = olddfurniture.function.container_group
+	var new_container_group = function.container_group
 	var old_destruction_group = olddfurniture.destruction.group
 	var old_disassembly_group = olddfurniture.disassembly.group
 	var changes_made = false
@@ -240,3 +239,14 @@ func delete():
 		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
 	else:
 		print_debug("No changes needed for item", id)
+
+
+# Removes any instance of an itemgroup from the furniture
+func remove_itemgroup(itemgroup_id: String) -> void:
+	if function.container_group == itemgroup_id:
+		function.container_group = ""
+	if destruction.group == itemgroup_id:
+		destruction.group = ""
+	if disassembly.group == itemgroup_id:
+		disassembly.group = ""
+	Gamedata.furnitures.save_furnitures_to_disk()

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -7,7 +7,9 @@ extends RefCounted
 
 
 var dataPath: String = "./Mods/Core/Furniture/Furniture.json"
+var spritePath: String = "./Mods/Core/Furniture/"
 var furnituredict: Dictionary = {}
+var sprites: Dictionary = {}
 
 
 func _init():
@@ -22,6 +24,27 @@ func load_furnitures_from_disk() -> void:
 		furnituredict[furniture.id] = furniture
 
 
+# Loads sprites and assigns them to the proper dictionary
+func load_sprites() -> void:
+	var png_files: Array = Helper.json_helper.file_names_in_dir(spritePath, ["png"])
+	for png_file in png_files:
+		# Load the .png file as a texture
+		var texture := load(spritePath + png_file) 
+		# Add the material to the dictionary
+		sprites[png_file] = texture
+
+
+func on_data_changed():
+	save_furnitures_to_disk()
+
+# Saves all furnitures to disk
+func save_furnitures_to_disk() -> void:
+	var save_data: Array = []
+	for furniture in furnituredict:
+		save_data.append(furniture.get_data())
+	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+
+
 func get_furnitures() -> Dictionary:
 	return furnituredict
 
@@ -31,27 +54,34 @@ func duplicate_furniture_to_disk(furnitureid: String, newfurnitureid: String) ->
 	furnituredata.id = newfurnitureid
 	var newfurniture: DFurniture = DFurniture.new(furnituredata)
 	furnituredict[newfurnitureid] = newfurniture
-	save_data_to_disk()
+	save_furnitures_to_disk()
 
 
-func add_new_furniture(newdata: Dictionary) -> void:
-	var newfurniture: DFurniture = DFurniture.new(newdata)
+func add_new_furniture(newid: String) -> void:
+	var newfurniture: DFurniture = DFurniture.new({"id":newid})
 	furnituredict[newfurniture.id] = newfurniture
-	save_data_to_disk()
+	save_furnitures_to_disk()
 
-
-func save_data_to_disk():
-	var furniture_data_json = JSON.stringify(furnituredict, "\t")
-	Helper.json_helper.write_json_file(dataPath, furniture_data_json)
-	
 
 func delete_furniture(furnitureid: String) -> void:
 	furnituredict[furnitureid].delete()
 	furnituredict.erase(furnitureid)
+	save_furnitures_to_disk()
 
 
 func by_id(furnitureid: String) -> DFurniture:
 	return furnituredict[furnitureid]
+
+
+# Returns the sprite of the furniture
+# furnitureid: The id of the furniture to return the sprite of
+func sprite_by_id(furnitureid: String) -> Texture:
+	return sprites[furnituredict[furnitureid].sprite]
+
+# Returns the sprite of the furniture
+# furnitureid: The id of the furniture to return the sprite of
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites[spritefile]
 
 
 # Removes the reference from the selected furniture

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -1,0 +1,71 @@
+class_name DFurnitures
+extends RefCounted
+
+# There's a D in front of the class name to indicate this class only handles furniture data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the list of furnitures. You can access it trough Gamedata.furnitures
+
+
+var dataPath: String = "./Mods/Core/Furniture/Furniture.json"
+var furnituredict: Dictionary = {}
+
+
+func _init():
+	load_furnitures_from_disk()
+
+
+# Load all furnituredata from disk into memory
+func load_furnitures_from_disk() -> void:
+	var furniturelist: Array = Helper.json_helper.load_json_array_file(dataPath)
+	for furnitureitem in furniturelist:
+		var furniture: DFurniture = DFurniture.new(furnitureitem)
+		furnituredict[furniture.id] = furniture
+
+
+func get_furnitures() -> Dictionary:
+	return furnituredict
+
+
+func duplicate_furniture_to_disk(furnitureid: String, newfurnitureid: String) -> void:
+	var furnituredata: Dictionary = furnituredict[furnitureid].get_data().duplicate(true)
+	furnituredata.id = newfurnitureid
+	var newfurniture: DFurniture = DFurniture.new(furnituredata)
+	furnituredict[newfurnitureid] = newfurniture
+	save_data_to_disk()
+
+
+func add_new_furniture(newdata: Dictionary) -> void:
+	var newfurniture: DFurniture = DFurniture.new(newdata)
+	furnituredict[newfurniture.id] = newfurniture
+	save_data_to_disk()
+
+
+func save_data_to_disk():
+	var furniture_data_json = JSON.stringify(furnituredict, "\t")
+	Helper.json_helper.write_json_file(dataPath, furniture_data_json)
+	
+
+func delete_furniture(furnitureid: String) -> void:
+	furnituredict[furnitureid].delete()
+	furnituredict.erase(furnitureid)
+
+
+func by_id(furnitureid: String) -> DFurniture:
+	return furnituredict[furnitureid]
+
+
+# Removes the reference from the selected furniture
+func remove_reference_from_furniture(furnitureid: String, module: String, type: String, refid: String):
+	var myfurniture: DFurniture = furnituredict[furnitureid]
+	myfurniture.remove_reference(module, type, refid)
+
+
+# Adds a reference to the references list
+# For example, add "grass_field" to references.Core.maps
+# furnitureid: The id of the furniture to add the reference to
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity to reference, for example "grass_field"
+func add_reference_to_furniture(furnitureid: String, module: String, type: String, refid: String):
+	var myfurniture: DFurniture = furnituredict[furnitureid]
+	myfurniture.add_reference(module, type, refid)

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -13,6 +13,7 @@ var sprites: Dictionary = {}
 
 
 func _init():
+	load_sprites()
 	load_furnitures_from_disk()
 
 
@@ -21,6 +22,7 @@ func load_furnitures_from_disk() -> void:
 	var furniturelist: Array = Helper.json_helper.load_json_array_file(dataPath)
 	for furnitureitem in furniturelist:
 		var furniture: DFurniture = DFurniture.new(furnitureitem)
+		furniture.sprite = sprites[furniture.spriteid]
 		furnituredict[furniture.id] = furniture
 
 
@@ -76,7 +78,7 @@ func by_id(furnitureid: String) -> DFurniture:
 # Returns the sprite of the furniture
 # furnitureid: The id of the furniture to return the sprite of
 func sprite_by_id(furnitureid: String) -> Texture:
-	return sprites[furnituredict[furnitureid].sprite]
+	return furnituredict[furnitureid].sprite
 
 # Returns the sprite of the furniture
 # furnitureid: The id of the furniture to return the sprite of

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -42,7 +42,7 @@ func on_data_changed():
 # Saves all furnitures to disk
 func save_furnitures_to_disk() -> void:
 	var save_data: Array = []
-	for furniture in furnituredict:
+	for furniture in furnituredict.values():
 		save_data.append(furniture.get_data())
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -169,14 +169,24 @@ func data_changed(oldmap: DMap):
 
 	# Add references for new entities
 	for entity_type in new_entities.keys():
-		for entity_id in new_entities[entity_type]:
-			Gamedata.add_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id)
+		if entity_type == "furniture":
+			for entity_id in new_entities[entity_type]:
+				var furniture: DFurniture = Gamedata.furnitures.by_id(entity_id)
+				furniture.add_reference("core","maps",id)
+		else:
+			for entity_id in new_entities[entity_type]:
+				Gamedata.add_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id)
 
 	# Remove references for entities not present in new data
 	for entity_type in old_entities.keys():
-		for entity_id in old_entities[entity_type]:
-			if not new_entities[entity_type].has(entity_id):
-				Gamedata.remove_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id)
+		if entity_type == "furniture":
+			for entity_id in old_entities[entity_type]:
+				var furniture: DFurniture = Gamedata.furnitures.by_id(entity_id)
+				furniture.remove_reference("core","maps",id)
+		else:
+			for entity_id in old_entities[entity_type]:
+				if not new_entities[entity_type].has(entity_id):
+					Gamedata.remove_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id)
 
 	# Save changes to the data files if there were any updates
 	if new_entities["mobs"].size() > 0 or old_entities["mobs"].size() > 0:

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -340,16 +340,7 @@ func erase_entity_from_areas(entity_type: String, entity_id: String) -> void:
 # type: The type of entity, for example "tacticlmaps"
 # refid: The id of the entity, for example "town_00"
 func remove_reference(module: String, type: String, refid: String):
-	var changes_made = false
-	var refs = references[module][type]
-	if refid in refs:
-		refs.erase(refid)
-		changes_made = true
-		# Clean up if necessary
-		if refs.size() == 0:
-			references[module].erase(type)
-		if references[module].is_empty():
-			references.erase(module)
+	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
 	if changes_made:
 		save_data_to_disk()
 
@@ -360,17 +351,9 @@ func remove_reference(module: String, type: String, refid: String):
 # type: The type of entity, for example "tacticlmaps"
 # refid: The id of the entity, for example "town_00"
 func add_reference(module: String, type: String, refid: String):
-	var changes_made: bool = false
-	if not references.has(module):
-		references[module] = {}
-	if not references[module].has(type):
-		references[module][type] = []
-	if refid not in references[module][type]:
-		references[module][type].append(refid)
-		changes_made = true
+	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
 	if changes_made:
 		save_data_to_disk()
-
 
 
 # Function to remove a area from mapData.areas by its id

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -155,7 +155,7 @@ func remove_my_reference_from_all_entities() -> void:
 		# References have been added to tiles, furniture and/or mobs
 		# We could track changes individually so we only save what has actually changed.
 		Gamedata.save_data_to_file(Gamedata.data.tiles)
-		Gamedata.save_data_to_file(Gamedata.data.furniture)
+		Gamedata.furnitures.save_furnitures_to_disk()
 		Gamedata.save_data_to_file(Gamedata.data.mobs)
 		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
 
@@ -182,7 +182,7 @@ func data_changed(oldmap: DMap):
 	if new_entities["mobs"].size() > 0 or old_entities["mobs"].size() > 0:
 		Gamedata.save_data_to_file(Gamedata.data.mobs)
 	if new_entities["furniture"].size() > 0 or old_entities["furniture"].size() > 0:
-		Gamedata.save_data_to_file(Gamedata.data.furniture)
+		Gamedata.furnitures.save_furnitures_to_disk()
 	if new_entities["tiles"].size() > 0 or old_entities["tiles"].size() > 0:
 		Gamedata.save_data_to_file(Gamedata.data.tiles)
 	if new_entities["itemgroups"].size() > 0 or old_entities["itemgroups"].size() > 0:

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 # There's a D in front of the class name to indicate this class only handles map data, nothing more
 # This script is intended to be used inside the GameData autoload singleton
-# This script handles the list of maps. You can access it trough Gamedata.maps
+# This script handles data for one map. You can access it trough Gamedata.maps
 
 
 var id: String = "":

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -83,7 +83,7 @@ func get_data() -> Dictionary:
 
 func load_data_from_disk():
 	set_data(Helper.json_helper.load_json_dictionary_file(get_file_path()))
-	sprite = load(get_file_path().replace(".json", ".png")) 
+	sprite = load(get_sprite_path()) 
 
 
 func save_data_to_disk() -> void:

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -28,7 +28,7 @@ func get_maps() -> Dictionary:
 
 func duplicate_map_to_disk(mapid: String, newmapid: String) -> void:
 	var newmap: DMap = DMap.new(newmapid, dataPath)
-	newmap.set_data(mapdict[mapid].get_data().duplicate())
+	newmap.set_data(mapdict[mapid].get_data().duplicate(true))
 	newmap.save_data_to_disk()
 	mapdict[newmapid] = newmap
 

--- a/Scripts/Gamedata/itemgroup_references.gd
+++ b/Scripts/Gamedata/itemgroup_references.gd
@@ -42,11 +42,8 @@ func on_itemgroup_deleted(itemgroup_id: String):
 
 	# Callable to remove the itemgroup from every furniture that references this itemgroup.
 	var myfunc: Callable = func(furn_id):
-		var furniture_data = Gamedata.get_data_by_id(Gamedata.data.furniture, furn_id)
-		var paths = ["Function.container.itemgroup", "disassembly.group", "destruction.group"]
-		for path in paths:
-			if Helper.json_helper.get_nested_data(furniture_data, path) == itemgroup_id:
-				changes_made = Helper.json_helper.delete_nested_property(furniture_data, path) or changes_made
+		var furniture: DFurniture = Gamedata.furnitures.by_id(furn_id)
+		furniture.remove_itemgroup(itemgroup_id)
 
 	# Pass the callable to every furniture in the itemgroup's references
 	# It will call myfunc on every furniture in itemgroup_data.references.core.furniture
@@ -64,7 +61,6 @@ func on_itemgroup_deleted(itemgroup_id: String):
 	# Save changes to the data files if any changes were made.
 	if changes_made:
 		Gamedata.save_data_to_file(Gamedata.data.items)
-		Gamedata.save_data_to_file(Gamedata.data.furniture)
 		print_debug("Itemgroup", itemgroup_id, "has been successfully deleted from all items.")
 	else:
 		print_debug("No changes needed for itemgroup", itemgroup_id)

--- a/Scripts/Gamedata/itemgroup_references.gd
+++ b/Scripts/Gamedata/itemgroup_references.gd
@@ -56,7 +56,8 @@ func on_itemgroup_deleted(itemgroup_id: String):
 	# Remove references to this itemgroup from maps.
 	for mod in itemgroup_data.get("references", []):
 		var maps = Helper.json_helper.get_nested_data(itemgroup_data, "references." + mod + ".maps")
-		Gamedata.maps.remove_entity_from_selected_maps("itemgroup", itemgroup_id,maps)
+		if maps:
+			Gamedata.maps.remove_entity_from_selected_maps("itemgroup", itemgroup_id, maps)
 
 	# Save changes to the data files if any changes were made.
 	if changes_made:

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -72,16 +72,22 @@ func _on_quest_failed(_quest: Dictionary):
 	pass
 
 
-# Function to handle step completion
+# When a step is complete.
+# step: the step dictionary
 func _on_step_complete(_step: Dictionary):
 	# To be developed later
 	pass
 
 
-# Function to handle next step
-func _on_next_step(_step: Dictionary):
-	# To be developed later
-	pass
+# Called after the previous step was completed
+# step: the new step in the quest
+func _on_next_step(step: Dictionary):
+	# The player might already have the item for the next step so check it
+	match step.get("step_type", ""):	
+		QuestManager.INCREMENTAL_STEP:
+			update_quest_by_inventory(null)
+		QuestManager.ITEMS_STEP:
+			update_quest_by_inventory(null)
 
 
 # Function to handle step update
@@ -166,7 +172,7 @@ func update_quest_by_inventory(item: InventoryItem):
 	var item_counts = ItemManager.count_player_inventory_items_by_id()
 
 	# Check if the player has the item; if not, set its count to 0
-	if not ItemManager.playerInventory.has_item_by_id(item.prototype_id):
+	if item and not ItemManager.playerInventory.has_item_by_id(item.prototype_id):
 		item_counts[item.prototype_id] = 0
 
 	# Get the current quests in progress

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -163,7 +163,7 @@ func set_texture(mytex: String):
 	if not mytex:
 		sprite_3d.texture = load("res://Textures/container_32.png")
 		return
-	var newsprite: Texture = Gamedata.data.furniture.sprites[mytex]
+	var newsprite: Texture = Gamedata.furnitures.sprite_by_file(mytex)
 	if newsprite:
 		sprite_3d.texture = newsprite
 		texture_id = mytex  # Save the texture ID

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -121,7 +121,7 @@ func deserialize_and_apply_items(items_data: Dictionary):
 func _create_inventory():
 	inventory = InventoryStacked.new()
 	inventory.capacity = 1000
-	inventory.item_protoset = load("res://ItemProtosets.tres")
+	inventory.item_protoset = ItemManager.item_protosets
 	add_child.call_deferred(inventory)
 	inventory.item_removed.connect(_on_item_removed)
 	inventory.item_added.connect(_on_item_added)

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -21,11 +21,13 @@ func _ready():
 	if texture_id:
 		set_texture(texture_id)
 
+
 # Called when a function creates this class using ContainerItem.new(container_json)
 # Basic setup for this container. Should be called before adding it to the scene tree
 func _init(item: Dictionary):
 	_initialize_container(item)
 	create_loot()
+
 
 func _initialize_container(item: Dictionary):
 	containerpos = Vector3(item.global_position_x, item.global_position_y, item.global_position_z)
@@ -85,6 +87,7 @@ func _add_items_to_inventory(items: Array) -> bool:
 			var quantity = randi_range(item_object["min"], item_object["max"])
 			_add_item_to_inventory(item_id, quantity)
 	return item_added
+
 
 # Takes an item_id and quantity and adds it to the inventory
 func _add_item_to_inventory(item_id: String, quantity: int):
@@ -232,15 +235,13 @@ func _on_item_removed(_item: InventoryItem):
 			
 	else: # There are still items in the container
 		if is_inside_tree():
-			# Check if this ContainerItem is a direct child of the tree root
-			if get_parent() == get_tree().get_root():
-				set_random_inventory_item_texture() # Update to a new sprite
+			set_random_inventory_item_texture() # Update to a new sprite
 
 
 func _on_item_added(_item: InventoryItem):
 	# Check if this ContainerItem is a direct child of the tree root
 	if is_inside_tree() and not get_parent() == get_tree().get_root():
-		sprite_3d.texture = load("res://Textures/container_filled_32.png")
+		set_random_inventory_item_texture() # Update to a new sprite
 
 
 func add_item(item_id: String):

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -194,7 +194,6 @@ func remove_item_from_data(contentData: Dictionary, id: String):
 		remove_references_of_deleted_id(contentData, id)
 		contentData.data.erase(id)
 		var json_file_path = contentData.dataPath + id + ".json"
-		var png_file_path = id + ".png"
 		Helper.json_helper.delete_json_file(json_file_path)
 	else:
 		print_debug("Tried to remove item from data, but the data's datapath ends with \
@@ -985,3 +984,45 @@ func on_quest_changed(newdata: Dictionary, olddata: Dictionary):
 	if changes_made:
 		save_data_to_file(data.items)
 		save_data_to_file(data.mobs)
+
+
+
+
+# Removes the provided reference from references
+# For example, remove "town_00" from references.Core.tacticalmaps
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "tacticlmaps"
+# refid: The id of the entity, for example "town_00"
+# TODO: Have this function replace add_reference when all entities have been transformed into
+# their own class. Until then, a d is added to the front to indicate it's used in data classes
+func dremove_reference(references: Dictionary, module: String, type: String, refid: String) -> bool:
+	var changes_made = false
+	var refs = references[module][type]
+	if refid in refs:
+		refs.erase(refid)
+		changes_made = true
+		# Clean up if necessary
+		if refs.size() == 0:
+			references[module].erase(type)
+		if references[module].is_empty():
+			references.erase(module)
+	return changes_made
+
+
+# Adds a reference to the references list
+# For example, add "town_00" to references.Core.tacticalmaps
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "tacticlmaps"
+# refid: The id of the entity, for example "town_00"
+# TODO: Have this function replace add_reference when all entities have been transformed into
+# their own class. Until then, a d is added to the front to indicate it's used in data classes
+func dadd_reference(references: Dictionary, module: String, type: String, refid: String) -> bool:
+	var changes_made: bool = false
+	if not references.has(module):
+		references[module] = {}
+	if not references[module].has(type):
+		references[module][type] = []
+	if refid not in references[module][type]:
+		references[module][type].append(refid)
+		changes_made = true
+	return changes_made

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -302,12 +302,12 @@ func get_items_by_type(item_type: String) -> Array:
 
 # Adds a reference to an entity
 # data = any data group, like Gamedata.data.itemgroups
-# type = the type of reference, for example furniture
+# type = the type of reference, for example "item"
 # onid = where to add the reference to
 # refid = The reference to add on the fromid
 # Example usage: var changes_made = add_reference(Gamedata.data.itemgroups, "core", 
-# "furniture", itemgroup_id, furniture_id)
-# This example will add the specified furniture from the itemgroup's references
+# "item", itemgroup_id, item_id)
+# This example will add the specified item from the itemgroup's references
 func add_reference(mydata: Dictionary, module: String, type: String, onid: String, refid: String) -> bool:
 	var changes_made: bool = false
 
@@ -347,12 +347,12 @@ func add_reference(mydata: Dictionary, module: String, type: String, onid: Strin
 
 # Removes a reference from an entity. 
 # data = any data group, like Gamedata.data.itemgroups
-# type = the type of reference, for example furniture
+# type = the type of reference, for example item
 # fromid = where to remove the reference from
 # refid = The reference to remove from the fromid
 # Example usage: var changes_made = remove_reference(Gamedata.data.itemgroups, "core", 
-# "furniture", itemgroup_id, furniture_id)
-# This example will remove the specified furniture from the itemgroup's references
+# "item", itemgroup_id, item_id)
+# This example will remove the specified item from the itemgroup's references
 func remove_reference(mydata: Dictionary, module: String, type: String, fromid: String, refid: String) -> bool:
 	var changes_made: bool = false
 	
@@ -444,7 +444,7 @@ func erase_property_by_path(mydata: Dictionary, item_id: String, property_path: 
 # Executes a callable function on each reference of the given type
 # data = json data representing one entity
 # module = name of the mod. for example "core"
-# type = the type of reference we want to handle. For example "furniture"
+# type = the type of reference we want to handle. For example "item"
 # callable = a function to execute on each reference ID
 # We will check if data has the ["references"] and [type] properties and execute the callable on each found ID
 func execute_callable_on_references_of_type(mydata: Dictionary, module: String, type: String, callable: Callable):
@@ -474,10 +474,10 @@ func on_mob_changed(newdata: Dictionary, olddata: Dictionary):
 		print_debug("No change in itemgroup. Exiting function.")
 		return
 	var changes_made = false
-	# This furniture will be removed from the old itemgroup's references
+	# This mob will be removed from the old itemgroup's references
 	# The 'or' makes sure changes_made does not change back to false
 	changes_made = remove_reference(data.itemgroups, "core", "mobs", old_loot_group, mob_id) or changes_made
-	# This furniture will be added to the new itemgroup's references
+	# This mob will be added to the new itemgroup's references
 	# The 'or' makes sure changes_made does not change back to false
 	changes_made = add_reference(data.itemgroups, "core", "mobs", new_loot_group, mob_id) or changes_made
 	# Save changes if any modifications were made
@@ -493,9 +493,9 @@ func on_mob_changed(newdata: Dictionary, olddata: Dictionary):
 # new: an entity id that is present in the new data
 # entity_id: The entity that's referenced in old and/or new
 # type: The type of entity that will be referenced
-# Example usage: update_reference(old_itemgroup, new_itemgroup, furniture_id, "furniture")
-# This example will remove furniture_id from the old_itemgroup's references and
-# add the furniture_id to the new_itemgroup's refrences
+# Example usage: update_reference(old_itemgroup, new_itemgroup, item_id, "item")
+# This example will remove item_id from the old_itemgroup's references and
+# add the item_id to the new_itemgroup's refrences
 func update_reference(old: String, new: String, entity_id: String, type: String) -> bool:
 	if old == new:
 		return false  # No change detected, exit early
@@ -979,9 +979,9 @@ func dadd_reference(references: Dictionary, module: String, type: String, refid:
 # new: an entity id that is present in the new data
 # entity_id: The entity that's referenced in old and/or new
 # type: The type of entity that will be referenced
-# Example usage: update_reference(old_itemgroup, new_itemgroup, furniture_id, "furniture")
-# This example will remove furniture_id from the old_itemgroup's references and
-# add the furniture_id to the new_itemgroup's refrences
+# Example usage: update_reference(old_itemgroup, new_itemgroup, item_id, "item")
+# This example will remove item_id from the old_itemgroup's references and
+# add the item_id to the new_itemgroup's refrences
 # TODO: Have this function replace update_reference when all entities have been transformed into
 # their own class. Until then, a d is added to the front to indicate it's used in data classes
 func dupdate_reference(ref: Dictionary, old: String, new: String, type: String) -> bool:

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -13,6 +13,7 @@ var proximityInventory: InventoryStacked = null
 var proximityInventories = {}  # Dictionary to hold inventories and their items
 var allAccessibleItems = []  # List to hold all accessible InventoryItems
 var player_max_inventory_volume: int = 1000
+var item_protosets: Resource = preload("res://ItemProtosets.tres")
 
 
 signal allAccessibleItems_changed(items_added: Array, items_removed: Array)


### PR DESCRIPTION
Requires #272 
Fixes #249 

Made some changes to improve the performance of furniture.
- Freezes and unfreezes furniturephysics when they are spawned. As evidenced by the messy code, this is a troublesome process without using timers. 
- I changed it so that: 1. it will spawn at 0,0 when created. 2. it will move to it's assigned position in the chunk. 3. Godot will confirm it's position is actually in the chunk that it needs to be in. 4. The furniture is un-frozen
- I preload the itemprotosets.tres at the start of the game instead of during runtime. This was a bottleneck with a heavy disk operation. 

The highest frame time I got at the moment is 29ms which is a good improvement from what it was before. There are still improvements possible. My intention was to have it run on a thread, but it started crashing. That's why I did some refactoring but in the end it wasn't needed to have it run in a thread (yet).