### PR TITLE
Tile class

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -42,9 +42,11 @@ json_data = "[
 					\"cabinet_general\",
 					\"mob_loot\",
 					\"destroyed_furniture_medium\",
-					\"disassembled_furniture_medium\"
+					\"disassembled_furniture_medium\",
+					\"test_items\"
 				],
 				\"items\": [
+					\"pistol_magazine\",
 					\"screwdriver\"
 				]
 			}
@@ -70,6 +72,9 @@ json_data = "[
 					\"cabinet_general\",
 					\"mob_loot\",
 					\"test_items\"
+				],
+				\"items\": [
+					\"pistol_magazine\"
 				]
 			}
 		},
@@ -78,6 +83,59 @@ json_data = "[
 		\"two_handed\": false,
 		\"volume\": 0.1,
 		\"weight\": 0.01
+	},
+	{
+		\"Craft\": [
+			{
+				\"craft_amount\": 1,
+				\"craft_time\": 10,
+				\"flags\": {
+					\"requires_light\": true
+				},
+				\"required_resources\": [
+					{
+						\"amount\": 1,
+						\"id\": \"steel_scrap\"
+					},
+					{
+						\"amount\": 10,
+						\"id\": \"bullet_9mm\"
+					}
+				],
+				\"skill_progression\": {
+					\"id\": \"fabrication\",
+					\"xp\": 10
+				},
+				\"skill_requirement\": {
+					\"id\": \"fabrication\",
+					\"level\": 1
+				}
+			}
+		],
+		\"Magazine\": {
+			\"current_ammo\": 19,
+			\"max_ammo\": 20,
+			\"used_ammo\": \"bullet_9mm\"
+		},
+		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
+		\"id\": \"pistol_magazine\",
+		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
+		\"max_stack_size\": 1,
+		\"name\": \"Pistol magazine\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"cabinet_general\",
+					\"mob_loot\",
+					\"test_items\"
+				]
+			}
+		},
+		\"sprite\": \"pistol_magazine.png\",
+		\"stack_size\": 1,
+		\"two_handed\": false,
+		\"volume\": 10,
+		\"weight\": 0.25
 	},
 	{
 		\"Ranged\": {

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://bxubu34gjes1y"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 
@@ -45,7 +45,6 @@ json_data = "[
 					\"disassembled_furniture_medium\"
 				],
 				\"items\": [
-					\"pistol_magazine\",
 					\"screwdriver\"
 				]
 			}
@@ -71,9 +70,6 @@ json_data = "[
 					\"cabinet_general\",
 					\"mob_loot\",
 					\"test_items\"
-				],
-				\"items\": [
-					\"pistol_magazine\"
 				]
 			}
 		},
@@ -82,59 +78,6 @@ json_data = "[
 		\"two_handed\": false,
 		\"volume\": 0.1,
 		\"weight\": 0.01
-	},
-	{
-		\"Craft\": [
-			{
-				\"craft_amount\": 1,
-				\"craft_time\": 10,
-				\"flags\": {
-					\"requires_light\": true
-				},
-				\"required_resources\": [
-					{
-						\"amount\": 1,
-						\"id\": \"steel_scrap\"
-					},
-					{
-						\"amount\": 10,
-						\"id\": \"bullet_9mm\"
-					}
-				],
-				\"skill_progression\": {
-					\"id\": \"fabrication\",
-					\"xp\": 10
-				},
-				\"skill_requirement\": {
-					\"id\": \"fabrication\",
-					\"level\": 1
-				}
-			}
-		],
-		\"Magazine\": {
-			\"current_ammo\": 19,
-			\"max_ammo\": 20,
-			\"used_ammo\": \"bullet_9mm\"
-		},
-		\"description\": \"In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets\",
-		\"id\": \"pistol_magazine\",
-		\"image\": \"./Mods/Core/Items/pistol_magazine.png\",
-		\"max_stack_size\": 1,
-		\"name\": \"Pistol magazine\",
-		\"references\": {
-			\"core\": {
-				\"itemgroups\": [
-					\"cabinet_general\",
-					\"mob_loot\",
-					\"test_items\"
-				]
-			}
-		},
-		\"sprite\": \"pistol_magazine.png\",
-		\"stack_size\": 1,
-		\"two_handed\": false,
-		\"volume\": 10,
-		\"weight\": 0.25
 	},
 	{
 		\"Ranged\": {

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -221,25 +221,19 @@ func update_queues(potential_loads, potential_unloads):
 
 # This function will either load or unload a chunk if there are any to load or unload
 func process_next_chunk():
-	print_debug("process_next_chunk called")
 	if is_processing_chunk:
-		print_debug("is_processing_chunk is true, returning")
 		return  # Wait until the current chunk operation is finished
 
 	if load_queue.size() > 0:
 		var chunk_pos = load_queue.pop_front()
-		print_debug("Loading chunk at position: ", chunk_pos)
 		is_processing_chunk = true
 		load_chunk(chunk_pos)
 	elif unload_queue.size() > 0:
 		var chunk_pos = unload_queue.pop_front()
-		print_debug("Unloading chunk at position: ", chunk_pos)
 		is_processing_chunk = true
 		save_and_unload_chunk(chunk_pos)
 	else:
-		print_debug("No chunks left to process")
 		is_processing_chunk = false  # No chunks left to process
-
 
 
 # Returns the chunk instance at the given position

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -168,7 +168,7 @@
 				"id": "can_oil",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "flashlight_basic",
@@ -780,7 +780,7 @@
 				"id": "sharp_stone",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 40
 			},
 			{
 				"id": "small_rock",
@@ -845,7 +845,7 @@
 				"id": "long_stick",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 50
 			},
 			{
 				"id": "stick",

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -976,6 +976,12 @@
 				"max": 1,
 				"min": 1,
 				"probability": 100
+			},
+			{
+				"id": "steel_scrap",
+				"max": 22,
+				"min": 22,
+				"probability": 100
 			}
 		],
 		"mode": "Collection",

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -126,7 +126,7 @@
 				"id": "pistol_magazine",
 				"max": 1,
 				"min": 1,
-				"probability": 10
+				"probability": 15
 			},
 			{
 				"id": "pistol_9mm",

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -36,7 +36,8 @@
 					"cabinet_general",
 					"mob_loot",
 					"destroyed_furniture_medium",
-					"disassembled_furniture_medium"
+					"disassembled_furniture_medium",
+					"test_items"
 				],
 				"items": [
 					"pistol_magazine",

--- a/Mods/Core/Maps/field_grass_basic_00.json
+++ b/Mods/Core/Maps/field_grass_basic_00.json
@@ -93,7 +93,7 @@
 			"spawn_chance": 30,
 			"tiles": [
 				{
-					"count": 1000,
+					"count": 900,
 					"id": "null"
 				}
 			]

--- a/Mods/Core/Maps/generichouse_t.json
+++ b/Mods/Core/Maps/generichouse_t.json
@@ -4495,6 +4495,10 @@
 				"rotation": 180
 			},
 			{
+				"furniture": {
+					"id": "door_wood",
+					"rotation": 270
+				},
 				"id": "orange_carpet_00",
 				"rotation": 180
 			},
@@ -16361,7 +16365,7 @@
 				"rotation": 180
 			},
 			{
-
+				"id": "brick_wall_01"
 			},
 			{
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
@@ -14,9 +14,6 @@ extends Control
 @export var imageNameStringLabel: Label = null
 @export var cubeShapeCheckbox: Button = null
 @export var slopeShapeCheckbox: Button = null
-# This signal will be emitted when the user presses the save button
-# This signal should alert Gamedata that the tile data array should be saved to disk
-signal data_changed(game_data: Dictionary, new_data: Dictionary, old_data: Dictionary)
 
 var olddata: DTile # Remember what the value of the data was before editing
 var control_elements: Array = []
@@ -40,7 +37,6 @@ func _ready():
 		cubeShapeCheckbox,
 		slopeShapeCheckbox
 	]
-	data_changed.connect(Gamedata.on_data_changed)
 
 func _input(event):
 	if event.is_action_pressed("ui_focus_next"):
@@ -68,9 +64,9 @@ func load_tile_data():
 	if DescriptionTextEdit != null:
 		DescriptionTextEdit.text = dtile.description
 	if CategoriesList != null:
-		CategoriesList.clear()
+		CategoriesList.clear_list()
 		for category in dtile.categories:
-			CategoriesList.add_item(category)
+			CategoriesList.add_item_to_list(category)
 	if cubeShapeCheckbox != null and dtile.shape:
 		# By default the cubeShapeCheckbox is selected so we only account for slope
 		if dtile.shape == "slope":
@@ -90,11 +86,9 @@ func _on_save_button_button_up():
 	dtile.spriteid = imageNameStringLabel.text
 	dtile.name = NameTextEdit.text
 	dtile.description = DescriptionTextEdit.text
-	dtile.categories = []
-	for i in range(CategoriesList.get_child_count()):
-		dtile.categories.append(CategoriesList.get_child(i).text)
+	dtile.categories = CategoriesList.get_items()
 	dtile.shape = "cube"
-	if slopeShapeCheckbox.pressed:
+	if slopeShapeCheckbox.button_pressed:
 		dtile.shape = "slope"
 	dtile.changed(olddata)
 	olddata = DTile.new(dtile.get_data().duplicate(true))

