### PR TITLE
Save map chunks

### DIFF
--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -3,6 +3,9 @@ extends Node3D
   # Initialize with a value that's unlikely to be a valid starting Y-level
 var last_player_y_level: float = -1
 
+func _ready():
+	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	var player = get_tree().get_first_node_in_group("Players")
@@ -30,3 +33,11 @@ func update_visibility(player_y: float):
 		# Add 0.1 margin otherwise they are invisible on high furniture.
 		var is_above_player = container.global_position.y-0.1 > player_y
 		container.visible = not is_above_player
+
+
+# When the initial chuks around the player are generated, 
+# we update the visibility even before the player moves.
+func _on_initial_chunks_generated():
+	var player = get_tree().get_first_node_in_group("Players")
+	if player:
+		update_visibility(player.global_position.y)

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -126,7 +126,7 @@
 				"id": "pistol_magazine",
 				"max": 1,
 				"min": 1,
-				"probability": 10
+				"probability": 15
 			},
 			{
 				"id": "pistol_9mm",

--- a/Mods/Core/Maps/generichouse_t.json
+++ b/Mods/Core/Maps/generichouse_t.json
@@ -4495,6 +4495,10 @@
 				"rotation": 180
 			},
 			{
+				"furniture": {
+					"id": "door_wood",
+					"rotation": 270
+				},
 				"id": "orange_carpet_00",
 				"rotation": 180
 			},
