### PR TITLE
Loading screen

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://bxubu34gjes1y"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 
@@ -45,7 +45,6 @@ json_data = "[
 					\"disassembled_furniture_medium\"
 				],
 				\"items\": [
-					\"pistol_magazine\",
 					\"screwdriver\"
 				]
 			}
@@ -71,9 +70,6 @@ json_data = "[
 					\"cabinet_general\",
 					\"mob_loot\",
 					\"test_items\"
-				],
-				\"items\": [
-					\"pistol_magazine\"
 				]
 			}
 		},
@@ -82,59 +78,6 @@ json_data = "[
 		\"two_handed\": false,
 		\"volume\": 0.1,
 		\"weight\": 0.01
-	},
-	{
-		\"Craft\": [
-			{
-				\"craft_amount\": 1,
-				\"craft_time\": 10,
-				\"flags\": {
-					\"requires_light\": true
-				},
-				\"required_resources\": [
-					{
-						\"amount\": 1,
-						\"id\": \"steel_scrap\"
-					},
-					{
-						\"amount\": 10,
-						\"id\": \"bullet_9mm\"
-					}
-				],
-				\"skill_progression\": {
-					\"id\": \"fabrication\",
-					\"xp\": 10
-				},
-				\"skill_requirement\": {
-					\"id\": \"fabrication\",
-					\"level\": 1
-				}
-			}
-		],
-		\"Magazine\": {
-			\"current_ammo\": 19,
-			\"max_ammo\": 20,
-			\"used_ammo\": \"bullet_9mm\"
-		},
-		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
-		\"id\": \"pistol_magazine\",
-		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
-		\"max_stack_size\": 1,
-		\"name\": \"Pistol magazine\",
-		\"references\": {
-			\"core\": {
-				\"itemgroups\": [
-					\"cabinet_general\",
-					\"mob_loot\",
-					\"test_items\"
-				]
-			}
-		},
-		\"sprite\": \"pistol_magazine.png\",
-		\"stack_size\": 1,
-		\"two_handed\": false,
-		\"volume\": 10,
-		\"weight\": 0.25
 	},
 	{
 		\"Ranged\": {

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -221,25 +221,19 @@ func update_queues(potential_loads, potential_unloads):
 
 # This function will either load or unload a chunk if there are any to load or unload
 func process_next_chunk():
-	print_debug("process_next_chunk called")
 	if is_processing_chunk:
-		print_debug("is_processing_chunk is true, returning")
 		return  # Wait until the current chunk operation is finished
 
 	if load_queue.size() > 0:
 		var chunk_pos = load_queue.pop_front()
-		print_debug("Loading chunk at position: ", chunk_pos)
 		is_processing_chunk = true
 		load_chunk(chunk_pos)
 	elif unload_queue.size() > 0:
 		var chunk_pos = unload_queue.pop_front()
-		print_debug("Unloading chunk at position: ", chunk_pos)
 		is_processing_chunk = true
 		save_and_unload_chunk(chunk_pos)
 	else:
-		print_debug("No chunks left to process")
 		is_processing_chunk = false  # No chunks left to process
-
 
 
 # Returns the chunk instance at the given position

--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -3,6 +3,9 @@ extends Node3D
   # Initialize with a value that's unlikely to be a valid starting Y-level
 var last_player_y_level: float = -1
 
+func _ready():
+	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	var player = get_tree().get_first_node_in_group("Players")
@@ -30,3 +33,11 @@ func update_visibility(player_y: float):
 		# Add 0.1 margin otherwise they are invisible on high furniture.
 		var is_above_player = container.global_position.y-0.1 > player_y
 		container.visible = not is_above_player
+
+
+# When the initial chuks around the player are generated, 
+# we update the visibility even before the player moves.
+func _on_initial_chunks_generated():
+	var player = get_tree().get_first_node_in_group("Players")
+	if player:
+		update_visibility(player.global_position.y)

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -168,7 +168,7 @@
 				"id": "can_oil",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "flashlight_basic",
@@ -780,7 +780,7 @@
 				"id": "sharp_stone",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 40
 			},
 			{
 				"id": "small_rock",
@@ -845,7 +845,7 @@
 				"id": "long_stick",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 50
 			},
 			{
 				"id": "stick",

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -126,7 +126,7 @@
 				"id": "pistol_magazine",
 				"max": 1,
 				"min": 1,
-				"probability": 10
+				"probability": 15
 			},
 			{
 				"id": "pistol_9mm",

--- a/Mods/Core/Maps/field_grass_basic_00.json
+++ b/Mods/Core/Maps/field_grass_basic_00.json
@@ -93,7 +93,7 @@
 			"spawn_chance": 30,
 			"tiles": [
 				{
-					"count": 1000,
+					"count": 900,
 					"id": "null"
 				}
 			]

--- a/Mods/Core/Maps/generichouse_t.json
+++ b/Mods/Core/Maps/generichouse_t.json
@@ -4495,6 +4495,10 @@
 				"rotation": 180
 			},
 			{
+				"furniture": {
+					"id": "door_wood",
+					"rotation": 270
+				},
 				"id": "orange_carpet_00",
 				"rotation": 180
 			},