--- a/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
@@ -21,14 +21,15 @@ signal data_changed(game_data: Dictionary, new_data: Dictionary, old_data: Dicti
 var olddata: DTile # Remember what the value of the data was before editing
 var control_elements: Array = []
 # The data that represents this tile
-# The data is selected from the Gamedata.data.tiles.data array
+# The data is selected from the Gamedata.tiles array
 # based on the ID that the user has selected in the content editor
 var dtile: DTile = null:
 	set(value):
 		dtile = value
 		load_tile_data()
-		tileSelector.sprites_collection = Gamedata.data.tiles.sprites
+		tileSelector.sprites_collection = Gamedata.tiles.sprites
 		olddata = DTile.new(dtile.get_data().duplicate(true))
+
 
 func _ready():
 	control_elements = [
@@ -57,7 +58,7 @@ func _input(event):
 # This function updates the form based on the dtile that has been loaded
 func load_tile_data():
 	if tileImageDisplay != null and dtile.spriteid:
-		var myTexture: Resource = Gamedata.data.tiles.sprites[dtile.spriteid]
+		var myTexture: Resource = Gamedata.tiles.sprite_by_file(dtile.spriteid)
 		tileImageDisplay.texture = myTexture
 		imageNameStringLabel.text = dtile.spriteid
 	if IDTextLabel != null:
@@ -82,7 +83,7 @@ func _on_close_button_button_up():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in dtile
-# Since dtile is a reference to an item in Gamedata.data.tiles.data
+# Since dtile is a reference to an item in Gamedata.tiles
 # the central array for tile data is updated with the changes as well
 # The function will signal to Gamedata that the data has changed and needs to be saved
 func _on_save_button_button_up():
@@ -95,7 +96,7 @@ func _on_save_button_button_up():
 	dtile.shape = "cube"
 	if slopeShapeCheckbox.pressed:
 		dtile.shape = "slope"
-	data_changed.emit(Gamedata.data.tiles, dtile.get_data(), olddata.get_data())
+	dtile.changed(olddata)
 	olddata = DTile.new(dtile.get_data().duplicate(true))
 
 # When the tileImageDisplay is clicked, the user will be prompted to select an image from

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -746,7 +746,7 @@ func update_preview_texture_with_copied_data():
 func get_texture_from_tile_data(tile_data: Dictionary) -> Texture:
 	if tile_data.has("id"):
 		var texture_id = tile_data["id"]
-		return Gamedata.get_sprite_by_id(Gamedata.data.tiles, texture_id).albedo_texture
+		return Gamedata.tiles.sprite_by_id(texture_id)
 	else:
 		return load("res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png")
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -19,7 +19,7 @@ func _ready():
 	loadTiles()
 	loadFurniture()
 	
-# this function will read all files in Gamedata.data.tiles.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
+# this function will read all files in Gamedata.data.mobs.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the mobs belong to.
 func loadMobs():
 	var mobList: Array = Gamedata.data.mobs.data
 	var newMobsList: Control = scrolling_Flow_Container.instantiate()
@@ -66,16 +66,16 @@ func loadFurniture():
 		instanced_brushes.append(brushInstance)
 
 
-# this function will read all files in Gamedata.data.tiles.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
+# this function will read all files in Gamedata.tiles and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
 func loadTiles():
-	var tileList: Array = Gamedata.data.tiles.data
+	var tileList: Dictionary = Gamedata.tiles.get_tiles()
 
-	for item in tileList:
-		if item.has("sprite"):
-			#We need to put the tiles the right catecory
-			#Each tile can have 0 or more categories
-			for category in item["categories"]:
-				#Check if the category was already added
+	for tile: DTile in tileList.values():
+		if tile.spriteid:
+			# We need to put the tiles in the right category
+			# Each tile can have 0 or more categories
+			for category in tile.categories:
+				# Check if the category was already added
 				var newTilesList: Control = find_list_by_category(category)
 				if !newTilesList:
 					newTilesList = scrolling_Flow_Container.instantiate()
@@ -83,22 +83,24 @@ func loadTiles():
 					newTilesList.collapse_button_pressed.connect(_on_collapse_button_pressed)
 					add_child(newTilesList)
 					newTilesList.is_collapsed = load_collapse_state(category)
-				var imagefileName: String = item["sprite"]
+				
+				var imagefileName: String = tile.spriteid
 				imagefileName = imagefileName.get_file()
 				# Get the texture from gamedata
-				var texture: Resource = Gamedata.data.tiles.sprites[imagefileName].albedo_texture
-				# Create a TextureRect node
+				var texture: Resource = Gamedata.tiles.sprite_by_file(imagefileName)
+				# Create a TileBrush node
 				var brushInstance = tileBrush.instantiate()
-				# Assign the texture to the TextureRect
+				# Assign the texture to the TileBrush
 				brushInstance.set_tile_texture(texture)
-				# Since the map editor needs to knw what tile ID is used,
-				# We store the tile id in a variable in the brush
-				brushInstance.entityID = item.id
+				# Since the map editor needs to know what tile ID is used,
+				# we store the tile id in a variable in the brush
+				brushInstance.entityID = tile.id
 				brushInstance.tilebrush_clicked.connect(tilebrush_clicked)
 
-				# Add the TextureRect as a child to the TilesList
+				# Add the TileBrush as a child to the newTilesList
 				newTilesList.add_content_item(brushInstance)
 				instanced_brushes.append(brushInstance)
+
 
 
 #Find the list associated with the category

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -387,7 +387,7 @@ func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 		# Get the appropriate sprite based on the entity type
 		match newtype:
 			"tile":
-				properties["texture"] = Gamedata.get_sprite_by_id(Gamedata.data.tiles, entity["id"]).albedo_texture
+				properties["texture"] = Gamedata.tiles.sprite_by_id(entity["id"])
 			"mob":
 				properties["texture"] = Gamedata.get_sprite_by_id(Gamedata.data.mobs, entity["id"])
 			"furniture":

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -12,7 +12,7 @@ var tileData: Dictionary = defaultTileData.duplicate():
 			return
 		tileData = data
 		if tileData.has("id") and not tileData.id == "":
-			$TileSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.tiles, tileData.id).albedo_texture
+			$TileSprite.texture = Gamedata.tiles.sprite_by_id(tileData.id)
 			set_rotation_amount(tileData.get("rotation", 0))
 			$ObjectSprite.hide()
 			$ObjectSprite.rotation_degrees = 0
@@ -79,7 +79,7 @@ func set_tile_id(id: String) -> void:
 		$TileSprite.texture = load(defaultTexture)
 	else:
 		tileData.id = id
-		$TileSprite.texture = Gamedata.get_sprite_by_id(Gamedata.data.tiles, id).albedo_texture
+		$TileSprite.texture = Gamedata.tiles.sprite_by_id(id)
 	set_tooltip()
 
 

--- a/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
+++ b/Scenes/ContentManager/ModMaintenance/Scripts/removepropertyscript.gd
@@ -80,6 +80,4 @@ func get_type_data() -> Variant:
 		return Gamedata.data.itemgroups
 	elif selected_type == "Mob":
 		return Gamedata.data.mobs
-	elif selected_type == "Tile":
-		return Gamedata.data.tiles
 	return null

--- a/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
+++ b/Scenes/ContentManager/ModMaintenance/removepropertyscript.tscn
@@ -49,14 +49,12 @@ text = "Selected type:"
 
 [node name="TypesOptionButton" type="OptionButton" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2
-item_count = 3
+item_count = 2
 selected = 0
 popup/item_0/text = "Itemgroup"
 popup/item_0/id = 3
 popup/item_1/text = "Mob"
 popup/item_1/id = 2
-popup/item_2/text = "Tile"
-popup/item_2/id = 4
 
 [node name="GetPropertiesButton" type="Button" parent="VBoxContainer/TypesHBoxContainer"]
 layout_mode = 2

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -55,6 +55,11 @@ func load_data():
 		load_items_list()
 		load_collapse_state()
 		return
+	# HACK Hacky exception for furniture, need to find a better solution
+	if contentData == {"tiles": true}:
+		load_tiles_list()
+		load_collapse_state()
+		return
 	if not contentData.has("data"):
 		return
 	if contentData.data.is_empty():
@@ -191,9 +196,13 @@ func _on_delete_button_button_up():
 	if contentData == {"furnitures": true}:
 		delete_furniture(selected_id)
 		return
-	# HACK Exception for furnitures, need to find a better solution
+	# HACK Exception for items, need to find a better solution
 	if contentData == {"items": true}:
 		delete_item(selected_id)
+		return
+	# HACK Exception for tiles, need to find a better solution
+	if contentData == {"tiles": true}:
+		delete_tile(selected_id)
 		return
 	contentItems.remove_item(contentItems.get_selected_items()[0])
 	Gamedata.remove_item_from_data(contentData, selected_id)
@@ -360,7 +369,7 @@ func load_furnitures_list():
 		if mySprite:
 			contentItems.set_item_icon(item_index, mySprite)
 
-# Load the furniture list
+# Load the items list
 func load_items_list():
 	var itemlist: Dictionary = Gamedata.items.get_items()
 	for item: DItem in itemlist.values():
@@ -371,6 +380,18 @@ func load_items_list():
 		var mySprite: Texture = item.sprite
 		if mySprite:
 			contentItems.set_item_icon(item_index, mySprite)
+
+# Load the tiles list
+func load_tiles_list():
+	var tilelist: Dictionary = Gamedata.tiles.get_tiles()
+	for tile: DTile in tilelist.values():
+		# Add all the filenames to the Contenttiles list as child nodes
+		var tile_index: int = contentItems.add_tile(tile.id)
+		# Add the ID as metadata which can be used to load the tile data
+		contentItems.set_item_metadata(tile_index, tile.id)
+		var mySprite: Texture = tile.sprite
+		if mySprite:
+			contentItems.set_tile_icon(tile_index, mySprite)
 
 
 func add_map_popup_ok():
@@ -413,4 +434,8 @@ func delete_furniture(selected_id) -> void:
 
 func delete_item(selected_id) -> void:
 	Gamedata.items.delete_item(selected_id)
+	load_data()
+
+func delete_tile(selected_id) -> void:
+	Gamedata.tiles.delete_tile(selected_id)
 	load_data()

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -269,6 +269,10 @@ func _create_drag_preview(item_id: String) -> Control:
 		preview.texture = Gamedata.furnitures.sprite_by_id(item_id)
 	if contentData == {"maps": true}:
 		preview.texture = Gamedata.maps.by_id(item_id).sprite
+	if contentData == {"tiles": true}:
+		preview.texture = Gamedata.tiles.by_id(item_id).sprite
+	if contentData == {"items": true}:
+		preview.texture = Gamedata.items.by_id(item_id).sprite
 	else:
 		preview.texture = Gamedata.get_sprite_by_id(contentData, item_id)
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -386,12 +386,12 @@ func load_tiles_list():
 	var tilelist: Dictionary = Gamedata.tiles.get_tiles()
 	for tile: DTile in tilelist.values():
 		# Add all the filenames to the Contenttiles list as child nodes
-		var tile_index: int = contentItems.add_tile(tile.id)
+		var tile_index: int = contentItems.add_item(tile.id)
 		# Add the ID as metadata which can be used to load the tile data
 		contentItems.set_item_metadata(tile_index, tile.id)
 		var mySprite: Texture = tile.sprite
 		if mySprite:
-			contentItems.set_tile_icon(tile_index, mySprite)
+			contentItems.set_item_icon(tile_index, mySprite)
 
 
 func add_map_popup_ok():

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -23,7 +23,7 @@ func _ready():
 	# Hacky exception for maps, need to find a better solution
 	load_content_list({"maps": true}, "Maps")
 	load_content_list({"items": true}, "Items")
-	load_content_list(Gamedata.data.tiles, "Terrain Tiles")
+	load_content_list({"tiles": true}, "Terrain Tiles")
 	load_content_list(Gamedata.data.mobs, "Mobs")
 	# Hacky exception for furnitures, need to find a better solution
 	load_content_list({"furnitures": true}, "Furniture")
@@ -61,7 +61,8 @@ func _on_content_item_activated(data: Dictionary, itemID: String):
 		print_debug("Tried to load the selected content item, but either \
 		data (Array) or itemID ("+itemID+") is empty")
 		return
-	if data == Gamedata.data.tiles:
+	if data == {"tiles": true}:
+		# HACK Hacky exception for tiles, need to find a better solution
 		instantiate_editor(data, itemID, terrainTileEditor)
 	if data == {"furnitures": true}:
 		# HACK Hacky exception for furniture, need to find a better solution
@@ -116,6 +117,9 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 		return
 	if data == {"items": true}:# HACK Hacky exception for furniture, need to find a better solution
 		newContentEditor.ditem = Gamedata.items.by_id(itemID)
+		return
+	if data == {"tiles": true}:# HACK Hacky exception for furniture, need to find a better solution
+		newContentEditor.dtile = Gamedata.tiles.by_id(itemID)
 		return
 	if data.dataPath.ends_with(".json"):
 		var itemdata: Dictionary = data.data[Gamedata.get_array_index_by_id(data, itemID)]

--- a/Scenes/LoadingScreen.tscn
+++ b/Scenes/LoadingScreen.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=2 format=3 uid="uid://dowehl4nfwxm"]
+
+[ext_resource type="Script" path="res://Scripts/LoadingScreen.gd" id="1_nmrn0"]
+
+[node name="LoadingScreen" type="Control" node_paths=PackedStringArray("sub_label")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_nmrn0")
+sub_label = NodePath("VBoxContainer/SubLabel")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.129412, 0.14902, 0.180392, 1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -89.5
+offset_top = -52.0
+offset_right = 89.5
+offset_bottom = 52.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="LoadingLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Loading..."
+horizontal_alignment = 1
+
+[node name="SubLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Initializing"
+horizontal_alignment = 1

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -166,7 +166,7 @@ func create_block_position_dictionary_new_arraymesh() -> Dictionary:
 							# We only save the data we need, exluding mob and furniture data
 							new_block_positions[block_position_key] = {
 								"id": tileJSON.id,
-								"shape": dtile.shape,
+								"shape": dtile.shape if dtile.shape else "cube",
 								"rotation": tileJSON.get("rotation", 0)
 							}
 	return new_block_positions
@@ -607,7 +607,7 @@ func create_atlas() -> Dictionary:
 		if not material_to_blocks.has(material_id):
 			var sprite = Gamedata.tiles.sprite_by_id(material_id)
 			if sprite:
-				material_to_blocks[material_id] = sprite.albedo_texture
+				material_to_blocks[material_id] = sprite
 
 	# Calculate the atlas size needed
 	var num_textures: int = material_to_blocks.keys().size()
@@ -701,7 +701,7 @@ func prepare_mesh_data(arrays: Array, blocks_at_same_y: Array, block_uv_map: Dic
 			(Vector2(0, 1) * uv_scale + Vector2(margin, -margin)) + uv_offset
 		])
 		
-		var blockshape = block_data["shape"]
+		var blockshape = block_data.get("shape", "cube")
 		if is_new_chunk(): # This chunk is created for the first time, so we need to save 
 			# the rotation to the block json dictionary
 			var blockrotation: int = 0

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -423,15 +423,27 @@ func get_chunk_data() -> Dictionary:
 # the helper variable. First we wait until the current thread is finished.
 func unload_chunk():
 	start_unloading()
-	await Helper.task_manager.create_task(save_and_unload_chunk).completed
+	await Helper.task_manager.create_task(free_chunk_resources).completed
 	chunk_unloaded.emit()
 
 
+# Saves all the chunk data and then unloads it
+# You might want to call this by:
+# await Helper.task_manager.create_task(chunk.save_and_unload_chunk).completed
 func save_and_unload_chunk():
+	start_unloading()
+	save_chunk()  # Save the chunk data
+	free_chunk_resources()
+	chunk_unloaded.emit()
+
+
+# Save chunk data without unloading the chunk
+# You might want to call this by:
+# await Helper.task_manager.create_task(chunk.save_chunk).completed
+func save_chunk():
 	var chunkdata: Dictionary = get_chunk_data()
 	var chunkposition: Vector2 = Vector2(int(chunkdata.chunk_x/32),int(chunkdata.chunk_z/32))
 	Helper.overmap_manager.loaded_chunk_data.chunks[chunkposition] = chunkdata
-	free_chunk_resources()
 
 
 # Adds triangles represented by 3 vertices to the navigation mesh data

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -162,11 +162,11 @@ func create_block_position_dictionary_new_arraymesh() -> Dictionary:
 						if tileJSON.has("id") and tileJSON.id != "":
 							var block_position_key = str(w) + "," + str(level_index-10) + "," + str(h)
 							# Get the shape of the block and the transparency
-							var tileJSONData = Gamedata.get_data_by_id(Gamedata.data.tiles,tileJSON.id)
+							var dtile: DTile = Gamedata.tiles.by_id(tileJSON.id)
 							# We only save the data we need, exluding mob and furniture data
 							new_block_positions[block_position_key] = {
 								"id": tileJSON.id,
-								"shape": tileJSONData.get("shape", "cube"),
+								"shape": dtile.shape,
 								"rotation": tileJSON.get("rotation", 0)
 							}
 	return new_block_positions
@@ -605,7 +605,7 @@ func create_atlas() -> Dictionary:
 		var block_data: Dictionary = block_positions[key]
 		var material_id: String = str(block_data["id"]) # Key for material ID
 		if not material_to_blocks.has(material_id):
-			var sprite = Gamedata.get_sprite_by_id(Gamedata.data.tiles, material_id)
+			var sprite = Gamedata.tiles.sprite_by_id(material_id)
 			if sprite:
 				material_to_blocks[material_id] = sprite.albedo_texture
 
@@ -1235,7 +1235,6 @@ func update_all_navigation_data():
 		var block_position = Vector3(float(pos_array[0]), float(pos_array[1]), float(pos_array[2]))
 		var block_rotation = block_data.rotation
 		var block_shape = block_data.get("shape", "cube")
-		#var block_shape = Gamedata.get_data_by_id(Gamedata.data.tiles, block_data.id).shape
 		
 		add_mesh_to_navigation_data(block_position, block_rotation, block_shape)
 	update_navigation_mesh()

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -106,12 +106,13 @@ func _on_recipe_button_pressed(recipe: DItem.CraftRecipe):
 		resource_container.add_child(label)
 
 	# Display skill progression information if it exists
-	var skill_id = Helper.json_helper.get_nested_data(recipe, "skill_progression.id")
-	var skill_xp = Helper.json_helper.get_nested_data(recipe, "skill_progression.xp")
-	if skill_id and skill_xp:
-		skill_progression_label.text = "Get XP: %s: %s" % [skill_id, skill_xp]
-	else:
-		skill_progression_label.text = ""
+	if recipe.skill_progression:
+		var skill_id = recipe.skill_progression.id
+		var skill_xp = recipe.skill_progression.xp
+		if skill_id and skill_xp:
+			skill_progression_label.text = "Get XP: %s: %s" % [skill_id, skill_xp]
+		else:
+			skill_progression_label.text = ""
 
 
 func _on_start_crafting_button_pressed():
@@ -209,11 +210,11 @@ func display_feedback(message: String, color: Color):
 	timer.start()
 
 
-func _on_craft_successful(_item: Dictionary, _recipe: Dictionary):
+func _on_craft_successful(_item: DItem, _recipe: DItem.CraftRecipe):
 	var color = Color(0.4, 1, 0.4)  # Brighter green color with more white
 	display_feedback("craft succesful!", color)
 
 
-func _on_craft_failed(_item: Dictionary, _recipe: Dictionary, reason: String):
+func _on_craft_failed(_item: DItem, _recipe: DItem.CraftRecipe, reason: String):
 	var color = Color(1, 0, 0)  # Red color
 	display_feedback(reason, color)

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -6,6 +6,7 @@ extends Control
 @export var resume_button: Button
 @export var return_button: Button
 @export var save_button: Button
+@export var loadingscreen: Control
 
 
 # Called when the node enters the scene tree for the first time.
@@ -60,4 +61,5 @@ func _resume_game():
 func _return_to_main_menu():
 	if is_inside_tree():
 		get_tree().paused = false
+		loadingscreen.on_exit_game()
 		Helper.save_and_exit_game()

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -23,13 +23,8 @@ func _process(_delta):
 
 
 # Called when the save button is pressed.
-# TODO: We should just call Helper.save_helper.save_game() instead
-# But before we can do that, we need to separate saving the map data from unloading the chunks
-# We will need to modify Chunk.gd for that.
 func _on_save_button_pressed():
-	Helper.save_helper.save_player_inventory()
-	Helper.save_helper.save_player_equipment()
-	Helper.save_helper.save_player_state(get_tree().get_first_node_in_group("Players"))
+	Helper.save_helper.save_game()
 
 
 # Called when the resume button is pressed.
@@ -65,7 +60,4 @@ func _resume_game():
 func _return_to_main_menu():
 	if is_inside_tree():
 		get_tree().paused = false
-		Helper.save_helper.save_game()
-		await Helper.save_helper.all_chunks_unloaded
-		Helper.signal_broker.game_ended.emit()
-		get_tree().change_scene_to_file("res://scene_selector.tscn")
+		Helper.save_and_exit_game()

--- a/Scripts/FurniturePhysics.gd
+++ b/Scripts/FurniturePhysics.gd
@@ -96,25 +96,11 @@ func _physics_process(_delta) -> void:
 	# or set_position is too late and it's differs from furnitureposition because it's still 0,0
 	# So we add in extra checks to handle those edge cases. There's probably a better way
 	var is_zero = global_transform.origin.x == 0 and global_transform.origin.z == 0
-	if (x_changed or z_changed) and not is_in_current_chunk() and not is_zero:
+	if (x_changed or z_changed) and not is_zero:
 		_moved(global_transform.origin)
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:
 		last_rotation = current_rotation
-
-
-# Returns if the current position is inside the current chunk
-func is_in_current_chunk() -> bool:
-	var chunk_pos: Vector3 = current_chunk.mypos
-	var chunk_range: Vector3 = chunk_pos + Vector3(32, 0, 32)
-
-	var myposition: Vector3 = global_transform.origin
-
-	# Check if position is within chunk bounds in the x and z axes
-	var in_x_range: bool = (myposition.x >= chunk_pos.x) and (myposition.x <= chunk_range.x)
-	var in_z_range: bool = (myposition.z >= chunk_pos.z) and (myposition.z <= chunk_range.z)
-
-	return in_x_range and in_z_range
 
 
 # Set the new rotation for the furniture

--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -5,9 +5,4 @@ extends Control
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	Helper.map_manager.level_generator.unload_all_chunks()
-	await Helper.map_manager.level_generator.all_chunks_unloaded
-	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
-	Helper.overmap_manager.unload_all_remaining_segments()
-	Helper.signal_broker.game_ended.emit()
-	get_tree().change_scene_to_file("res://scene_selector.tscn")
+	Helper.exit_game()

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -1,7 +1,7 @@
 class_name DFurniture
 extends RefCounted
 
-# There's a D in front of the class name to indicate this class only handles map data, nothing more
+# There's a D in front of the class name to indicate this class only handles furniture data, nothing more
 # This script is intended to be used inside the GameData autoload singleton
 # This script handles the data for one furniture. You can access it through Gamedata.furnitures
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -397,8 +397,7 @@ func get_data() -> Dictionary:
 # type: The type of entity, for example "maps"
 # refid: The id of the entity, for example "grass_field"
 func remove_reference(module: String, type: String, refid: String):
-	var refitem: DItem = Gamedata.items.by_id(refid)
-	var changes_made = Gamedata.dremove_reference(refitem.references, module, type, id)
+	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
 	if changes_made:
 		Gamedata.items.save_items_to_disk()
 
@@ -409,8 +408,7 @@ func remove_reference(module: String, type: String, refid: String):
 # type: The type of entity, for example "maps"
 # refid: The id of the entity, for example "grass_field"
 func add_reference(module: String, type: String, refid: String):
-	var refitem: DItem = Gamedata.items.by_id(refid)
-	var changes_made = Gamedata.dadd_reference(refitem.references, module, type, id)
+	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
 	if changes_made:
 		Gamedata.items.save_items_to_disk()
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -34,8 +34,8 @@ class CraftRecipe:
 	var craft_time: int
 	var flags: Dictionary
 	var required_resources: Array # A list of objects like {"amount": 1, "id": "steel_scrap"}
-	var skill_progression: Dictionary
-	var skill_requirement: Dictionary
+	var skill_progression: Dictionary # example: { "id": "fabrication", "xp": 10 }
+	var skill_requirement: Dictionary # example: { "id": "fabrication", "level": 1 }
 
 	# Constructor to initialize craft properties from a dictionary
 	func _init(data: Dictionary):

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -149,7 +149,14 @@ func remove_my_reference_from_all_entities() -> void:
 	# Remove references for unique entities
 	for entity_type in unique_entities.keys():
 		for entity_id in unique_entities[entity_type]:
-			changes_made = Gamedata.remove_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id) or changes_made
+			if entity_type == "furniture":
+				var furniture: DFurniture = Gamedata.furnitures.by_id(entity_id)
+				furniture.remove_reference("core","maps",id)
+			elif entity_type == "tiles":
+				var dtile: DTile = Gamedata.tiles.by_id(entity_id)
+				dtile.remove_reference("core","maps",id)
+			else:
+				changes_made = Gamedata.remove_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id) or changes_made
 
 	if changes_made:
 		# References have been added to tiles, furniture and/or mobs