@@ -16361,7 +16365,7 @@
 				"rotation": 180
 			},
 			{
-
+				"id": "brick_wall_01"
 			},
 			{
 

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -19,6 +19,9 @@ var previous_visible_tile: Control = null
 # Object pool for reusing tiles
 var tile_pool: Array = []
 
+# Dictionary to keep track of text visibility by coordinate
+var text_visible_by_coord: Dictionary = {}
+
 # We will emit this signal when the position_coords change
 # Which happens when the user has panned the overmap
 signal position_coord_changed(delta: Vector2)
@@ -179,6 +182,12 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 			tile.set_meta("global_pos", global_pos)
 			tile.set_meta("local_pos", local_pos)
 
+			# Check if this global position has text visibility set
+			if text_visible_by_coord.has(global_pos) and text_visible_by_coord[global_pos]:
+				tile.set_text_visible(true)
+			else:
+				tile.set_text_visible(false)
+
 			if global_pos == Vector2.ZERO:
 				tile.set_color(Color(0.3, 0.3, 1))  # blue color
 			else:
@@ -190,7 +199,7 @@ func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vect
 	return grid_container
 
 
-#This function will be connected to the signal of the tiles
+# This function will be connected to the signal of the tiles
 func _on_tile_clicked(clicked_tile):
 	if clicked_tile.has_meta("map_file"):
 		selected_overmap_tile = clicked_tile
@@ -235,10 +244,16 @@ func _on_home_button_button_up():
 
 # Function to update the visibility of overmap tile text
 func update_overmap_tile_visibility(new_pos: Vector2):
+	if previous_visible_tile:
+		previous_visible_tile.set_text_visible(false)
+
+	# Update the dictionary to reflect the new position with visible text
+	text_visible_by_coord.clear()
+	text_visible_by_coord[new_pos] = true
+
 	var current_tile = get_overmap_tile_at_position(new_pos)
 	if current_tile:
-		if previous_visible_tile and previous_visible_tile != current_tile:
-			previous_visible_tile.set_text_visible(false)
+		print_debug("Setting new text on tile at pos " + str(new_pos))
 		current_tile.set_text_visible(true)
 		previous_visible_tile = current_tile
 

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -253,7 +253,6 @@ func update_overmap_tile_visibility(new_pos: Vector2):
 
 	var current_tile = get_overmap_tile_at_position(new_pos)
 	if current_tile:
-		print_debug("Setting new text on tile at pos " + str(new_pos))
 		current_tile.set_text_visible(true)
 		previous_visible_tile = current_tile
 

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -423,15 +423,27 @@ func get_chunk_data() -> Dictionary:
 # the helper variable. First we wait until the current thread is finished.
 func unload_chunk():
 	start_unloading()
-	await Helper.task_manager.create_task(save_and_unload_chunk).completed
+	await Helper.task_manager.create_task(free_chunk_resources).completed
 	chunk_unloaded.emit()
 
 
+# Saves all the chunk data and then unloads it
+# You might want to call this by:
+# await Helper.task_manager.create_task(chunk.save_and_unload_chunk).completed
 func save_and_unload_chunk():
+	start_unloading()
+	save_chunk()  # Save the chunk data
+	free_chunk_resources()
+	chunk_unloaded.emit()
+
+
+# Save chunk data without unloading the chunk
+# You might want to call this by:
+# await Helper.task_manager.create_task(chunk.save_chunk).completed
+func save_chunk():
 	var chunkdata: Dictionary = get_chunk_data()
 	var chunkposition: Vector2 = Vector2(int(chunkdata.chunk_x/32),int(chunkdata.chunk_z/32))
 	Helper.overmap_manager.loaded_chunk_data.chunks[chunkposition] = chunkdata
-	free_chunk_resources()
 
 
 # Adds triangles represented by 3 vertices to the navigation mesh data

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -65,7 +65,7 @@ func _ready():
 	chunk_unloaded.connect(_finish_unload)
 	source_geometry_data = NavigationMeshSourceGeometryData3D.new()
 	setup_navigation()
-	# The Helper keeps track of which navigationmap belogns to which chunk. When a navigationagent
+	# The Helper keeps track of which navigationmap belongs to which chunk. When a navigationagent
 	# crosses the chunk boundary, it will get the current chunk's navigationmap id to work with
 	chunk_ready.connect(Helper.on_chunk_loaded.bind({"mypos": mypos, "map": navigation_map_id}))
 	chunk_unloaded.connect(Helper.on_chunk_unloaded.bind({"mypos": mypos}))

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -23,13 +23,8 @@ func _process(_delta):
 
 
 # Called when the save button is pressed.
-# TODO: We should just call Helper.save_helper.save_game() instead
-# But before we can do that, we need to separate saving the map data from unloading the chunks
-# We will need to modify Chunk.gd for that.
 func _on_save_button_pressed():
-	Helper.save_helper.save_player_inventory()
-	Helper.save_helper.save_player_equipment()
-	Helper.save_helper.save_player_state(get_tree().get_first_node_in_group("Players"))
+	Helper.save_helper.save_game()
 
 
 # Called when the resume button is pressed.
@@ -65,7 +60,4 @@ func _resume_game():
 func _return_to_main_menu():
 	if is_inside_tree():
 		get_tree().paused = false
-		Helper.save_helper.save_game()
-		await Helper.save_helper.all_chunks_unloaded
-		Helper.signal_broker.game_ended.emit()
-		get_tree().change_scene_to_file("res://scene_selector.tscn")
+		Helper.save_and_exit_game()

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -96,25 +96,11 @@ func _physics_process(_delta) -> void:
 	# or set_position is too late and it's differs from furnitureposition because it's still 0,0
 	# So we add in extra checks to handle those edge cases. There's probably a better way
 	var is_zero = global_transform.origin.x == 0 and global_transform.origin.z == 0
-	if (x_changed or z_changed) and not is_in_current_chunk() and not is_zero:
+	if (x_changed or z_changed) and not is_zero:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:
 		last_rotation = current_rotation
-
-
-# Returns if the current position is inside the current chunk
-func is_in_current_chunk() -> bool:
-	var chunk_pos: Vector3 = current_chunk.mypos
-	var chunk_range: Vector3 = chunk_pos + Vector3(32, 0, 32)
-
-	var myposition: Vector3 = global_transform.origin
-
-	# Check if position is within chunk bounds in the x and z axes
-	var in_x_range: bool = (myposition.x >= chunk_pos.x) and (myposition.x <= chunk_range.x)
-	var in_z_range: bool = (myposition.z >= chunk_pos.z) and (myposition.z <= chunk_range.z)
-
-	return in_x_range and in_z_range
 
 
 # Set the new rotation for the furniture

--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -5,6 +5,9 @@ extends Control
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	await Helper.save_helper.all_chunks_unloaded
+	Helper.map_manager.level_generator.unload_all_chunks()
+	await Helper.map_manager.level_generator.all_chunks_unloaded
+	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
+	Helper.overmap_manager.unload_all_remaining_segments()
 	Helper.signal_broker.game_ended.emit()
 	get_tree().change_scene_to_file("res://scene_selector.tscn")

--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -5,9 +5,4 @@ extends Control
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	Helper.map_manager.level_generator.unload_all_chunks()
-	await Helper.map_manager.level_generator.all_chunks_unloaded
-	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
-	Helper.overmap_manager.unload_all_remaining_segments()
-	Helper.signal_broker.game_ended.emit()
-	get_tree().change_scene_to_file("res://scene_selector.tscn")
+	Helper.exit_game()

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -62,6 +62,22 @@ func reset():
 	ItemManager.player_equipment.reset_to_default()
 
 
+# When the player quits without saving (i.e. game over)
+func exit_game():
+	Helper.overmap_manager.player.axis_lock_linear_y = true # Stop vertical movement
+	Helper.map_manager.level_generator.unload_all_chunks()
+	await Helper.map_manager.level_generator.all_chunks_unloaded
+	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
+	Helper.overmap_manager.unload_all_remaining_segments()
+	Helper.signal_broker.game_ended.emit()
+	get_tree().change_scene_to_file("res://scene_selector.tscn")
+
+
+# When the player saves and quits (i.e. return to main menu)
+func save_and_exit_game():
+	Helper.save_helper.save_game()
+	exit_game()
+
 
 #Level_name is a filename in /mods/core/maps
 #global_pos is the absolute position on the overmap

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -30,7 +30,8 @@ func save_map_data() -> void:
 	var chunks = get_tree().get_nodes_in_group("chunks")
 	for chunk in chunks:
 		if is_instance_valid(chunk): # some might be queue_freed at this point
-			await Helper.task_manager.create_task(chunk.save_chunk).completed
+			chunk.save_chunk()
+			#await Helper.task_manager.create_task(chunk.save_chunk).completed
 
 
 # Function to save a map segment to disk. The Helper.overmap_manager will call this
@@ -97,6 +98,7 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 # Save game state
 func save_game():
 	save_map_data()
+	Helper.overmap_manager.save_all_segments()
 	save_player_inventory()
 	save_player_equipment()
 	save_player_state(get_tree().get_first_node_in_group("Players"))

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -7,7 +7,6 @@ extends Node
 #It also has functions to load saved data and place the items, mobs and tiles on the map
 
 var current_save_folder: String = ""
-signal all_chunks_unloaded
 
 
 #Creates a new save folder. The name of this folder will be the current date and time
@@ -27,16 +26,11 @@ func create_new_save():
 
 # We can only save the data when all chunks are unloaded.
 func save_map_data() -> void:
-	Helper.map_manager.level_generator.all_chunks_unloaded.connect(_on_chunks_unloaded)
-	Helper.map_manager.level_generator.unload_all_chunks()
-
-
-# The level_generator has unloaded all the chunks. Save the data to disk
-func _on_chunks_unloaded():
-		print_debug("All chunks are unloaded")
-		# Devides the loaded_chunk_data.chunks into segments and saves them to disk
-		Helper.overmap_manager.unload_all_remaining_segments()
-		all_chunks_unloaded.emit()
+	# Get all chunks in the group "chunks"
+	var chunks = get_tree().get_nodes_in_group("chunks")
+	for chunk in chunks:
+		if is_instance_valid(chunk): # some might be queue_freed at this point
+			await Helper.task_manager.create_task(chunk.save_chunk).completed
 
 
 # Function to save a map segment to disk. The Helper.overmap_manager will call this
@@ -81,7 +75,6 @@ func load_map_segment_data(segment_pos: Vector2) -> Dictionary:
 		chunk_data[chunk_pos] = tactical_map_json[key]
 	
 	return chunk_data
-
 
 
 # This function determines the saved map folder path for the current level. 

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -72,6 +72,9 @@ signal data_sprites_changed(contentData: Dictionary, spriteid: String)
 # When a mob was killed
 signal mob_killed(mobinstance: Mob)
 
+signal initial_chunks_generated() # When the chunks around the player's spawn position are generated
+
+
 # We signal to the hud to start a progressbar
 func on_start_timer_progressbar(time_left: float):
 	hud_start_progressbar.emit(time_left)


### PR DESCRIPTION
Requires #306 
Fixes #294 

You can now save chunks from the escape menu. This will save the map around you, so you come back to the same furniture and items and their positions. 

Had to fiddle with the chunk timers, so there will be a delay when exiting the game so it doesn't crash when all chunks are unloaded. To make it quicker, we'd have to investigate and resolve the reason it crashes when unloading chunks on a thread.