### PR TITLE
Chunk spawning is controlled by timer

### DIFF
--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -112,7 +112,6 @@ func initialize_map_data():
 
 
 # Return an array of chunks that fall inside the creation radius
-# We only return chunks that have it's coordinate in the tacticalmap, so we don't go out of bounds
 func calculate_chunks_to_load(player_chunk_pos: Vector2) -> Array:
 	var chunks_to_load = []
 	for x in range(player_chunk_pos.x - creation_radius, player_chunk_pos.x + creation_radius + 1):

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -75,15 +75,26 @@ func _on_player_spawned(playernode):
 	print_debug("player position is " + str(new_position))
 	load_queue.append(new_position.floor())
 	# Start a loop to update chunks based on player position
-	calculate_initial_chunks(new_position.floor())  # Calculate and add initial chunks to the load queue
+	load_initial_chunks_around_player(new_position.floor())
 	start_timer()
 
-
-func calculate_initial_chunks(playerpos):
-	var initial_chunks = calculate_chunks_to_load(playerpos)
+# Function to load initial chunks around the player's position
+func load_initial_chunks_around_player(player_pos: Vector2):
+	var initial_chunks = [
+		player_pos,  # Center
+		player_pos + Vector2(1, 0),  # East
+		player_pos + Vector2(-1, 0),  # West
+		player_pos + Vector2(0, 1),  # South
+		player_pos + Vector2(0, -1),  # North
+		player_pos + Vector2(-1, -1),  # North-west
+		player_pos + Vector2(1, -1),  # North-east
+		player_pos + Vector2(-1, 1)  # South-west
+	]
+	
 	for chunk_pos in initial_chunks:
 		if not loaded_chunks.has(chunk_pos) and not load_queue.has(chunk_pos):  # Ensure chunk isn't already loaded or queued
 			load_queue.append(chunk_pos)
+
 
 # Function for handling game ended signal
 func _on_game_ended():

--- a/Mods/Core/Maps/generichouse_corner.json
+++ b/Mods/Core/Maps/generichouse_corner.json
@@ -4536,6 +4536,10 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"furniture": {
+					"id": "window_glass",
+					"rotation": 270
+				},
 				"id": "dirt_light_00",
 				"rotation": 270
 			},

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -12787,6 +12787,10 @@
 				"rotation": 270
 			},
 			{
+				"furniture": {
+					"id": "window_glass",
+					"rotation": 90
+				},
 				"id": "brick_wall_01",
 				"rotation": 270
 			},
@@ -13636,6 +13640,10 @@
 				"rotation": 270
 			},
 			{
+				"furniture": {
+					"id": "window_glass",
+					"rotation": 90
+				},
 				"id": "brick_wall_01",
 				"rotation": 270
 			},

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -31,7 +31,9 @@ func _ready():
 	update_chunks()
 	position_coord_changed.connect(on_position_coord_changed)
 	Helper.overmap_manager.player_coord_changed.connect(on_player_coord_changed)
-	move_overmap(Vector2(-7, -5)) # Center the map, at least for small resolution
+	# Center the map
+	move_overmap(Helper.overmap_manager.player_last_cell - calculate_screen_center_offset()) 
+	update_overmap_tile_visibility(Helper.overmap_manager.player_last_cell)
 
 
 # This function updates the chunks.
@@ -253,5 +255,12 @@ func get_overmap_tile_at_position(myposition: Vector2) -> Control:
 # Movement could be between (0,0) and (0,1) for example
 func on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
 	update_overmap_tile_visibility(new_pos)
-	var delta = new_pos - Helper.position_coord
+	var delta = new_pos - Helper.position_coord - calculate_screen_center_offset()
 	move_overmap(delta)