@@ -173,6 +180,10 @@ func data_changed(oldmap: DMap):
 			for entity_id in new_entities[entity_type]:
 				var furniture: DFurniture = Gamedata.furnitures.by_id(entity_id)
 				furniture.add_reference("core","maps",id)
+		elif entity_type == "tiles":
+			for entity_id in new_entities[entity_type]:
+				var dtile: DTile = Gamedata.tiles.by_id(entity_id)
+				dtile.add_reference("core","maps",id)
 		else:
 			for entity_id in new_entities[entity_type]:
 				Gamedata.add_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id)
@@ -251,7 +262,8 @@ func add_entities_in_area_to_set(myarea: Dictionary, entity_set: Dictionary):
 
 	if myarea.has("tiles"):
 		for tile in myarea["tiles"]:
-			if not entity_set["tiles"].has(tile["id"]):
+			# The "null" tile in areas is used to control propoprtions and is not really an entity
+			if not entity_set["tiles"].has(tile["id"]) and not tile["id"] == "null":
 				entity_set["tiles"].append(tile["id"])
 
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -154,7 +154,7 @@ func remove_my_reference_from_all_entities() -> void:
 	if changes_made:
 		# References have been added to tiles, furniture and/or mobs
 		# We could track changes individually so we only save what has actually changed.