@@ -16361,7 +16365,7 @@
 				"rotation": 180
 			},
 			{
-
+				"id": "brick_wall_01"
 			},
 			{
 

--- a/Scenes/LoadingScreen.tscn
+++ b/Scenes/LoadingScreen.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=2 format=3 uid="uid://dowehl4nfwxm"]
+
+[ext_resource type="Script" path="res://Scripts/LoadingScreen.gd" id="1_nmrn0"]
+
+[node name="LoadingScreen" type="Control" node_paths=PackedStringArray("sub_label")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_nmrn0")
+sub_label = NodePath("VBoxContainer/SubLabel")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.129412, 0.14902, 0.180392, 1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -89.5
+offset_top = -52.0
+offset_right = 89.5
+offset_bottom = 52.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="LoadingLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Loading..."
+horizontal_alignment = 1
+
+[node name="SubLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Initializing"
+horizontal_alignment = 1

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -253,7 +253,6 @@ func update_overmap_tile_visibility(new_pos: Vector2):
 
 	var current_tile = get_overmap_tile_at_position(new_pos)
 	if current_tile:
-		print_debug("Setting new text on tile at pos " + str(new_pos))
 		current_tile.set_text_visible(true)
 		previous_visible_tile = current_tile
 

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -423,15 +423,27 @@ func get_chunk_data() -> Dictionary:
 # the helper variable. First we wait until the current thread is finished.
 func unload_chunk():
 	start_unloading()
-	await Helper.task_manager.create_task(save_and_unload_chunk).completed
+	await Helper.task_manager.create_task(free_chunk_resources).completed
 	chunk_unloaded.emit()
 
 
+# Saves all the chunk data and then unloads it
+# You might want to call this by:
+# await Helper.task_manager.create_task(chunk.save_and_unload_chunk).completed
 func save_and_unload_chunk():
+	start_unloading()
+	save_chunk()  # Save the chunk data
+	free_chunk_resources()
+	chunk_unloaded.emit()
+
+
+# Save chunk data without unloading the chunk
+# You might want to call this by:
+# await Helper.task_manager.create_task(chunk.save_chunk).completed
+func save_chunk():
 	var chunkdata: Dictionary = get_chunk_data()
 	var chunkposition: Vector2 = Vector2(int(chunkdata.chunk_x/32),int(chunkdata.chunk_z/32))
 	Helper.overmap_manager.loaded_chunk_data.chunks[chunkposition] = chunkdata
-	free_chunk_resources()
 
 
 # Adds triangles represented by 3 vertices to the navigation mesh data

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -65,7 +65,7 @@ func _ready():
 	chunk_unloaded.connect(_finish_unload)
 	source_geometry_data = NavigationMeshSourceGeometryData3D.new()
 	setup_navigation()
-	# The Helper keeps track of which navigationmap belogns to which chunk. When a navigationagent
+	# The Helper keeps track of which navigationmap belongs to which chunk. When a navigationagent
 	# crosses the chunk boundary, it will get the current chunk's navigationmap id to work with
 	chunk_ready.connect(Helper.on_chunk_loaded.bind({"mypos": mypos, "map": navigation_map_id}))
 	chunk_unloaded.connect(Helper.on_chunk_unloaded.bind({"mypos": mypos}))

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -106,12 +106,13 @@ func _on_recipe_button_pressed(recipe: DItem.CraftRecipe):
 		resource_container.add_child(label)
 
 	# Display skill progression information if it exists
-	var skill_id = Helper.json_helper.get_nested_data(recipe, "skill_progression.id")
-	var skill_xp = Helper.json_helper.get_nested_data(recipe, "skill_progression.xp")
-	if skill_id and skill_xp:
-		skill_progression_label.text = "Get XP: %s: %s" % [skill_id, skill_xp]
-	else:
-		skill_progression_label.text = ""
+	if recipe.skill_progression:
+		var skill_id = recipe.skill_progression.id
+		var skill_xp = recipe.skill_progression.xp
+		if skill_id and skill_xp:
+			skill_progression_label.text = "Get XP: %s: %s" % [skill_id, skill_xp]
+		else:
+			skill_progression_label.text = ""
 
 
 func _on_start_crafting_button_pressed():
@@ -209,11 +210,11 @@ func display_feedback(message: String, color: Color):
 	timer.start()
 
 
-func _on_craft_successful(_item: Dictionary, _recipe: Dictionary):
+func _on_craft_successful(_item: DItem, _recipe: DItem.CraftRecipe):
 	var color = Color(0.4, 1, 0.4)  # Brighter green color with more white
 	display_feedback("craft succesful!", color)
 
 
-func _on_craft_failed(_item: Dictionary, _recipe: Dictionary, reason: String):
+func _on_craft_failed(_item: DItem, _recipe: DItem.CraftRecipe, reason: String):
 	var color = Color(1, 0, 0)  # Red color
 	display_feedback(reason, color)

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -6,6 +6,7 @@ extends Control
 @export var resume_button: Button
 @export var return_button: Button
 @export var save_button: Button
+@export var loadingscreen: Control
 
 
 # Called when the node enters the scene tree for the first time.
@@ -60,4 +61,5 @@ func _resume_game():
 func _return_to_main_menu():
 	if is_inside_tree():
 		get_tree().paused = false
+		loadingscreen.on_exit_game()
 		Helper.save_and_exit_game()

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -23,13 +23,8 @@ func _process(_delta):
 
 
 # Called when the save button is pressed.
-# TODO: We should just call Helper.save_helper.save_game() instead
-# But before we can do that, we need to separate saving the map data from unloading the chunks
-# We will need to modify Chunk.gd for that.
 func _on_save_button_pressed():
-	Helper.save_helper.save_player_inventory()
-	Helper.save_helper.save_player_equipment()
-	Helper.save_helper.save_player_state(get_tree().get_first_node_in_group("Players"))
+	Helper.save_helper.save_game()
 
 
 # Called when the resume button is pressed.
@@ -65,7 +60,4 @@ func _resume_game():
 func _return_to_main_menu():
 	if is_inside_tree():
 		get_tree().paused = false
-		Helper.save_helper.save_game()
-		await Helper.save_helper.all_chunks_unloaded
-		Helper.signal_broker.game_ended.emit()
-		get_tree().change_scene_to_file("res://scene_selector.tscn")
+		Helper.save_and_exit_game()

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -96,25 +96,11 @@ func _physics_process(_delta) -> void:
 	# or set_position is too late and it's differs from furnitureposition because it's still 0,0
 	# So we add in extra checks to handle those edge cases. There's probably a better way
 	var is_zero = global_transform.origin.x == 0 and global_transform.origin.z == 0
-	if (x_changed or z_changed) and not is_in_current_chunk() and not is_zero:
+	if (x_changed or z_changed) and not is_zero:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:
 		last_rotation = current_rotation
-
-
-# Returns if the current position is inside the current chunk
-func is_in_current_chunk() -> bool:
-	var chunk_pos: Vector3 = current_chunk.mypos
-	var chunk_range: Vector3 = chunk_pos + Vector3(32, 0, 32)
-
-	var myposition: Vector3 = global_transform.origin
-
-	# Check if position is within chunk bounds in the x and z axes
-	var in_x_range: bool = (myposition.x >= chunk_pos.x) and (myposition.x <= chunk_range.x)
-	var in_z_range: bool = (myposition.z >= chunk_pos.z) and (myposition.z <= chunk_range.z)
-
-	return in_x_range and in_z_range
 
 
 # Set the new rotation for the furniture

--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -5,9 +5,4 @@ extends Control
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	Helper.map_manager.level_generator.unload_all_chunks()
-	await Helper.map_manager.level_generator.all_chunks_unloaded
-	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
-	Helper.overmap_manager.unload_all_remaining_segments()
-	Helper.signal_broker.game_ended.emit()
-	get_tree().change_scene_to_file("res://scene_selector.tscn")
+	Helper.exit_game()

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -34,8 +34,8 @@ class CraftRecipe:
 	var craft_time: int
 	var flags: Dictionary
 	var required_resources: Array # A list of objects like {"amount": 1, "id": "steel_scrap"}
-	var skill_progression: Dictionary
-	var skill_requirement: Dictionary
+	var skill_progression: Dictionary # example: { "id": "fabrication", "xp": 10 }
+	var skill_requirement: Dictionary # example: { "id": "fabrication", "level": 1 }
 
 	# Constructor to initialize craft properties from a dictionary
 	func _init(data: Dictionary):

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -62,6 +62,22 @@ func reset():
 	ItemManager.player_equipment.reset_to_default()
 
 
+# When the player quits without saving (i.e. game over)
+func exit_game():
+	Helper.overmap_manager.player.axis_lock_linear_y = true # Stop vertical movement
+	Helper.map_manager.level_generator.unload_all_chunks()
+	await Helper.map_manager.level_generator.all_chunks_unloaded
+	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
+	Helper.overmap_manager.unload_all_remaining_segments()
+	Helper.signal_broker.game_ended.emit()
+	get_tree().change_scene_to_file("res://scene_selector.tscn")
+
+
+# When the player saves and quits (i.e. return to main menu)
+func save_and_exit_game():
+	Helper.save_helper.save_game()
+	exit_game()
+
 
 #Level_name is a filename in /mods/core/maps
 #global_pos is the absolute position on the overmap

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -221,7 +221,7 @@ func _on_mob_killed(mobinstance: Mob):
 
 
 # The player has succesfully crafted an item.
-func _on_craft_successful(item: Dictionary, _recipe: Dictionary):
+func _on_craft_successful(item: Dictionary, _recipe: DItem.CraftRecipe):
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the collected item information

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -221,7 +221,7 @@ func _on_mob_killed(mobinstance: Mob):
 
 
 # The player has succesfully crafted an item.
-func _on_craft_successful(item: Dictionary, _recipe: DItem.CraftRecipe):
+func _on_craft_successful(item: DItem, _recipe: DItem.CraftRecipe):
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the collected item information

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -30,7 +30,8 @@ func save_map_data() -> void:
 	var chunks = get_tree().get_nodes_in_group("chunks")
 	for chunk in chunks:
 		if is_instance_valid(chunk): # some might be queue_freed at this point
-			await Helper.task_manager.create_task(chunk.save_chunk).completed
+			chunk.save_chunk()
+			#await Helper.task_manager.create_task(chunk.save_chunk).completed
 
 
 # Function to save a map segment to disk. The Helper.overmap_manager will call this
@@ -97,6 +98,7 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 # Save game state
 func save_game():
 	save_map_data()
+	Helper.overmap_manager.save_all_segments()
 	save_player_inventory()
 	save_player_equipment()
 	save_player_state(get_tree().get_first_node_in_group("Players"))

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -7,7 +7,6 @@ extends Node
 #It also has functions to load saved data and place the items, mobs and tiles on the map
 
 var current_save_folder: String = ""
-signal all_chunks_unloaded
 
 
 #Creates a new save folder. The name of this folder will be the current date and time
@@ -27,16 +26,11 @@ func create_new_save():
 
 # We can only save the data when all chunks are unloaded.
 func save_map_data() -> void:
-	Helper.map_manager.level_generator.all_chunks_unloaded.connect(_on_chunks_unloaded)
-	Helper.map_manager.level_generator.unload_all_chunks()
-
-
-# The level_generator has unloaded all the chunks. Save the data to disk
-func _on_chunks_unloaded():
-		print_debug("All chunks are unloaded")
-		# Devides the loaded_chunk_data.chunks into segments and saves them to disk
-		Helper.overmap_manager.unload_all_remaining_segments()
-		all_chunks_unloaded.emit()
+	# Get all chunks in the group "chunks"
+	var chunks = get_tree().get_nodes_in_group("chunks")
+	for chunk in chunks:
+		if is_instance_valid(chunk): # some might be queue_freed at this point
+			await Helper.task_manager.create_task(chunk.save_chunk).completed
 
 
 # Function to save a map segment to disk. The Helper.overmap_manager will call this
@@ -81,7 +75,6 @@ func load_map_segment_data(segment_pos: Vector2) -> Dictionary:
 		chunk_data[chunk_pos] = tactical_map_json[key]
 	
 	return chunk_data
-
 
 
 # This function determines the saved map folder path for the current level. 

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -61,6 +61,7 @@ signal playerInventory_item_modified(item: InventoryItem, inventory: InventorySt
 signal player_stat_changed(player: CharacterBody3D)
 signal player_skill_changed(player: CharacterBody3D)
 
+# Save load start end events
 signal game_started() # When the user presses 'play demo' on the main menu
 signal game_loaded() # When the user presses 'load game' on the main menu
 signal game_ended() # When the user presses 'main menu' button on the escape menu

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -72,6 +72,9 @@ signal data_sprites_changed(contentData: Dictionary, spriteid: String)
 # When a mob was killed
 signal mob_killed(mobinstance: Mob)
 
+signal initial_chunks_generated() # When the chunks around the player's spawn position are generated
+
+
 # We signal to the hud to start a progressbar
 func on_start_timer_progressbar(time_left: float):
 	hud_start_progressbar.emit(time_left)

--- a/Scripts/LoadingScreen.gd
+++ b/Scripts/LoadingScreen.gd
@@ -1,0 +1,27 @@
+extends Control
+
+
+# This script belongs to the loading window that shows in-game when the map is loading
+@export var sub_label: Label
+
+
+func _init():
+	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
+	Helper.signal_broker.game_started.connect(update_sub_text.bind("Creating new save"))
+	Helper.signal_broker.game_loaded.connect(update_sub_text.bind("Loading saved game"))
+	Helper.signal_broker.player_spawned.connect(_on_player_spawned)
+	
+func _on_initial_chunks_generated():
+	visible = false
+
+func update_sub_text(newtext: String):
+	sub_label.text = newtext
+
+# Function for handling player spawned signal
+func _on_player_spawned(_playernode):
+	sub_label.text = "Spawning player"
+
+
+func on_exit_game():
+	visible = true
+	sub_label.text = "Quitting game..."

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -442,8 +442,6 @@ func add_skill_xp(skill_id: String, xp: float) -> void:
 
 # The player has succesfully crafted an item. Get the skill id and xp from
 # the recipe and add it to the player's skill xp
-func _on_craft_successful(_item: Dictionary, recipe: Dictionary):
-	var skill_id = Helper.json_helper.get_nested_data(recipe, "skill_progression.id")
-	var xp = Helper.json_helper.get_nested_data(recipe, "skill_progression.xp")
-	if skill_id and xp:
-		add_skill_xp(skill_id, xp)
+func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
+	if recipe.skill_progression:
+		add_skill_xp(recipe.skill_progression.id, recipe.skill_progression.xp)

--- a/hud.tscn
+++ b/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://clhj525tmme3k"]
+[gd_scene load_steps=22 format=3 uid="uid://clhj525tmme3k"]
 
 [ext_resource type="FontFile" uid="uid://chm7lbcdeyo0h" path="res://Roboto-Bold.ttf" id="1_pxloi"]
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
@@ -19,6 +19,7 @@
 [ext_resource type="PackedScene" uid="uid://b50xhj4218wjd" path="res://Scenes/UI/QuestWindow.tscn" id="19_orjb2"]
 [ext_resource type="PackedScene" uid="uid://e0ebcv1n8jnq" path="res://Scenes/InventoryWindow.tscn" id="20_0l505"]
 [ext_resource type="PackedScene" uid="uid://ckuh2s0nvwg0x" path="res://Scenes/GameOver.tscn" id="20_jlthm"]
+[ext_resource type="PackedScene" uid="uid://dowehl4nfwxm" path="res://Scenes/LoadingScreen.tscn" id="20_kxcpa"]
 
 [sub_resource type="Theme" id="Theme_xn5t2"]
 default_font = ExtResource("1_pxloi")
@@ -250,11 +251,14 @@ anchor_top = 0.2
 anchor_right = 0.8
 anchor_bottom = 0.8
 
-[node name="EscapeMenu" parent="." instance=ExtResource("17_ewtgs")]
+[node name="EscapeMenu" parent="." node_paths=PackedStringArray("loadingscreen") instance=ExtResource("17_ewtgs")]
 visible = false
+loadingscreen = NodePath("../LoadingScreen")
 
 [node name="GameOver" parent="." instance=ExtResource("20_jlthm")]
 visible = false
+
+[node name="LoadingScreen" parent="." instance=ExtResource("20_kxcpa")]
 
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]


### PR DESCRIPTION
Requires #309 
Fixes #287 

Adds a loading screen that's visible on top of all other screen and blocking all sight to the game. It has a label that says "loading" and a sub label that can be used to update the player on the progress. Right now it just jumps to "spawning player".

It will also appear when leaving the game trough the escape menu.

Image of the loading screen:
![image](https://github.com/user-attachments/assets/cc0a8754-28fc-4129-8265-c2b0c745c8cd)
