### PR TITLE
No visible roof on spawn

### DIFF
--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -3,6 +3,9 @@ extends Node3D
   # Initialize with a value that's unlikely to be a valid starting Y-level
 var last_player_y_level: float = -1
 
+func _ready():
+	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	var player = get_tree().get_first_node_in_group("Players")
@@ -30,3 +33,11 @@ func update_visibility(player_y: float):
 		# Add 0.1 margin otherwise they are invisible on high furniture.
 		var is_above_player = container.global_position.y-0.1 > player_y
 		container.visible = not is_above_player
+
+
+# When the initial chuks around the player are generated, 
+# we update the visibility even before the player moves.
+func _on_initial_chunks_generated():
+	var player = get_tree().get_first_node_in_group("Players")
+	if player:
+		update_visibility(player.global_position.y)

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -19,6 +19,9 @@ var previous_visible_tile: Control = null
 # Object pool for reusing tiles
 var tile_pool: Array = []
 
+# Dictionary to keep track of text visibility by coordinate
+var text_visible_by_coord: Dictionary = {}
+
 # We will emit this signal when the position_coords change
 # Which happens when the user has panned the overmap
 signal position_coord_changed(delta: Vector2)
@@ -179,6 +182,12 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 			tile.set_meta("global_pos", global_pos)
 			tile.set_meta("local_pos", local_pos)
 
+			# Check if this global position has text visibility set
+			if text_visible_by_coord.has(global_pos) and text_visible_by_coord[global_pos]:
+				tile.set_text_visible(true)
+			else:
+				tile.set_text_visible(false)
+
 			if global_pos == Vector2.ZERO:
 				tile.set_color(Color(0.3, 0.3, 1))  # blue color
 			else:
@@ -190,7 +199,7 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 	return grid_container
 
 
-#This function will be connected to the signal of the tiles
+# This function will be connected to the signal of the tiles
 func _on_tile_clicked(clicked_tile):
 	if clicked_tile.has_meta("map_file"):
 		selected_overmap_tile = clicked_tile
@@ -235,10 +244,16 @@ func _on_home_button_button_up():
 
 # Function to update the visibility of overmap tile text
 func update_overmap_tile_visibility(new_pos: Vector2):
+	if previous_visible_tile:
+		previous_visible_tile.set_text_visible(false)
+
+	# Update the dictionary to reflect the new position with visible text
+	text_visible_by_coord.clear()
+	text_visible_by_coord[new_pos] = true
+
 	var current_tile = get_overmap_tile_at_position(new_pos)
 	if current_tile:
-		if previous_visible_tile and previous_visible_tile != current_tile:
-			previous_visible_tile.set_text_visible(false)
+		print_debug("Setting new text on tile at pos " + str(new_pos))
 		current_tile.set_text_visible(true)
 		previous_visible_tile = current_tile
 

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -253,7 +253,6 @@ func update_overmap_tile_visibility(new_pos: Vector2):
 
 	var current_tile = get_overmap_tile_at_position(new_pos)
 	if current_tile:
-		print_debug("Setting new text on tile at pos " + str(new_pos))
 		current_tile.set_text_visible(true)
 		previous_visible_tile = current_tile
 

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -65,7 +65,7 @@ func _ready():
 	chunk_unloaded.connect(_finish_unload)
 	source_geometry_data = NavigationMeshSourceGeometryData3D.new()
 	setup_navigation()
-	# The Helper keeps track of which navigationmap belogns to which chunk. When a navigationagent
+	# The Helper keeps track of which navigationmap belongs to which chunk. When a navigationagent
 	# crosses the chunk boundary, it will get the current chunk's navigationmap id to work with
 	chunk_ready.connect(Helper.on_chunk_loaded.bind({"mypos": mypos, "map": navigation_map_id}))
 	chunk_unloaded.connect(Helper.on_chunk_unloaded.bind({"mypos": mypos}))

--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -5,6 +5,9 @@ extends Control
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	await Helper.save_helper.all_chunks_unloaded
+	Helper.map_manager.level_generator.unload_all_chunks()
+	await Helper.map_manager.level_generator.all_chunks_unloaded
+	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
+	Helper.overmap_manager.unload_all_remaining_segments()
 	Helper.signal_broker.game_ended.emit()
 	get_tree().change_scene_to_file("res://scene_selector.tscn")

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -72,6 +72,9 @@ signal data_sprites_changed(contentData: Dictionary, spriteid: String)
 # When a mob was killed
 signal mob_killed(mobinstance: Mob)
 
+signal initial_chunks_generated() # When the chunks around the player's spawn position are generated
+
+
 # We signal to the hud to start a progressbar
 func on_start_timer_progressbar(time_left: float):
 	hud_start_progressbar.emit(time_left)

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -398,7 +398,6 @@ func remove_inventory_item(item: InventoryItem) -> bool:
 	var iteminventory: InventoryStacked = item.get_inventory()
 	if iteminventory.has_item(item):
 		if iteminventory.remove_item(item):
-			Helper.signal_broker.item_removed_from_inventory.emit(item)
 			return true
 		else:
 			print_debug("Failed to remove item from inventory.")


### PR DESCRIPTION
Requires #305 
Fixes #292 

Adds a signal that is emitted when the initial chunks are done loading. Well, not exactly. It's emitted when all initial chunks are initialized and some are done loading. This will work for the purposes of this pr. 

When the signal is emitted, the visibility of blocks above the player will update, even if the player is not moving. This also paves the way for the loading screen to hide itself when it's implemented.

I tested it by loading a game where the player is on the first floor and under a roof. It takes a moment, but then the roof is hidden.