-		Gamedata.save_data_to_file(Gamedata.data.tiles)
+		Gamedata.tiles.save_tiles_to_disk()
 		Gamedata.furnitures.save_furnitures_to_disk()
 		Gamedata.save_data_to_file(Gamedata.data.mobs)
 		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
@@ -195,7 +195,7 @@ func data_changed(oldmap: DMap):
 	if new_entities["furniture"].size() > 0 or old_entities["furniture"].size() > 0:
 		Gamedata.furnitures.save_furnitures_to_disk()
 	if new_entities["tiles"].size() > 0 or old_entities["tiles"].size() > 0:
-		Gamedata.save_data_to_file(Gamedata.data.tiles)
+		Gamedata.tiles.save_tiles_to_disk()
 	if new_entities["itemgroups"].size() > 0 or old_entities["itemgroups"].size() > 0:
 		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
 

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -52,26 +52,26 @@ func get_data() -> Dictionary:
 		"id": id,
 		"name": name,
 		"description": description,
-		"shape": shape,
 		"sprite": spriteid,
 		"categories": categories
 	}
 	if not references.is_empty():
 		data["references"] = references
+	
+	if shape and not shape == "":
+		data["shape"] = shape
 
 	return data
 
 # Removes the provided reference from references
 func remove_reference(module: String, type: String, refid: String):
-	var reftile: DTile = Gamedata.tiles.by_id(refid)
-	var changes_made = Gamedata.dremove_reference(reftile.references, module, type, id)
+	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
 	if changes_made:
 		Gamedata.tiles.save_tiles_to_disk()
 
 # Adds a reference to the references list
 func add_reference(module: String, type: String, refid: String):
-	var reftile: DTile = Gamedata.tiles.by_id(refid)
-	var changes_made = Gamedata.dadd_reference(reftile.references, module, type, id)
+	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
 	if changes_made:
 		Gamedata.tiles.save_tiles_to_disk()
 
@@ -88,74 +88,21 @@ func on_data_changed(_oldtile: DTile):
 		print_debug("Tile reference updates saved successfully.")
 		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
 
+
 # Some tile has been changed
-# We need to update the relation between the tile and other tiles based on their references
-func changed(olddata: DTile):
-	var changes_made = false
-	
-	# Dictionaries to track unique reference IDs
-	var old_reference_ids: Dictionary = {}
-	var new_reference_ids: Dictionary = {}
-
-	# Collect all unique reference IDs from old data
-	if olddata.references:
-		for ref in olddata.references:
-			old_reference_ids[ref] = true
-
-	# Collect all unique reference IDs from new data
-	if references:
-		for ref in references:
-			new_reference_ids[ref] = true
-
-	# References that are no longer present
-	for ref_id in old_reference_ids:
-		if not new_reference_ids.has(ref_id):
-			changes_made = remove_reference("core", "tiles", ref_id) or changes_made
-	
-	# Add references for new data
-	for ref_id in new_reference_ids:
-		changes_made = add_reference("core", "tiles", ref_id) or changes_made
-	
+# INFO if the tiles reference other entities, update them here
+func changed(_olddata: DTile):
 	Gamedata.tiles.save_tiles_to_disk()
 
-	# Save changes if any modifications were made
-	if changes_made:
-		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
-		print_debug("Tile changes saved successfully.")
-	else:
-		print_debug("No changes were made to tile.")
 
 # A tile is being deleted from the data
 # We have to remove it from everything that references it
 func delete():
-	var changes_made = {"value": false}
+	# Check if the tile has references to maps and remove it from those maps
+	var mapsdata = Helper.json_helper.get_nested_data(references, "core.maps")
+	if mapsdata:
+		Gamedata.maps.remove_entity_from_selected_maps("tile", id, mapsdata)
 
-	# This callable will remove this tile from tilegroups that reference this tile.
-	var myfunc: Callable = func (tilegroup_id):
-		var tilelist: Array = Gamedata.get_property_by_path(Gamedata.data.tilegroups, "tiles", tilegroup_id)
-		for i in range(tilelist.size()):
-			if tilelist[i].has("id") and tilelist[i]["id"] == id:
-				tilelist.remove_at(i)
-				changes_made["value"] = true
-				break  # Exit loop after removal to avoid index issues
-
-	execute_callable_on_references_of_type("core", "tilegroups", myfunc)
-	
-	# This callable will handle the removal of this tile from all references in other tiles
-	var remove_from_tile: Callable = func(other_tile_id: String):
-		var other_tile: DTile = Gamedata.tiles.by_id(other_tile_id)
-		if other_tile and other_tile.references:
-			if other_tile.references.erase(id):
-				changes_made["value"] = true
-
-	execute_callable_on_references_of_type("core", "tiles", remove_from_tile)
-	
-	# Save changes to the data file if any changes were made
-	if changes_made["value"]:
-		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
-		Gamedata.tiles.save_tiles_to_disk()
-	else:
-		print_debug("No changes needed for tile", id)
 
 # Executes a callable function on each reference of the given type
 func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -36,57 +36,15 @@ var spriteid: String
 var categories: Array
 var references: Dictionary = {}
 
-
-# Constructor to initialize item properties from a dictionary
+# Constructor to initialize tile properties from a dictionary
 func _init(data: Dictionary):
 	id = data.get("id", "")
 	name = data.get("name", "")
 	description = data.get("description", "")
-	weight = data.get("weight", 1.0)
-	volume = data.get("volume", 1.0)
+	shape = data.get("shape", "")
 	spriteid = data.get("sprite", "")
-	image = data.get("image", "")
-	stack_size = data.get("stack_size", 1)
-	max_stack_size = data.get("max_stack_size", 1)
-	two_handed = data.get("two_handed", false)
+	categories = data.get("categories", [])
 	references = data.get("references", {})
