### PR TITLE
Show player marker only once.

### DIFF
--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -72,7 +72,6 @@ func _on_player_spawned(playernode):
 	initialize_map_data()
 	
 	var new_position = Vector2(playernode.global_transform.origin.x, playernode.global_transform.origin.z) / Vector2(level_width, level_height)
-	print_debug("player position is " + str(new_position))
 	load_queue.append(new_position.floor())
 	# Start a loop to update chunks based on player position
 	load_initial_chunks_around_player(new_position.floor())
@@ -157,9 +156,7 @@ func load_chunk(chunk_pos: Vector2):
 
 # When we unload the chunk, we save its data into memory so we can re-use it later
 func unload_chunk(chunk_pos: Vector2):
-	#print_debug("Unloading chunk at chunk_pos (" + str(chunk_pos) + ")")
 	if loaded_chunks.has(chunk_pos):
-		#print_debug("found chunk at chunk_pos (" + str(chunk_pos) + ")")
 		var chunk = loaded_chunks[chunk_pos]
 		chunk.unload_chunk()
 		loaded_chunks.erase(chunk_pos)
@@ -204,7 +201,6 @@ func update_queues(potential_loads, potential_unloads):
 # This function will either load or unload a chunk if there are any to load or unload
 func process_next_chunk():
 	if load_queue.size() > 0:
-		print_debug("Processing next chunk. load_queue.size() = " + str(load_queue.size()))
 		var chunk_pos = load_queue.pop_front()
 		is_processing_chunk = true
 		load_chunk(chunk_pos)
@@ -250,7 +246,6 @@ func get_chunk_from_position(position_in_3d_space: Vector3) -> Chunk:
 
 # Function to get chunk_pos from mypos
 func get_chunk_pos_from_mypos(mypos: Vector3) -> Vector2:
-	print_debug("Unloading chunk at mypos (" + str(mypos) + ")")
 	var chunk_x = mypos.x / level_width
 	var chunk_y = mypos.z / level_height
 	return Vector2(chunk_x, chunk_y)

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -19,6 +19,9 @@ var previous_visible_tile: Control = null
 # Object pool for reusing tiles
 var tile_pool: Array = []
 
+# Dictionary to keep track of text visibility by coordinate
+var text_visible_by_coord: Dictionary = {}
+
 # We will emit this signal when the position_coords change
 # Which happens when the user has panned the overmap
 signal position_coord_changed(delta: Vector2)
@@ -179,6 +182,12 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 			tile.set_meta("global_pos", global_pos)
 			tile.set_meta("local_pos", local_pos)
 
+			# Check if this global position has text visibility set
+			if text_visible_by_coord.has(global_pos) and text_visible_by_coord[global_pos]:
+				tile.set_text_visible(true)
+			else:
+				tile.set_text_visible(false)
+
 			if global_pos == Vector2.ZERO:
 				tile.set_color(Color(0.3, 0.3, 1))  # blue color
 			else:
@@ -190,7 +199,7 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 	return grid_container
 
 
-#This function will be connected to the signal of the tiles
+# This function will be connected to the signal of the tiles
 func _on_tile_clicked(clicked_tile):
 	if clicked_tile.has_meta("map_file"):
 		selected_overmap_tile = clicked_tile
@@ -235,10 +244,16 @@ func _on_home_button_button_up():
 
 # Function to update the visibility of overmap tile text
 func update_overmap_tile_visibility(new_pos: Vector2):
+	if previous_visible_tile:
+		previous_visible_tile.set_text_visible(false)
+
+	# Update the dictionary to reflect the new position with visible text
+	text_visible_by_coord.clear()
+	text_visible_by_coord[new_pos] = true
+
 	var current_tile = get_overmap_tile_at_position(new_pos)
 	if current_tile:
-		if previous_visible_tile and previous_visible_tile != current_tile:
-			previous_visible_tile.set_text_visible(false)
+		print_debug("Setting new text on tile at pos " + str(new_pos))
 		current_tile.set_text_visible(true)
 		previous_visible_tile = current_tile
 

--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -5,6 +5,9 @@ extends Control
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	await Helper.save_helper.all_chunks_unloaded
+	Helper.map_manager.level_generator.unload_all_chunks()
+	await Helper.map_manager.level_generator.all_chunks_unloaded
+	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
+	Helper.overmap_manager.unload_all_remaining_segments()
 	Helper.signal_broker.game_ended.emit()
 	get_tree().change_scene_to_file("res://scene_selector.tscn")

--- a/Scripts/WearableSlot.gd
+++ b/Scripts/WearableSlot.gd
@@ -89,8 +89,11 @@ func _can_drop_data(_newpos, data) -> bool:
 		var prototype_id = item.get("prototype_id")
 
 		if prototype_id:
-			# Only allow the user to drop the item if it matches the slot id
-			return Gamedata.items.by_id(prototype_id).wearable.slot == slot_id
+			
+			var ditem = Gamedata.items.by_id(prototype_id)
+			if ditem and ditem.wearable:
+				# Only allow the user to drop the item if it matches the slot id
+				return ditem.wearable.slot == slot_id
 	return false
 
 

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -398,7 +398,6 @@ func remove_inventory_item(item: InventoryItem) -> bool:
 	var iteminventory: InventoryStacked = item.get_inventory()
 	if iteminventory.has_item(item):
 		if iteminventory.remove_item(item):
-			Helper.signal_broker.item_removed_from_inventory.emit(item)
 			return true
 		else:
 			print_debug("Failed to remove item from inventory.")


### PR DESCRIPTION
Requires #304 
Fixes #295 

The bug was because of object pooling. The tile kept it's text visible after moving trough the tile pool. Now the tile's text is reset and only the one that needs the marker will have it's text visible.