+
+
+# Calculates the center of the window. We subtract 50% because the
+# overmap doesn't cover the whole screen, only about 50%
+func calculate_screen_center_offset() -> Vector2:
+	var screen_center_offset = get_viewport_rect().size * 0.5 / tile_size
+	return screen_center_offset * 0.5  # Reduce by 50%

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -253,3 +253,5 @@ func get_overmap_tile_at_position(myposition: Vector2) -> Control:
 # Movement could be between (0,0) and (0,1) for example
 func on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
 	update_overmap_tile_visibility(new_pos)
+	var delta = new_pos - Helper.position_coord
+	move_overmap(delta)

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -174,6 +174,8 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 			var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(global_pos)
 			var texture: Texture = map_cell.get_sprite() if map_cell else null
 			tile.set_texture(texture)
+			# Set the rotation of the tile based on the map_cell's rotation property
+			tile.set_texture_rotation(map_cell.rotation if map_cell else 0)
 			tile.set_meta("global_pos", global_pos)
 			tile.set_meta("local_pos", local_pos)
 

--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -57,7 +57,7 @@ func set_text_visible(isvisible: bool):
 # Set the rotation of the TextureRect based on the given rotation angle
 func set_texture_rotation(myrotation: int) -> void:
 	# Set the rotation pivot to the center of the TextureRect
-	$TextureRect.set_pivot_offset(Vector2($TextureRect.size.x / 2, $TextureRect.size.y / 2))
+	$TextureRect.pivot_offset = size / 2
 	# Set the rotation of the TextureRect based on the given rotation angle
 	match myrotation:
 		0:

--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -52,3 +52,21 @@ func set_text(newtext: String):
 # Hide or show the textlabel
 func set_text_visible(isvisible: bool):
 	$TextLabel.visible = isvisible
+
+
+# Set the rotation of the TextureRect based on the given rotation angle
+func set_texture_rotation(myrotation: int) -> void:
+	# Set the rotation pivot to the center of the TextureRect
+	$TextureRect.set_pivot_offset(Vector2($TextureRect.size.x / 2, $TextureRect.size.y / 2))
+	# Set the rotation of the TextureRect based on the given rotation angle
+	match myrotation:
+		0:
+			$TextureRect.rotation_degrees = 0
+		90:
+			$TextureRect.rotation_degrees = 90
+		180:
+			$TextureRect.rotation_degrees = 180
+		270:
+			$TextureRect.rotation_degrees = 270
+		_:
+			$TextureRect.rotation_degrees = 0  # Default to 0 if an invalid rotation is provided

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -566,7 +566,6 @@ func load_all_grids():
 func load_random_tactical_map() -> Dictionary:
 	var tacticalmaps = Helper.json_helper.file_names_in_dir(Gamedata.data.tacticalmaps.dataPath)
 	var random_tactical_map = tacticalmaps[randi() % tacticalmaps.size()]
-	print_debug("Picked taclcalmap: " + random_tactical_map)
 	return Helper.json_helper.load_json_dictionary_file(Gamedata.data.tacticalmaps.dataPath + random_tactical_map)
 
 