-
-	# Initialize Craft and Magazine subclasses if they exist in data
-	if data.has("Craft"):
-		craft = Craft.new(data["Craft"])
-	else:
-		craft = null
-
-	if data.has("Magazine"):
-		magazine = Magazine.new(data["Magazine"])
-	else:
-		magazine = null
-
-	if data.has("Ranged"):
-		ranged = Ranged.new(data["Ranged"])
-	else:
-		ranged = null
-
-	if data.has("Melee"):
-		melee = Melee.new(data["Melee"])
-	else:
-		melee = null
-
-	if data.has("Food"):
-		food = Food.new(data["Food"])
-	else:
-		food = null
-
-	if data.has("Ammo"):
-		ammo = Ammo.new(data["Ammo"])
-	else:
-		ammo = null
-
-	if data.has("Wearable"):
-		wearable = Wearable.new(data["Wearable"])
-	else:
-		wearable = null
-
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
@@ -94,217 +52,112 @@ func get_data() -> Dictionary:
 		"id": id,
 		"name": name,
 		"description": description,
-		"weight": weight,
-		"volume": volume,
+		"shape": shape,
 		"sprite": spriteid,
-		"image": image,
-		"stack_size": stack_size,
-		"max_stack_size": max_stack_size,
-		"two_handed": two_handed
+		"categories": categories
 	}
 	if not references.is_empty():
 		data["references"] = references
 
-	# Add Craft and Magazine data if they exist
-	if craft:
-		data["Craft"] = craft.get_data()
-
-	if magazine:
-		data["Magazine"] = magazine.get_data()
-
-	if ranged:
-		data["Ranged"] = ranged.get_data()
-
-	if melee:
-		data["Melee"] = melee.get_data()
-
-	if food:
-		data["Food"] = food.get_data()
-
-	if ammo:
-		data["Ammo"] = ammo.get_data()
-
-	if wearable:
-		data["Wearable"] = wearable.get_data()
-
 	return data
 
-
 # Removes the provided reference from references
-# For example, remove "grass_field" to references.Core.maps
-# module: the mod that the entity belongs to, for example "Core"
-# type: The type of entity, for example "maps"
-# refid: The id of the entity, for example "grass_field"
 func remove_reference(module: String, type: String, refid: String):
-	var refitem: DItem = Gamedata.items.by_id(refid)
-	var changes_made = Gamedata.dremove_reference(refitem.references, module, type, id)
+	var reftile: DTile = Gamedata.tiles.by_id(refid)
+	var changes_made = Gamedata.dremove_reference(reftile.references, module, type, id)
 	if changes_made:
-		Gamedata.items.save_items_to_disk()
-
+		Gamedata.tiles.save_tiles_to_disk()
 
 # Adds a reference to the references list
-# For example, add "grass_field" to references.Core.maps
-# module: the mod that the entity belongs to, for example "Core"
-# type: The type of entity, for example "maps"
-# refid: The id of the entity, for example "grass_field"
 func add_reference(module: String, type: String, refid: String):
-	var refitem: DItem = Gamedata.items.by_id(refid)
-	var changes_made = Gamedata.dadd_reference(refitem.references, module, type, id)
+	var reftile: DTile = Gamedata.tiles.by_id(refid)
+	var changes_made = Gamedata.dadd_reference(reftile.references, module, type, id)
 	if changes_made:
-		Gamedata.items.save_items_to_disk()
-
+		Gamedata.tiles.save_tiles_to_disk()
 
 # Returns the path of the sprite
 func get_sprite_path() -> String:
-	return Gamedata.items.spritePath + spriteid
+	return Gamedata.tiles.spritePath + spriteid
 
-
-# Handles item changes and updates references if necessary
-func on_data_changed(_oldditem: DItem):
+# Handles tile changes and updates references if necessary
+func on_data_changed(_oldtile: DTile):
 	var changes_made = false
 
 	# If any references were updated, save the changes to the data file
 	if changes_made:
-		print_debug("Item reference updates saved successfully.")
-		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
+		print_debug("Tile reference updates saved successfully.")
+		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
 
-
-# Some item has been changed
-# We need to update the relation between the item and other items based on crafting recipes
-func changed(olddata: DItem):
+# Some tile has been changed
+# We need to update the relation between the tile and other tiles based on their references
+func changed(olddata: DTile):
 	var changes_made = false
 	
-	# Handle wearable slot reference. 
-	if wearable:
-		# If the slot data changed between old and new, we update the reference
-		var old_slot = null
-		if olddata.wearable:
-			old_slot = olddata.wearable.slot
+	# Dictionaries to track unique reference IDs
+	var old_reference_ids: Dictionary = {}
+	var new_reference_ids: Dictionary = {}
 
-		if old_slot != wearable.slot:
-			if old_slot:
-				changes_made = olddata.wearable.remove_reference(id) or changes_made
-			if wearable.slot:
-				changes_made = wearable.add_reference(id) or changes_made
-	elif olddata.wearable and olddata.wearable.slot:
-		# The wearable is present in the old data but not in the new, so we remove the reference
-		changes_made = olddata.wearable.remove_reference(id) or changes_made
-	
-	
-	# Dictionaries to track unique resource IDs across all recipes
-	var old_resource_ids: Dictionary = {}
-	var new_resource_ids: Dictionary = {}
+	# Collect all unique reference IDs from old data
+	if olddata.references:
+		for ref in olddata.references:
+			old_reference_ids[ref] = true
 
-	# Collect all unique resource IDs from old recipes if olddata.craft is not null
-	if olddata.craft:
-		for recipe: CraftRecipe in olddata.craft.recipes:
-			for resource in recipe.required_resources:
-				old_resource_ids[resource["id"]] = true
+	# Collect all unique reference IDs from new data
+	if references:
+		for ref in references:
+			new_reference_ids[ref] = true
 
-	# Collect all unique resource IDs from new recipes if craft is not null
-	if craft:
-		for recipe in craft.recipes:
-			for resource in recipe.required_resources:
-				new_resource_ids[resource["id"]] = true
+	# References that are no longer present
+	for ref_id in old_reference_ids:
+		if not new_reference_ids.has(ref_id):
+			changes_made = remove_reference("core", "tiles", ref_id) or changes_made
+	
+	# Add references for new data
+	for ref_id in new_reference_ids:
+		changes_made = add_reference("core", "tiles", ref_id) or changes_made
+	
+	Gamedata.tiles.save_tiles_to_disk()
 
-	# Resources that are no longer in the recipe will no longer reference this item
-	for res_id in old_resource_ids:
-		if not new_resource_ids.has(res_id):
-			changes_made = remove_reference("core", "items", res_id) or changes_made
-	
-	# Add references for new resources, nothing happens if they are already present
-	for res_id in new_resource_ids:
-		changes_made = add_reference("core", "items", res_id) or changes_made
-	update_item_skill_references(olddata)
-	
-	Gamedata.items.save_items_to_disk()
 	# Save changes if any modifications were made
 	if changes_made:
-		Gamedata.save_data_to_file(Gamedata.data.wearableslots)
-		print_debug("Item changes saved successfully.")
+		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
+		print_debug("Tile changes saved successfully.")
 	else:
-		print_debug("No changes were made to item.")
+		print_debug("No changes were made to tile.")
 
-
-
-# An item is being deleted from the data
+# A tile is being deleted from the data
 # We have to remove it from everything that references it
 func delete():
-	var changes_made = { "value": false }
-	
-	# This callable will remove this item from itemgroups that reference this item.
-	var myfunc: Callable = func (itemgroup_id):
-		var itemlist: Array = Gamedata.get_property_by_path(Gamedata.data.itemgroups, "items", itemgroup_id)
-		for i in range(itemlist.size()):
-			if itemlist[i].has("id") and itemlist[i]["id"] == id:
-				itemlist.remove_at(i)
+	var changes_made = {"value": false}
+
+	# This callable will remove this tile from tilegroups that reference this tile.
+	var myfunc: Callable = func (tilegroup_id):
+		var tilelist: Array = Gamedata.get_property_by_path(Gamedata.data.tilegroups, "tiles", tilegroup_id)
+		for i in range(tilelist.size()):
+			if tilelist[i].has("id") and tilelist[i]["id"] == id:
+				tilelist.remove_at(i)
 				changes_made["value"] = true
 				break  # Exit loop after removal to avoid index issues
 
-	execute_callable_on_references_of_type("core", "itemgroups", myfunc)
+	execute_callable_on_references_of_type("core", "tilegroups", myfunc)
 	
-	# This callable will handle the removal of this item from all crafting recipes in other items
-	var remove_from_item: Callable = func(other_item_id: String):
-		var other_item: DItem = Gamedata.items.by_id(other_item_id)
-		if other_item and other_item.craft:
-			if other_item.craft.remove_item_from_recipes(id):
+	# This callable will handle the removal of this tile from all references in other tiles
+	var remove_from_tile: Callable = func(other_tile_id: String):
+		var other_tile: DTile = Gamedata.tiles.by_id(other_tile_id)
+		if other_tile and other_tile.references:
+			if other_tile.references.erase(id):
 				changes_made["value"] = true
 
-	# Pass the callable to every item in the item's references
-	# It will call remove_from_item on every item in item_data.references.core.items
-	execute_callable_on_references_of_type("core", "items", remove_from_item)
+	execute_callable_on_references_of_type("core", "tiles", remove_from_tile)
 	
-	# This callable will handle the removal of this item from all steps in quests
-	var remove_from_quest: Callable = func(quest_id: String):
-		var quest_data = Gamedata.get_data_by_id(Gamedata.data.quests, quest_id)
-		# Removes all steps where the item is equal to item_id
-		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, \
-		"steps.item", id) or changes_made["value"]
-		# Removes all rewards where the reward's item_id is equal to item_id
-		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, \
-		"rewards.item_id", id) or changes_made["value"]
-
-	# Pass the callable to every quest in the item's references
-	# It will call remove_from_quest on every item in item_data.references.core.quests
-	execute_callable_on_references_of_type("core", "quests", remove_from_quest)
-	
-	# For each recipe and for each item in each recipe, remove the reference to this item
-	for resource in craft.get_all_used_items():
-		changes_made["value"] = remove_reference("core", "items", resource) or changes_made["value"]
-
-	# Collect unique skill IDs from the item's recipes
-	var skill_ids: Dictionary = {}
-	for skillid in craft.get_used_skill_ids():
-		skill_ids[skillid] = true
-
-	# Add the ranged skill to the skill list
-	if ranged and ranged.used_skill:
-		skill_ids[ranged.used_skill.skill_id] = true
-
-	# Add the melee skill to the skill list
-	if melee and melee.used_skill:
-		skill_ids[melee.used_skill.skill_id] = true
-
-	# Remove the reference of this item from each skill
-	for skill_id in skill_ids.keys():
-		changes_made["value"] = Gamedata.remove_reference(Gamedata.data.skills, "core", \
-		"items", skill_id, id) or changes_made["value"]
-
 	# Save changes to the data file if any changes were made
 	if changes_made["value"]:
-		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
-		Gamedata.save_data_to_file(Gamedata.data.skills)
-		Gamedata.save_data_to_file(Gamedata.data.quests)
-		Gamedata.items.save_items_to_disk()
+		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
+		Gamedata.tiles.save_tiles_to_disk()
 	else:
-		print_debug("No changes needed for item", id)
-
+		print_debug("No changes needed for tile", id)
 
 # Executes a callable function on each reference of the given type
-# module = name of the mod. for example "core"
-# type = the type of reference we want to handle. For example "itemgroup"
-# callable = a function to execute on each reference ID
-# We will check if data has the [module] and [type] properties and execute the callable on each found ID
 func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
 	# Check if it contains the specified 'module' and 'type'
 	if references.has(module) and references[module].has(type):

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -1,0 +1,313 @@
+class_name DTile
+extends RefCounted
+
+
+# There's a D in front of the class name to indicate this class only handles tile data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the data for one tile. You can access it through Gamedata.tiles
+
+#Example tile data:
+#	{
+#		"id": "kitchen_tiles_green_00",
+#		"name": "Kitchen tiles (green)",
+#		"description": "A tiled floor you would find in a kitchen. The tiles are painted green",
+#		"shape": "cube",
+#		"sprite": "kitchentilesgreen.png",
+#		"categories": [
+#			"Floor",
+#			"Urban"
+#		],
+#		"references": {
+#			"core": {
+#				"maps": [
+#					"generichouse_t"
+#				]
+#			}
+#		}
+#	}
+
+# This class represents a piece of item with its properties
+var id: String
+var name: String
+var description: String
+var shape: String
+var sprite: Texture
+var spriteid: String
+var categories: Array
+var references: Dictionary = {}
+
+
+# Constructor to initialize item properties from a dictionary
+func _init(data: Dictionary):
+	id = data.get("id", "")
+	name = data.get("name", "")
+	description = data.get("description", "")
+	weight = data.get("weight", 1.0)
+	volume = data.get("volume", 1.0)
+	spriteid = data.get("sprite", "")
+	image = data.get("image", "")
+	stack_size = data.get("stack_size", 1)
+	max_stack_size = data.get("max_stack_size", 1)
+	two_handed = data.get("two_handed", false)
+	references = data.get("references", {})
+
+	# Initialize Craft and Magazine subclasses if they exist in data
+	if data.has("Craft"):
+		craft = Craft.new(data["Craft"])
+	else:
+		craft = null
+
+	if data.has("Magazine"):
+		magazine = Magazine.new(data["Magazine"])
+	else:
+		magazine = null
+
+	if data.has("Ranged"):
+		ranged = Ranged.new(data["Ranged"])
+	else:
+		ranged = null
+
+	if data.has("Melee"):
+		melee = Melee.new(data["Melee"])
+	else:
+		melee = null
+
+	if data.has("Food"):
+		food = Food.new(data["Food"])
+	else:
+		food = null
+
+	if data.has("Ammo"):
+		ammo = Ammo.new(data["Ammo"])
+	else:
+		ammo = null
+
+	if data.has("Wearable"):
+		wearable = Wearable.new(data["Wearable"])
+	else:
+		wearable = null
+
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"weight": weight,
+		"volume": volume,
+		"sprite": spriteid,
+		"image": image,
+		"stack_size": stack_size,
+		"max_stack_size": max_stack_size,
+		"two_handed": two_handed
+	}
+	if not references.is_empty():
+		data["references"] = references
+
+	# Add Craft and Magazine data if they exist
+	if craft:
+		data["Craft"] = craft.get_data()
+
+	if magazine:
+		data["Magazine"] = magazine.get_data()
+
+	if ranged:
+		data["Ranged"] = ranged.get_data()
+
+	if melee:
+		data["Melee"] = melee.get_data()
+
+	if food:
+		data["Food"] = food.get_data()
+
+	if ammo:
+		data["Ammo"] = ammo.get_data()
+
+	if wearable:
+		data["Wearable"] = wearable.get_data()
+
+	return data
+
+
+# Removes the provided reference from references
+# For example, remove "grass_field" to references.Core.maps
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity, for example "grass_field"
+func remove_reference(module: String, type: String, refid: String):
+	var refitem: DItem = Gamedata.items.by_id(refid)
+	var changes_made = Gamedata.dremove_reference(refitem.references, module, type, id)
+	if changes_made:
+		Gamedata.items.save_items_to_disk()
+
+
+# Adds a reference to the references list
+# For example, add "grass_field" to references.Core.maps
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity, for example "grass_field"
+func add_reference(module: String, type: String, refid: String):
+	var refitem: DItem = Gamedata.items.by_id(refid)
+	var changes_made = Gamedata.dadd_reference(refitem.references, module, type, id)
+	if changes_made:
+		Gamedata.items.save_items_to_disk()
+
+
+# Returns the path of the sprite
+func get_sprite_path() -> String:
+	return Gamedata.items.spritePath + spriteid
+
+
+# Handles item changes and updates references if necessary
+func on_data_changed(_oldditem: DItem):
+	var changes_made = false
+
+	# If any references were updated, save the changes to the data file
+	if changes_made:
+		print_debug("Item reference updates saved successfully.")
+		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
+
+
+# Some item has been changed
+# We need to update the relation between the item and other items based on crafting recipes
+func changed(olddata: DItem):
+	var changes_made = false
+	
+	# Handle wearable slot reference. 
+	if wearable:
+		# If the slot data changed between old and new, we update the reference
+		var old_slot = null
+		if olddata.wearable:
+			old_slot = olddata.wearable.slot
+
+		if old_slot != wearable.slot:
+			if old_slot:
+				changes_made = olddata.wearable.remove_reference(id) or changes_made
+			if wearable.slot:
+				changes_made = wearable.add_reference(id) or changes_made
+	elif olddata.wearable and olddata.wearable.slot:
+		# The wearable is present in the old data but not in the new, so we remove the reference
+		changes_made = olddata.wearable.remove_reference(id) or changes_made
+	
+	
+	# Dictionaries to track unique resource IDs across all recipes
+	var old_resource_ids: Dictionary = {}
+	var new_resource_ids: Dictionary = {}
+
+	# Collect all unique resource IDs from old recipes if olddata.craft is not null
+	if olddata.craft:
+		for recipe: CraftRecipe in olddata.craft.recipes:
+			for resource in recipe.required_resources:
+				old_resource_ids[resource["id"]] = true
+
+	# Collect all unique resource IDs from new recipes if craft is not null
+	if craft:
+		for recipe in craft.recipes:
+			for resource in recipe.required_resources:
+				new_resource_ids[resource["id"]] = true
+
+	# Resources that are no longer in the recipe will no longer reference this item
+	for res_id in old_resource_ids:
+		if not new_resource_ids.has(res_id):
+			changes_made = remove_reference("core", "items", res_id) or changes_made
+	
+	# Add references for new resources, nothing happens if they are already present
+	for res_id in new_resource_ids:
+		changes_made = add_reference("core", "items", res_id) or changes_made
+	update_item_skill_references(olddata)
+	
+	Gamedata.items.save_items_to_disk()
+	# Save changes if any modifications were made
+	if changes_made:
+		Gamedata.save_data_to_file(Gamedata.data.wearableslots)
+		print_debug("Item changes saved successfully.")
+	else:
+		print_debug("No changes were made to item.")
+
+
+
+# An item is being deleted from the data
+# We have to remove it from everything that references it
+func delete():
+	var changes_made = { "value": false }
+	
+	# This callable will remove this item from itemgroups that reference this item.
+	var myfunc: Callable = func (itemgroup_id):
+		var itemlist: Array = Gamedata.get_property_by_path(Gamedata.data.itemgroups, "items", itemgroup_id)
+		for i in range(itemlist.size()):
+			if itemlist[i].has("id") and itemlist[i]["id"] == id:
+				itemlist.remove_at(i)
+				changes_made["value"] = true
+				break  # Exit loop after removal to avoid index issues
+
+	execute_callable_on_references_of_type("core", "itemgroups", myfunc)
+	
+	# This callable will handle the removal of this item from all crafting recipes in other items
+	var remove_from_item: Callable = func(other_item_id: String):
+		var other_item: DItem = Gamedata.items.by_id(other_item_id)
+		if other_item and other_item.craft:
+			if other_item.craft.remove_item_from_recipes(id):
+				changes_made["value"] = true
+
+	# Pass the callable to every item in the item's references
+	# It will call remove_from_item on every item in item_data.references.core.items
+	execute_callable_on_references_of_type("core", "items", remove_from_item)
+	
+	# This callable will handle the removal of this item from all steps in quests
+	var remove_from_quest: Callable = func(quest_id: String):
+		var quest_data = Gamedata.get_data_by_id(Gamedata.data.quests, quest_id)
+		# Removes all steps where the item is equal to item_id
+		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, \
+		"steps.item", id) or changes_made["value"]
+		# Removes all rewards where the reward's item_id is equal to item_id
+		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, \
+		"rewards.item_id", id) or changes_made["value"]
+
+	# Pass the callable to every quest in the item's references
+	# It will call remove_from_quest on every item in item_data.references.core.quests
+	execute_callable_on_references_of_type("core", "quests", remove_from_quest)
+	
+	# For each recipe and for each item in each recipe, remove the reference to this item
+	for resource in craft.get_all_used_items():
+		changes_made["value"] = remove_reference("core", "items", resource) or changes_made["value"]
+
+	# Collect unique skill IDs from the item's recipes
+	var skill_ids: Dictionary = {}
+	for skillid in craft.get_used_skill_ids():
+		skill_ids[skillid] = true
+
+	# Add the ranged skill to the skill list
+	if ranged and ranged.used_skill:
+		skill_ids[ranged.used_skill.skill_id] = true
+
+	# Add the melee skill to the skill list
+	if melee and melee.used_skill:
+		skill_ids[melee.used_skill.skill_id] = true
+
+	# Remove the reference of this item from each skill
+	for skill_id in skill_ids.keys():
+		changes_made["value"] = Gamedata.remove_reference(Gamedata.data.skills, "core", \
+		"items", skill_id, id) or changes_made["value"]
+
+	# Save changes to the data file if any changes were made
+	if changes_made["value"]:
+		Gamedata.save_data_to_file(Gamedata.data.itemgroups)
+		Gamedata.save_data_to_file(Gamedata.data.skills)
+		Gamedata.save_data_to_file(Gamedata.data.quests)
+		Gamedata.items.save_items_to_disk()
+	else:
+		print_debug("No changes needed for item", id)
+
+
+# Executes a callable function on each reference of the given type
+# module = name of the mod. for example "core"
+# type = the type of reference we want to handle. For example "itemgroup"
+# callable = a function to execute on each reference ID
+# We will check if data has the [module] and [type] properties and execute the callable on each found ID
+func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
+	# Check if it contains the specified 'module' and 'type'
+	if references.has(module) and references[module].has(type):
+		# If the type exists, execute the callable on each ID found under this type
+		for ref_id in references[module][type]:
+			callable.call(ref_id)

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -1,0 +1,139 @@
+class_name DTiles
+extends RefCounted
+
+# There's a D in front of the class name to indicate this class only handles tile data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the list of tiles. You can access it trough Gamedata.tiles
+
+
+var dataPath: String = "./Mods/Core/Tiles/Tiles.json"
+var spritePath: String = "./Mods/Core/Tiles/"
+var tiledict: Dictionary = {}
+var sprites: Dictionary = {}
+
+
+func _init():
+	load_sprites()
+	load_tiles_from_disk()
+
+
+# Load all tiledata from disk into memory
+func load_tiles_from_disk() -> void:
+	var tilelist: Array = Helper.json_helper.load_json_array_file(dataPath)
+	for mytile in tilelist:
+		var tile: DTile = DTile.new(mytile)
+		tile.sprite = sprites[tile.spriteid]
+		tiledict[tile.id] = tile
+
+
+# Loads sprites and assigns them to the proper dictionary
+func load_sprites() -> void:
+	var png_files: Array = Helper.json_helper.file_names_in_dir(spritePath, ["png"])
+	for png_file in png_files:
+		# Load the .png file as a texture
+		var texture := load(spritePath + png_file) 
+		# Add the material to the dictionary
+		sprites[png_file] = texture
+
+
+func on_data_changed():
+	save_tiles_to_disk()
+
+
+# Saves all tiles to disk
+func save_tiles_to_disk() -> void:
+	var save_data: Array = []
+	for tile in tiledict.values():
+		save_data.append(tile.get_data())
+	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+
+
+func get_tiles() -> Dictionary:
+	return tiledict
+
+
+func duplicate_tile_to_disk(tileid: String, newtileid: String) -> void:
+	var tiledata: Dictionary = tiledict[tileid].get_data().duplicate(true)
+	tiledata.id = newtileid
+	var newtile: DTile = DTile.new(tiledata)
+	tiledict[newtileid] = newtile
+	save_tiles_to_disk()
+
+
+func add_new_tile(newid: String) -> void:
+	var newtile: DTile = DTile.new({"id":newid})
+	tiledict[newtile.id] = newtile
+	save_tiles_to_disk()
+
+
+func delete_tile(tileid: String) -> void:
+	tiledict[tileid].delete()
+	tiledict.erase(tileid)
+	save_tiles_to_disk()
+
+
+func by_id(tileid: String) -> DTile:
+	return tiledict[tileid]
+
+
+func has_id(tileid: String) -> bool:
+	return tiledict.has(tileid)
+
+
+# Returns the sprite of the tile
+# tileid: The id of the tile to return the sprite of
+func sprite_by_id(tileid: String) -> Texture:
+	return tiledict[tileid].sprite
+
+# Returns the sprite of the tile
+# tileid: The id of the tile to return the sprite of
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites[spritefile]
+
+
+# Removes the reference from the selected tile
+func remove_reference_from_tile(tileid: String, module: String, type: String, refid: String):
+	var mytile: DTile = tiledict[tileid]
+	mytile.remove_reference(module, type, refid)
+
+
+# Adds a reference to the references list
+# For example, add "grass_field" to references.Core.maps
+# tileid: The id of the tile to add the reference to
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity to reference, for example "grass_field"
+func add_reference_to_tile(tileid: String, module: String, type: String, refid: String):
+	var mytile: DTile = tiledict[tileid]
+	mytile.add_reference(module, type, refid)
+
+
+# This will update the given resource file with the provided json data
+# It is intended to save tile data from json to the res://ItemProtosets.tres file
+# So we can use the tile json data in-game
+func update_tile_protoset_json_data(tres_path: String, new_json_data: String) -> void:
+	# Load the ItemProtoset resource
+	var tile_protoset = load(tres_path) as ItemProtoset
+	if not tile_protoset:
+		print_debug("Failed to load ItemProtoset resource from:", tres_path)
+		return
+
+	# Update the json_data property
+	tile_protoset.json_data = new_json_data
+
+	# Save the resource back to the .tres file
+	var save_result = ResourceSaver.save(tile_protoset, tres_path)
+	if save_result != OK:
+		print_debug("Failed to save updated ItemProtoset resource to:", tres_path)
+	else:
+		print_debug("ItemProtoset resource updated and saved successfully to:", tres_path)
+
+
+# Filters tiles by type. Returns a list of tiles of that type
+# tile_type: Any of craft, magazine, ranged, melee, food, wearable
+func get_tiles_by_type(tile_type: String) -> Array[DTile]:
+	var filtered_tiles: Array[DTile] = []
+	for tile in tiledict.values():
+		if not tile.get(tile_type) == null:
+			filtered_tiles.append(tile)
+	return filtered_tiles

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -107,12 +107,3 @@ func add_reference_to_tile(tileid: String, module: String, type: String, refid: 
 	var mytile: DTile = tiledict[tileid]
 	mytile.add_reference(module, type, refid)
 
-
-# Filters tiles by type. Returns a list of tiles of that type
-# tile_type: Any of craft, magazine, ranged, melee, food, wearable
-func get_tiles_by_type(tile_type: String) -> Array[DTile]:
-	var filtered_tiles: Array[DTile] = []
-	for tile in tiledict.values():
-		if not tile.get(tile_type) == null:
-			filtered_tiles.append(tile)
-	return filtered_tiles

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -108,27 +108,6 @@ func add_reference_to_tile(tileid: String, module: String, type: String, refid: 
 	mytile.add_reference(module, type, refid)
 
 
-# This will update the given resource file with the provided json data
-# It is intended to save tile data from json to the res://ItemProtosets.tres file
-# So we can use the tile json data in-game
-func update_tile_protoset_json_data(tres_path: String, new_json_data: String) -> void:
-	# Load the ItemProtoset resource
-	var tile_protoset = load(tres_path) as ItemProtoset
-	if not tile_protoset:
-		print_debug("Failed to load ItemProtoset resource from:", tres_path)
-		return
-
-	# Update the json_data property
-	tile_protoset.json_data = new_json_data
-
-	# Save the resource back to the .tres file
-	var save_result = ResourceSaver.save(tile_protoset, tres_path)
-	if save_result != OK:
-		print_debug("Failed to save updated ItemProtoset resource to:", tres_path)
-	else:
-		print_debug("ItemProtoset resource updated and saved successfully to:", tres_path)
-
-
 # Filters tiles by type. Returns a list of tiles of that type
 # tile_type: Any of craft, magazine, ranged, melee, food, wearable
 func get_tiles_by_type(tile_type: String) -> Array[DTile]:

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -62,6 +62,22 @@ func reset():
 	ItemManager.player_equipment.reset_to_default()
 
 
+# When the player quits without saving (i.e. game over)
+func exit_game():
+	Helper.overmap_manager.player.axis_lock_linear_y = true # Stop vertical movement
+	Helper.map_manager.level_generator.unload_all_chunks()
+	await Helper.map_manager.level_generator.all_chunks_unloaded
+	# Devides the loaded_chunk_data.chunks into segments and saves them to disk
+	Helper.overmap_manager.unload_all_remaining_segments()
+	Helper.signal_broker.game_ended.emit()
+	get_tree().change_scene_to_file("res://scene_selector.tscn")
+
+
+# When the player saves and quits (i.e. return to main menu)
+func save_and_exit_game():
+	Helper.save_helper.save_game()
+	exit_game()
+
 
 #Level_name is a filename in /mods/core/maps
 #global_pos is the absolute position on the overmap

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -221,7 +221,7 @@ func _on_mob_killed(mobinstance: Mob):
 
 
 # The player has succesfully crafted an item.
-func _on_craft_successful(item: Dictionary, _recipe: Dictionary):
+func _on_craft_successful(item: Dictionary, _recipe: DItem.CraftRecipe):
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the collected item information

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -221,7 +221,7 @@ func _on_mob_killed(mobinstance: Mob):
 
 
 # The player has succesfully crafted an item.
-func _on_craft_successful(item: Dictionary, _recipe: DItem.CraftRecipe):
+func _on_craft_successful(item: DItem, _recipe: DItem.CraftRecipe):
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the collected item information

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -30,7 +30,8 @@ func save_map_data() -> void:
 	var chunks = get_tree().get_nodes_in_group("chunks")
 	for chunk in chunks:
 		if is_instance_valid(chunk): # some might be queue_freed at this point
-			await Helper.task_manager.create_task(chunk.save_chunk).completed
+			chunk.save_chunk()
+			#await Helper.task_manager.create_task(chunk.save_chunk).completed
 
 
 # Function to save a map segment to disk. The Helper.overmap_manager will call this
@@ -97,6 +98,7 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 # Save game state
 func save_game():
 	save_map_data()
+	Helper.overmap_manager.save_all_segments()
 	save_player_inventory()
 	save_player_equipment()
 	save_player_state(get_tree().get_first_node_in_group("Players"))

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -7,7 +7,6 @@ extends Node
 #It also has functions to load saved data and place the items, mobs and tiles on the map
 
 var current_save_folder: String = ""
-signal all_chunks_unloaded
 
 
 #Creates a new save folder. The name of this folder will be the current date and time
@@ -27,16 +26,11 @@ func create_new_save():
 
 # We can only save the data when all chunks are unloaded.
 func save_map_data() -> void:
-	Helper.map_manager.level_generator.all_chunks_unloaded.connect(_on_chunks_unloaded)
-	Helper.map_manager.level_generator.unload_all_chunks()
-
-
-# The level_generator has unloaded all the chunks. Save the data to disk
-func _on_chunks_unloaded():
-		print_debug("All chunks are unloaded")
-		# Devides the loaded_chunk_data.chunks into segments and saves them to disk
-		Helper.overmap_manager.unload_all_remaining_segments()
-		all_chunks_unloaded.emit()
+	# Get all chunks in the group "chunks"
+	var chunks = get_tree().get_nodes_in_group("chunks")
+	for chunk in chunks:
+		if is_instance_valid(chunk): # some might be queue_freed at this point
+			await Helper.task_manager.create_task(chunk.save_chunk).completed
 
 
 # Function to save a map segment to disk. The Helper.overmap_manager will call this
@@ -81,7 +75,6 @@ func load_map_segment_data(segment_pos: Vector2) -> Dictionary:
 		chunk_data[chunk_pos] = tactical_map_json[key]
 	
 	return chunk_data
-
 
 
 # This function determines the saved map folder path for the current level. 

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -61,6 +61,7 @@ signal playerInventory_item_modified(item: InventoryItem, inventory: InventorySt
 signal player_stat_changed(player: CharacterBody3D)
 signal player_skill_changed(player: CharacterBody3D)
 
+# Save load start end events
 signal game_started() # When the user presses 'play demo' on the main menu
 signal game_loaded() # When the user presses 'load game' on the main menu
 signal game_ended() # When the user presses 'main menu' button on the escape menu

--- a/Scripts/LoadingScreen.gd
+++ b/Scripts/LoadingScreen.gd
@@ -1,0 +1,27 @@
+extends Control
+
+
+# This script belongs to the loading window that shows in-game when the map is loading
+@export var sub_label: Label
+
+
+func _init():
+	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
+	Helper.signal_broker.game_started.connect(update_sub_text.bind("Creating new save"))
+	Helper.signal_broker.game_loaded.connect(update_sub_text.bind("Loading saved game"))
+	Helper.signal_broker.player_spawned.connect(_on_player_spawned)
+	
+func _on_initial_chunks_generated():
+	visible = false
+
+func update_sub_text(newtext: String):
+	sub_label.text = newtext
+
+# Function for handling player spawned signal
+func _on_player_spawned(_playernode):
+	sub_label.text = "Spawning player"
+
+
+func on_exit_game():
+	visible = true
+	sub_label.text = "Quitting game..."

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -26,8 +26,6 @@ const DATA_CATEGORIES = {
 # We write down the associated paths for the files to load
 # Next, sprites are loaded from spritesPath into the .sprites property
 # Finally, the data is loaded from dataPath into the .data property
-# Maps tile sprites and map data are different so they 
-# are loaded in using their respective functions
 func _ready():
 	initialize_data_structures()
 	load_sprites()
@@ -354,8 +352,6 @@ func remove_references_of_deleted_id(contentData: Dictionary, id: String):
 		on_tacticalmap_deleted(id)
 	if contentData == data.mobs:
 		on_mob_deleted(id)
-	if contentData == data.tiles:
-		on_tile_deleted(id)
 	if contentData == data.skills:
 		on_skill_deleted(id)
 	if contentData == data.wearableslots:
@@ -493,20 +489,6 @@ func on_mob_deleted(mob_id: String):
 		save_data_to_file(data.quests)
 	else:
 		print_debug("No changes needed for item", mob_id)
-
-# Some tile is being deleted from the data
-# We have to remove it from everything that references it
-func on_tile_deleted(tile_id: String):
-	var tile_data = get_data_by_id(data.tiles, tile_id)
-	if tile_data.is_empty():
-		print_debug("Item with ID", tile_data, "not found.")
-		return
-
-	# Check if the tile has references to maps and remove it from those maps
-	var modules = tile_data.get("references", [])
-	for mod in modules:
-		var mapsdata = Helper.json_helper.get_nested_data(tile_data, "references." + mod + ".maps")
-		maps.remove_entity_from_selected_maps("tile", tile_id, mapsdata)
 
 
 # A tacticalmap is being deleted. Remove all references to this tacticalmap

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -211,7 +211,7 @@ func save_data_to_file(contentData: Dictionary):
 
 
 # Takes contentdata and an id and returns the json that belongs to an id
-# For example, contentData can be Gamedata.data.tiles
+# For example, contentData can be Gamedata.data.mobs
 # and id can be "plain_grass" and it will return the json data for plain_grass
 func get_data_by_id(contentData: Dictionary, id: String) -> Dictionary:
 	var idnr: int = get_array_index_by_id(contentData, id)
@@ -221,7 +221,7 @@ func get_data_by_id(contentData: Dictionary, id: String) -> Dictionary:
 
 
 # Takes contentData and an id and returns the sprite associated with the id
-# For example, contentData can be Gamedata.data.tiles
+# For example, contentData can be Gamedata.data.mobs
 # and id can be "plain_grass" and it will return the sprite for plain_grass
 func get_sprite_by_id(contentData: Dictionary, id: String) -> Resource:
 	if contentData.sprites.is_empty() or contentData.data.is_empty():

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -11,7 +11,6 @@ var items: DItems
 
 # Dictionary keys for game data categories
 const DATA_CATEGORIES = {
-	"tiles": {"dataPath": "./Mods/Core/Tiles/Tiles.json", "spritePath": "./Mods/Core/Tiles/"},
 	"mobs": {"dataPath": "./Mods/Core/Mobs/Mobs.json", "spritePath": "./Mods/Core/Mobs/"},
 	"overmaptiles": {"spritePath": "./Mods/Core/OvermapTiles/"},
 	"tacticalmaps": {"dataPath": "./Mods/Core/TacticalMaps/"},

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -8,6 +8,7 @@ var itemgroup_references: Node = null
 var maps: DMaps
 var furnitures: DFurnitures
 var items: DItems
+var tiles: DTiles
 
 # Dictionary keys for game data categories
 const DATA_CATEGORIES = {
@@ -30,13 +31,13 @@ const DATA_CATEGORIES = {
 func _ready():
 	initialize_data_structures()
 	load_sprites()
-	load_tile_sprites()
 	load_data()
 	data.tacticalmaps.data = Helper.json_helper.file_names_in_dir(data.tacticalmaps.dataPath, ["json"])
 	itemgroup_references = itemgroup_references_Class.new()
 	maps = DMaps.new()
 	furnitures = DFurnitures.new()
 	items = DItems.new()
+	tiles = DTiles.new()
 
 # Initializes the data structures for each category defined in DATA_CATEGORIES
 func initialize_data_structures():
@@ -73,20 +74,6 @@ func load_sprites() -> void:
 				# Add the material to the dictionary
 				loaded_sprites[png_file] = texture
 			data[dict].sprites = loaded_sprites
-
-
-# This function reads all the files in "res://Mods/Core/Tiles/". It will check if the file is a .png file. If the file is a .png file, it will create a new material with that .png image as the texture. It will put all of the created materials in a dictionary with the name of the file as the key and the material as the value.
-func load_tile_sprites() -> void:
-	var tile_materials: Dictionary = {} # Materials used to represent tiles
-	var tilesDir = data.tiles.spritePath
-	var png_files: Array = Helper.json_helper.file_names_in_dir(tilesDir, ["png"])
-	for png_file in png_files:
-		var texture := load(tilesDir + png_file) # Load the .png file as a texture
-		var material := StandardMaterial3D.new() 
-		material.albedo_texture = texture # Set the texture of the material
-		material.uv1_scale = Vector3(3,2,1)
-		tile_materials[png_file] = material # Add the material to the dictionary
-	data.tiles.sprites = tile_materials
 
 
 # Adds a sprite to a specific dictionary and emits a signal if successful

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -442,8 +442,6 @@ func add_skill_xp(skill_id: String, xp: float) -> void:
 
 # The player has succesfully crafted an item. Get the skill id and xp from
 # the recipe and add it to the player's skill xp
-func _on_craft_successful(_item: Dictionary, recipe: Dictionary):
-	var skill_id = Helper.json_helper.get_nested_data(recipe, "skill_progression.id")
-	var xp = Helper.json_helper.get_nested_data(recipe, "skill_progression.xp")
-	if skill_id and xp:
-		add_skill_xp(skill_id, xp)
+func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
+	if recipe.skill_progression:
+		add_skill_xp(recipe.skill_progression.id, recipe.skill_progression.xp)

--- a/hud.tscn
+++ b/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://clhj525tmme3k"]
+[gd_scene load_steps=22 format=3 uid="uid://clhj525tmme3k"]
 
 [ext_resource type="FontFile" uid="uid://chm7lbcdeyo0h" path="res://Roboto-Bold.ttf" id="1_pxloi"]
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
@@ -19,6 +19,7 @@
 [ext_resource type="PackedScene" uid="uid://b50xhj4218wjd" path="res://Scenes/UI/QuestWindow.tscn" id="19_orjb2"]
 [ext_resource type="PackedScene" uid="uid://e0ebcv1n8jnq" path="res://Scenes/InventoryWindow.tscn" id="20_0l505"]
 [ext_resource type="PackedScene" uid="uid://ckuh2s0nvwg0x" path="res://Scenes/GameOver.tscn" id="20_jlthm"]
+[ext_resource type="PackedScene" uid="uid://dowehl4nfwxm" path="res://Scenes/LoadingScreen.tscn" id="20_kxcpa"]
 
 [sub_resource type="Theme" id="Theme_xn5t2"]
 default_font = ExtResource("1_pxloi")
@@ -250,11 +251,14 @@ anchor_top = 0.2
 anchor_right = 0.8
 anchor_bottom = 0.8
 
-[node name="EscapeMenu" parent="." instance=ExtResource("17_ewtgs")]
+[node name="EscapeMenu" parent="." node_paths=PackedStringArray("loadingscreen") instance=ExtResource("17_ewtgs")]
 visible = false
+loadingscreen = NodePath("../LoadingScreen")
 
 [node name="GameOver" parent="." instance=ExtResource("20_jlthm")]
 visible = false
+
+[node name="LoadingScreen" parent="." instance=ExtResource("20_kxcpa")]
 
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]


### PR DESCRIPTION
Requires #310 

Motivation for this is performance and doing away with the pure json manipulation.
- Creates the DTile and DTiles class for managing tile data.
- Phased out the old albedo_texture call on the tile sprites. This was residue from when each block was it's own entity
- Made the required changes to gamedata and the content editor

I saw that there were a lot of calls to Gamedata.get_data_by_id. Now we can find out if it was for tiles now that the calls should go to Gamedata.tiles.by_id() instead.