@@ -593,7 +592,6 @@ func find_valid_position(placed_positions: Array, map_width: int, map_height: in
 			return Vector2(random_x, random_y)
 		
 		attempts += 1
-	print_debug("Failed to find a position")
 	return Vector2(-1, -1)  # Indicate that a valid position was not found
 
 
@@ -611,7 +609,6 @@ func place_tactical_maps_on_grid(grid: map_grid):
 		if position == Vector2(-1, -1):
 			print("Failed to find a valid position for tactical map")
 			continue
-		print_debug("Placing chunk " + chunks[0].id + ", at position " + str(position))
 
 		var random_x = position.x
 		var random_y = position.y
@@ -630,6 +627,7 @@ func place_tactical_maps_on_grid(grid: map_grid):
 
 # Helper function to update a cell's map ID if it exists
 func update_cell_map_id(grid: map_grid, cell_key: Vector2, map_id: String, rotation: int):
-	if grid.cells.has(cell_key):
-		grid.cells[cell_key].map_id = map_id.replace(".json", "")
-		grid.cells[cell_key].rotation = rotation  # Update rotation
+	var adjusted_cell_key = cell_key + grid.pos * grid_width
+	if grid.cells.has(adjusted_cell_key):
+		grid.cells[adjusted_cell_key].map_id = map_id.replace(".json", "")
+		grid.cells[adjusted_cell_key].rotation = rotation  # Update rotation

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -219,6 +219,7 @@ func load_cells_around(position: Vector3):
 					generate_cells_for_grid(grid)
 
 
+
 # This function generates chunks for each cell in the grid, ensuring the grid is filled with cells.
 func generate_cells_for_grid(grid: map_grid):
 	for x in range(grid_width):
@@ -240,6 +241,8 @@ func generate_cells_for_grid(grid: map_grid):
 				cell.map_id = "field_grass_basic_00.json"  # Fallback if no maps are found
 
 			grid.cells[cell_key] = cell
+
+	place_tactical_maps_on_grid(grid)
 
 
 # Helper function to convert Region enum to string
@@ -554,3 +557,75 @@ func load_all_grids():
 	var loaded_grids_array: Array = Helper.save_helper.load_all_overmap_grids_from_file()
 	for loadedgrid: Dictionary in loaded_grids_array:
 		process_loaded_grid_data(loadedgrid)
+
+
+# Function to randomly load and return a tactical map
+func load_random_tactical_map() -> Dictionary:
+	var tacticalmaps = Helper.json_helper.file_names_in_dir(Gamedata.data.tacticalmaps.dataPath)
+	var random_tactical_map = tacticalmaps[randi() % tacticalmaps.size()]
+	print_debug("Picked taclcalmap: " + random_tactical_map)
+	return Helper.json_helper.load_json_dictionary_file(Gamedata.data.tacticalmaps.dataPath + random_tactical_map)
+
+
+# Function to find a valid position for placing a tactical map
+func find_valid_position(placed_positions: Array, map_width: int, map_height: int) -> Vector2:
+	var attempts = 0
+	while attempts < 100:
+		var random_x = randi() % (grid_width - map_width + 1)
+		var random_y = randi() % (grid_height - map_height + 1)
+		var valid_position_found = true
+
+		for i in range(map_width):
+			for j in range(map_height):
+				var local_x = random_x + i
+				var local_y = random_y + j
+				var cell_key = Vector2(local_x, local_y)
+				if cell_key in placed_positions:
+					valid_position_found = false
+					break
+			if not valid_position_found:
+				break
+
+		if valid_position_found:
+			return Vector2(random_x, random_y)
+		
+		attempts += 1
+	print_debug("Failed to find a position")
+	return Vector2(-1, -1)  # Indicate that a valid position was not found
+
+
+# Function to place tactical maps on a specific grid
+func place_tactical_maps_on_grid(grid: map_grid):
+	var placed_positions = []
+	for n in range(10):
+		var tactical_map_data = load_random_tactical_map()
+
+		var map_width = tactical_map_data.get("mapwidth", 0)
+		var map_height = tactical_map_data.get("mapheight", 0)
+		var chunks = tactical_map_data.get("chunks", [])
+
+		var position = find_valid_position(placed_positions, map_width, map_height)
+		if position == Vector2(-1, -1):
+			print("Failed to find a valid position for tactical map")
+			continue
+		print_debug("Placing chunk " + chunks[0].id)
+
+		var random_x = position.x
+		var random_y = position.y
+
+		for i in range(map_width):
+			for j in range(map_height):
+				var local_x = random_x + i
+				var local_y = random_y + j
+				if local_x < grid_width and local_y < grid_height:
+					var cell_key = Vector2(local_x, local_y)
+					var chunk_index = j * map_width + i
+					var chunk_data = chunks[chunk_index]
+					update_cell_map_id(grid, cell_key, chunk_data["id"])
+					placed_positions.append(cell_key)
+
+
+# Helper function to update a cell's map ID if it exists
+func update_cell_map_id(grid: map_grid, cell_key: Vector2, map_id: String):
+	if grid.cells.has(cell_key):
+		grid.cells[cell_key].map_id = map_id.replace(".json", "")

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -66,6 +66,8 @@ const NOISE_VALUE_PLAINS = 0.3
 
 var noise: FastNoiseLite
 
+# When the player coordinate changed. player: The player node. 
+# old_pos: The old coordinate in the grid. new_pos: The new coordinate in the grid
 signal player_coord_changed(player: CharacterBody3D, old_pos: Vector2, new_pos: Vector2)
 
 
@@ -177,6 +179,9 @@ func _on_player_spawned(playernode):
 	player = playernode
 	var player_position = player.position
 	load_cells_around(player_position)
+	var cellpos: Vector2 = get_cell_pos_from_global_pos(Vector2(player_position.x, player_position.z))
+	player_coord_changed.emit(player, player_last_cell, cellpos)
+
 
 # Function for handling game loaded signal
 func _on_game_loaded():

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -80,6 +80,7 @@ class map_cell:
 	var map_id: String = "field_grass_basic_00.json"
 	var tacticalmapname: String = "town_00.json"
 	var revealed: bool = false
+	var rotation: int = 0  # Will be any of [0, 90, 180, 270]
 
 	func get_data() -> Dictionary:
 		return {
@@ -88,7 +89,8 @@ class map_cell:
 			"coordinate_y": coordinate_y,
 			"map_id": map_id,
 			"tacticalmapname": tacticalmapname,
-			"revealed": revealed
+			"revealed": revealed,
+			"rotation": rotation  # Include rotation in data
 		}
 
 	func set_data(newdata: Dictionary):
@@ -100,6 +102,7 @@ class map_cell:
 		map_id = newdata.get("map_id", "field_grass_basic_00.json")
 		tacticalmapname = newdata.get("tacticalmapname", "town_00.json")
 		revealed = newdata.get("revealed", false)
+		rotation = newdata.get("rotation", 0)  # Set rotation from data
 
 	func get_sprite() -> Texture:
 		return Gamedata.maps.by_id(map_id).sprite
@@ -608,7 +611,7 @@ func place_tactical_maps_on_grid(grid: map_grid):
 		if position == Vector2(-1, -1):
 			print("Failed to find a valid position for tactical map")
 			continue
-		print_debug("Placing chunk " + chunks[0].id)
+		print_debug("Placing chunk " + chunks[0].id + ", at position " + str(position))
 
 		var random_x = position.x
 		var random_y = position.y
@@ -621,11 +624,12 @@ func place_tactical_maps_on_grid(grid: map_grid):
 					var cell_key = Vector2(local_x, local_y)
 					var chunk_index = j * map_width + i
 					var chunk_data = chunks[chunk_index]
-					update_cell_map_id(grid, cell_key, chunk_data["id"])
+					update_cell_map_id(grid, cell_key, chunk_data["id"], chunk_data.get("rotation", 0))
 					placed_positions.append(cell_key)
 
 
 # Helper function to update a cell's map ID if it exists
-func update_cell_map_id(grid: map_grid, cell_key: Vector2, map_id: String):
+func update_cell_map_id(grid: map_grid, cell_key: Vector2, map_id: String, rotation: int):
 	if grid.cells.has(cell_key):
 		grid.cells[cell_key].map_id = map_id.replace(".json", "")
+		grid.cells[cell_key].rotation = rotation  # Update rotation


### PR DESCRIPTION
Fixes #299 

The only timing for the initial chunks that was present before this pr was the chunk_ready signal from the chunks themselves

This pr makes the initial chunk spawning respect the .5 second timer and they are spawned one at a time.

On the long run, we'll have to figure out why it crashes without this delay. If we can figure it out, we can spawn more chunks at once.