### PR TITLE
Distribution mode

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -71,7 +71,8 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\",
-					\"test_items\"
+					\"test_items\",
+					\"M4A1_gun_ammo\"
 				],
 				\"items\": [
 					\"pistol_magazine\"
@@ -127,7 +128,8 @@ json_data = "[
 				\"itemgroups\": [
 					\"cabinet_general\",
 					\"mob_loot\",
-					\"test_items\"
+					\"test_items\",
+					\"M4A1_gun_ammo\"
 				]
 			}
 		},
@@ -191,6 +193,13 @@ json_data = "[
 		\"image\": \"./Mods/Core/Items/rifle_64_32.png\",
 		\"max_stack_size\": 1,
 		\"name\": \"M4a1 rifle\",
+		\"references\": {
+			\"core\": {
+				\"itemgroups\": [
+					\"M4A1_gun_ammo\"
+				]
+			}
+		},
 		\"sprite\": \"rifle_64_32.png\",
 		\"stack_size\": 1,
 		\"two_handed\": true,

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -197,6 +197,9 @@ json_data = "[
 			\"core\": {
 				\"itemgroups\": [
 					\"M4A1_gun_ammo\"
+				],
+				\"quests\": [
+					\"starter_tutorial_00\"
 				]
 			}
 		},

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -21,6 +21,7 @@ var load_queue = []
 var unload_queue = []
 # Enforces loading or unloading one chunk at a time
 var is_processing_chunk = false
+const TIME_DELAY: float = 0.5
 
 signal all_chunks_unloaded
 signal all_chunks_loaded  # Signal to indicate all initial chunks are loaded for the first time
@@ -40,7 +41,7 @@ func _ready():
 # Function to create and start a timer that will generate chunks every 1 second if applicable
 func start_timer():
 	var my_timer = Timer.new() # Create a new Timer instance
-	my_timer.wait_time = 0.5 # Timer will tick every 0.5 second
+	my_timer.wait_time = TIME_DELAY # Timer will tick every TIME_DELAY second
 	my_timer.one_shot = false # False means the timer will repeat
 	add_child(my_timer) # Add the Timer to the scene as a child of this node
 	my_timer.timeout.connect(_on_Timer_timeout) # Connect the timeout signal
@@ -293,7 +294,7 @@ func handle_chunk_unload():
 		# Get all chunks in the group "chunks"
 		var chunks = get_tree().get_nodes_in_group("chunks")
 		for chunk in chunks:
-			await get_tree().create_timer(0.5).timeout # Wait for a bit before checking again
+			await get_tree().create_timer(TIME_DELAY).timeout # Wait for a bit before checking again
 			if is_instance_valid(chunk): # some might be queue_freed at this point
 				match chunk.load_state:
 					chunk.LoadStates.NEITHER:
@@ -307,5 +308,5 @@ func handle_chunk_unload():
 			is_processing_chunk = false
 			all_chunks_unloaded.emit()
 		else:
-			await get_tree().create_timer(0.5).timeout # Wait for a bit before checking again
+			await get_tree().create_timer(TIME_DELAY).timeout # Wait for a bit before checking again
 			handle_chunk_unload()

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -21,7 +21,7 @@ var load_queue = []
 var unload_queue = []
 # Enforces loading or unloading one chunk at a time
 var is_processing_chunk = false
-const TIME_DELAY: float = 0.5
+const TIME_DELAY: float = 0.4
 
 signal all_chunks_unloaded
 signal all_chunks_loaded  # Signal to indicate all initial chunks are loaded for the first time
@@ -142,7 +142,7 @@ func load_chunk(chunk_pos: Vector2):
 	new_chunk.mypos = Vector3(chunk_pos.x * level_width, 0, chunk_pos.y * level_height)
 	new_chunk.level_manager = level_manager
 	new_chunk.level_generator = self
-	new_chunk.chunk_ready.connect(_on_chunk_un_loaded)
+	new_chunk.chunk_generated.connect(_on_chunk_un_loaded)
 	new_chunk.chunk_unloaded.connect(_on_chunk_un_loaded)
 	if Helper.overmap_manager.loaded_chunk_data.chunks.has(chunk_pos):
 		# If the chunk has been loaded before, we use that data

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -20,7 +20,8 @@
 					"generichouse_cross",
 					"generichouse_t",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -48,7 +49,8 @@
 					"generichouse_cross",
 					"generichouse_t",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -123,7 +125,9 @@
 					"forest_basic_00",
 					"Generichouse",
 					"Generichouse_00",
-					"field_grass_basic_00"
+					"field_grass_basic_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -158,7 +162,9 @@
 					"generichouse_corner",
 					"store_electronic_clothing",
 					"forest_basic_00",
-					"field_grass_basic_00"
+					"field_grass_basic_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -195,7 +201,9 @@
 					"forest_basic_00",
 					"Generichouse",
 					"Generichouse_00",
-					"field_grass_basic_00"
+					"field_grass_basic_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -294,7 +302,8 @@
 					"generichouse_cross",
 					"generichouse_t",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -334,7 +343,8 @@
 					"generichouse_cross",
 					"generichouse_t",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -649,7 +659,8 @@
 				"maps": [
 					"Generichouse",
 					"Generichouse_00",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -683,7 +694,8 @@
 				"maps": [
 					"Generichouse",
 					"Generichouse_00",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1061,7 +1073,8 @@
 		"references": {
 			"core": {
 				"maps": [
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"RockyHill_SW"
 				]
 			}
 		},

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -825,7 +825,9 @@
 			"core": {
 				"maps": [
 					"field_grass_basic_00",
-					"field_grass_flowers_00"
+					"field_grass_flowers_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -1015,6 +1015,13 @@
 		],
 		"mode": "Collection",
 		"name": "M4A1 Gun and ammo",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SW"
+				]
+			}
+		},
 		"sprite": "rifle_64_32.png"
 	}
 ]

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -989,5 +989,32 @@
 		"mode": "Collection",
 		"name": "Test items",
 		"sprite": "screw_32.png"
+	},
+	{
+		"description": "The player finds this rare pile of a M4A1 gun and ammo",
+		"id": "M4A1_gun_ammo",
+		"items": [
+			{
+				"id": "rifle_m4a1",
+				"max": 1,
+				"min": 1,
+				"probability": 100
+			},
+			{
+				"id": "pistol_magazine",
+				"max": 5,
+				"min": 3,
+				"probability": 100
+			},
+			{
+				"id": "bullet_9mm",
+				"max": 100,
+				"min": 25,
+				"probability": 100
+			}
+		],
+		"mode": "Collection",
+		"name": "M4A1 Gun and ammo",
+		"sprite": "rifle_64_32.png"
 	}
 ]

--- a/Mods/Core/Itemgroups/Itemgroups.json
+++ b/Mods/Core/Itemgroups/Itemgroups.json
@@ -841,100 +841,100 @@
 				"id": "herbs_wild",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "long_stick",
 				"max": 1,
 				"min": 1,
-				"probability": 50
+				"probability": 100
 			},
 			{
 				"id": "stick",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "small_rock",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "pebble",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "acorn",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "pinecone",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "bird_egg",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "mushrooms_forest",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "berries_wild",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "small_stick",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "plant_remnants",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "pine_branch",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "leaf",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "branch",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			},
 			{
 				"id": "log",
 				"max": 1,
 				"min": 1,
-				"probability": 20
+				"probability": 5
 			}
 		],
-		"mode": "Collection",
+		"mode": "Distribution",
 		"name": "Generic forest finds",
 		"references": {
 			"core": {

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -65,7 +65,8 @@
 				"itemgroups": [
 					"cabinet_general",
 					"mob_loot",
-					"test_items"
+					"test_items",
+					"M4A1_gun_ammo"
 				],
 				"items": [
 					"pistol_magazine"
@@ -121,7 +122,8 @@
 				"itemgroups": [
 					"cabinet_general",
 					"mob_loot",
-					"test_items"
+					"test_items",
+					"M4A1_gun_ammo"
 				]
 			}
 		},
@@ -185,6 +187,13 @@
 		"image": "./Mods/Core/Items/rifle_64_32.png",
 		"max_stack_size": 1,
 		"name": "M4a1 rifle",
+		"references": {
+			"core": {
+				"itemgroups": [
+					"M4A1_gun_ammo"
+				]
+			}
+		},
 		"sprite": "rifle_64_32.png",
 		"stack_size": 1,
 		"two_handed": true,

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -191,6 +191,9 @@
 			"core": {
 				"itemgroups": [
 					"M4A1_gun_ammo"
+				],
+				"quests": [
+					"starter_tutorial_00"
 				]
 			}
 		},

--- a/Mods/Core/Maps/RockyHill_SE.json
+++ b/Mods/Core/Maps/RockyHill_SE.json
@@ -4,6 +4,7 @@
 		"Mountain"
 	],
 	"description": "A rocky hill located in the southeast, featuring steep slopes and rugged paths.",
+	"id": "RockyHill_SE",
 	"levels": [
 		[],
 		[],
@@ -6486,16 +6487,16 @@
 
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_04"
@@ -6586,13 +6587,13 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -6682,13 +6683,13 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -6778,13 +6779,13 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -6874,13 +6875,13 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_05"
@@ -6970,13 +6971,13 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_05"
@@ -7069,7 +7070,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -7165,7 +7166,8 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_slope_00",
+				"rotation": 180
 			},
 			{
 				"id": "rock_floor_03"
@@ -7262,7 +7264,7 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7358,7 +7360,7 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7454,7 +7456,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7551,7 +7553,7 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7647,7 +7649,7 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7743,7 +7745,7 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_05"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7839,7 +7841,7 @@
 				"id": "rock_floor_05"
 			},
 			{
-				"id": "rock_floor_05"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -7935,7 +7937,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -8031,7 +8033,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -8127,7 +8129,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -8223,7 +8225,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_01"
 			},
 			{
 				"id": "rock_floor_03"
@@ -10146,7 +10148,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -10242,7 +10244,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -10338,7 +10340,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -10390,196 +10392,6 @@
 			},
 			{
 				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_slope_00",
-				"rotation": 270
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_02"
 			},
 			{
 				"id": "rock_floor_02"
@@ -10619,7 +10431,28 @@
 
 			},
 			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
 
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_05"
 			},
 			{
 				"id": "rock_floor_05"
@@ -10629,6 +10462,175 @@
 			},
 			{
 				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_slope_00",
+				"rotation": 270
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+
 			},
 			{
 				"id": "rock_floor_05"
@@ -10724,7 +10726,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -10820,93 +10822,6 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
 
 			},
 			{
@@ -10922,10 +10837,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_05"
-			},
-			{
-				"id": "rock_floor_05"
+				"id": "rock_floor_03"
 			},
 			{
 				"id": "rock_floor_03"
@@ -10949,6 +10861,96 @@
 				"id": "rock_floor_02"
 			},
 			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_03"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_05"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
 				"id": "rock_floor_00"
 			},
 			{
@@ -11012,7 +11014,7 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -11108,93 +11110,6 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-				"id": "rock_floor_00"
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-
-			},
-			{
 
 			},
 			{
@@ -11213,16 +11128,10 @@
 				"id": "rock_floor_00"
 			},
 			{
-				"id": "rock_floor_02"
-			},
-			{
 				"id": "rock_floor_00"
 			},
 			{
-				"id": "rock_floor_02"
-			},
-			{
-				"id": "rock_floor_02"
+				"id": "rock_floor_00"
 			},
 			{
 				"id": "rock_floor_02"
@@ -11291,6 +11200,12 @@
 
 			},
 			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
 
 			},
 			{
@@ -11300,7 +11215,94 @@
 				"id": "rock_floor_00"
 			},
 			{
+				"id": "rock_floor_02"
+			},
+			{
 				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_02"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+				"id": "rock_floor_00"
+			},
+			{
+
 			},
 			{
 				"id": "rock_floor_00"
@@ -11396,7 +11398,7 @@
 				"id": "rock_floor_00"
 			},
 			{
-				"id": "rock_floor_00"
+
 			},
 			{
 				"id": "rock_floor_00"

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -186,6 +186,17 @@
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "table_round_wood",
+					"rotation": 90
+				},
+				"id": "rock_floor_03"
+			},
+			{
+				"furniture": {
+					"id": "chair_wood",
+					"rotation": 270
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -195,9 +206,13 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
-			},
-			{
+				"furniture": {
+					"id": "cabinet_wood_00",
+					"itemgroups": [
+						"M4A1_gun_ammo"
+					],
+					"rotation": 90
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -282,6 +297,9 @@
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "chair_wood"
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -477,15 +495,27 @@
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "lamp_standing",
+					"rotation": 180
+				},
 				"id": "rock_floor_03"
 			},
 			{
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "table_metal",
+					"rotation": 180
+				},
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "bed_wood_single_00",
+					"rotation": 180
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -3333,33 +3363,19 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"furniture": {
-					"id": "table_round_wood"
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
-				"furniture": {
-					"id": "chair_wood",
-					"rotation": 270
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"furniture": {
-					"id": "cabinet_wood_00",
-					"itemgroups": [
-						"M4A1_gun_ammo"
-					],
-					"rotation": 90
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -3443,22 +3459,19 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"furniture": {
-					"id": "chair_wood"
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -3542,22 +3555,23 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_slope_00",
+				"rotation": 90
 			},
 			{
 				"id": "rock_floor_03"
@@ -3638,31 +3652,19 @@
 				"id": "rock_floor_00"
 			},
 			{
-				"furniture": {
-					"id": "lamp_standing",
-					"rotation": 180
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"furniture": {
-					"id": "bed_wood_single_00",
-					"rotation": 180
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
-				"furniture": {
-					"id": "table_metal",
-					"rotation": 180
-				},
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 				"id": "rock_floor_03"
@@ -6438,19 +6440,23 @@
 				"id": "rock_floor_03"
 			},
 			{
-
+				"id": "rock_floor_05"
 			},
 			{
-
+				"id": "rock_floor_03",
+				"rotation": 270
 			},
 			{
-
+				"id": "rock_floor_06",
+				"rotation": 270
 			},
 			{
-
+				"id": "rock_floor_06",
+				"rotation": 270
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 180
 			},
 			{
 				"id": "rock_floor_05",
@@ -6536,19 +6542,24 @@
 				"id": "rock_floor_03"
 			},
 			{
-
+				"id": "rock_floor_06",
+				"rotation": 270
 			},
 			{
-
+				"id": "rock_floor_03",
+				"rotation": 180
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 90
 			},
 			{
-
+				"id": "rock_floor_03",
+				"rotation": 90
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 270
 			},
 			{
 				"id": "rock_floor_03",
@@ -6634,34 +6645,35 @@
 				"id": "rock_floor_03"
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 270
+			},
+			{
+				"id": "rock_floor_03",
+				"rotation": 180
+			},
+			{
+				"id": "rock_floor_04",
+				"rotation": 270
+			},
+			{
+				"id": "rock_floor_06",
+				"rotation": 180
 			},
 			{
 
 			},
 			{
 
-			},
-			{
-
-			},
-			{
-
-			},
-			{
-				"id": "rock_slope_00",
-				"rotation": 90
 			},
 			{
 				"furniture": {
 					"id": "security_gate",
 					"rotation": 90
-				},
-				"id": "rock_floor_00"
+				}
 			},
 			{
-				"id": "rock_floor_00",
-				"rotation": 90
+
 			},
 			{
 
@@ -6736,19 +6748,23 @@
 				"id": "rock_floor_03"
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 270
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 180
 			},
 			{
-
+				"id": "rock_floor_06"
 			},
 			{
-
+				"id": "rock_floor_03",
+				"rotation": 270
 			},
 			{
-
+				"id": "rock_floor_04",
+				"rotation": 270
 			},
 			{
 				"id": "rock_floor_03",

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -3354,6 +3354,9 @@
 			{
 				"furniture": {
 					"id": "cabinet_wood_00",
+					"itemgroups": [
+						"M4A1_gun_ammo"
+					],
 					"rotation": 90
 				},
 				"id": "rock_floor_03"

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -4,6 +4,7 @@
 		"Mountain"
 	],
 	"description": "A rocky hill located in the southwest, perfect for adventurous climbs.",
+	"id": "RockyHill_SW",
 	"levels": [
 		[],
 		[],
@@ -3332,6 +3333,16 @@
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "table_round_wood"
+				},
+				"id": "rock_floor_03"
+			},
+			{
+				"furniture": {
+					"id": "chair_wood",
+					"rotation": 270
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -3341,9 +3352,10 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
-			},
-			{
+				"furniture": {
+					"id": "cabinet_wood_00",
+					"rotation": 90
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -3428,6 +3440,9 @@
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "chair_wood"
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -3620,15 +3635,27 @@
 				"id": "rock_floor_00"
 			},
 			{
+				"furniture": {
+					"id": "lamp_standing",
+					"rotation": 180
+				},
 				"id": "rock_floor_03"
 			},
 			{
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "bed_wood_single_00",
+					"rotation": 180
+				},
 				"id": "rock_floor_03"
 			},
 			{
+				"furniture": {
+					"id": "table_metal",
+					"rotation": 180
+				},
 				"id": "rock_floor_03"
 			},
 			{
@@ -6408,25 +6435,27 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_05",
+				"rotation": 270
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_05",
+				"rotation": 180
 			},
 			{
 				"id": "rock_floor_03"
@@ -6504,25 +6533,27 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_03",
+				"rotation": 90
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_04",
+				"rotation": 180
 			},
 			{
 				"id": "rock_floor_03"
@@ -6600,28 +6631,34 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_slope_00",
+				"rotation": 90
 			},
 			{
-				"id": "rock_floor_03"
+				"furniture": {
+					"id": "security_gate",
+					"rotation": 90
+				},
+				"id": "rock_floor_00"
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_00",
+				"rotation": 90
 			},
 			{
 
@@ -6696,22 +6733,23 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+				"id": "rock_floor_03",
+				"rotation": 180
 			},
 			{
 				"id": "rock_floor_03"
@@ -9689,16 +9727,16 @@
 				"id": "rock_floor_03"
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
-				"id": "rock_floor_03"
+
 			},
 			{
 

--- a/Mods/Core/Maps/forest_basic_00.json
+++ b/Mods/Core/Maps/forest_basic_00.json
@@ -97,7 +97,7 @@
 			"spawn_chance": 100,
 			"tiles": [
 				{
-					"count": 200,
+					"count": 100,
 					"id": "null"
 				}
 			]

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -18,7 +18,9 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"generichouse_t",
-					"store_electronic_clothing"
+					"store_electronic_clothing",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				],
 				"quests": [
 					"starter_tutorial_00"

--- a/Mods/Core/Quests/Quests.json
+++ b/Mods/Core/Quests/Quests.json
@@ -33,6 +33,12 @@
 				"mob": "scrapwalker",
 				"tip": "You can find them in town",
 				"type": "kill"
+			},
+			{
+				"amount": 1,
+				"item": "rifle_m4a1",
+				"tip": "Go to the mountain and enter the cave from the south",
+				"type": "collect"
 			}
 		]
 	}

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -144,7 +144,9 @@
 					"generichouse_t",
 					"store_electronic_clothing",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -617,6 +619,14 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_00",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyfloor1.png"
 	},
@@ -627,6 +637,14 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_01",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyfloor2.png"
 	},
@@ -637,6 +655,14 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_02",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyfloor3.png"
 	},
@@ -647,6 +673,14 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_03",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockfloor.png"
 	},
@@ -657,6 +691,14 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_04",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyfloor4.png"
 	},
@@ -667,6 +709,14 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_05",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyfloor5.png"
 	},
@@ -677,6 +727,13 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_06",
 		"name": "Rock floor",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "rockyfloor6.png"
 	},
@@ -687,6 +744,14 @@
 		"description": "A rocky surface allowing you to move up or down",
 		"id": "rock_slope_00",
 		"name": "Rock slope",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SE",
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "slope",
 		"sprite": "rockyfloorrampnorth.png"
 	},
@@ -700,7 +765,8 @@
 		"references": {
 			"core": {
 				"maps": [
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1091,7 +1157,8 @@
 					"generichouse_corner",
 					"generichouse_t",
 					"store_electronic_clothing",
-					"forest_basic_00"
+					"forest_basic_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1116,7 +1183,9 @@
 					"generichouse_corner",
 					"generichouse_t",
 					"forest_basic_00",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1167,7 +1236,9 @@
 					"generichouse_t",
 					"store_electronic_clothing",
 					"forest_basic_00",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1194,7 +1265,8 @@
 					"generichouse_t",
 					"store_electronic_clothing",
 					"forest_basic_00",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1219,7 +1291,8 @@
 					"generichouse_corner",
 					"store_electronic_clothing",
 					"forest_basic_00",
-					"Generichouse"
+					"Generichouse",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1233,6 +1306,13 @@
 		"description": "One side of the terrain is just dirt and no grass",
 		"id": "grass_dirt_north_00",
 		"name": "Grass with a patch of dirt",
+		"references": {
+			"core": {
+				"maps": [
+					"RockyHill_SW"
+				]
+			}
+		},
 		"shape": "cube",
 		"sprite": "grassnorthdirt.png"
 	},
@@ -1268,7 +1348,9 @@
 					"urbanroad_t",
 					"urbanroad_corner",
 					"generichouse_corner",
-					"field_grass_basic_00"
+					"field_grass_basic_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1293,7 +1375,9 @@
 					"generichouse_corner",
 					"generichouse_t",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1316,7 +1400,8 @@
 					"urbanroad_t",
 					"urbanroad_corner",
 					"generichouse_corner",
-					"generichouse_t"
+					"generichouse_t",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1341,7 +1426,9 @@
 					"generichouse_corner",
 					"generichouse_t",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},
@@ -1426,7 +1513,8 @@
 		"references": {
 			"core": {
 				"maps": [
-					"forest_basic_00"
+					"forest_basic_00",
+					"RockyHill_SW"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -730,7 +730,8 @@
 		"references": {
 			"core": {
 				"maps": [
-					"RockyHill_SE"
+					"RockyHill_SE",
+					"RockyHill_SW"
 				]
 			}
 		},

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -107,7 +107,8 @@ func load_furniture_data():
 	if not dfurniture.destruction.get_data().is_empty():
 		canDestroyCheckbox.button_pressed = true
 		destructionTextEdit.set_text(dfurniture.destruction.group)
-		destructionImageDisplay.texture = Gamedata.furnitures.sprite_by_file(dfurniture.destruction.sprite)
+		if not dfurniture.destruction.sprite == "":
+			destructionImageDisplay.texture = Gamedata.furnitures.sprite_by_file(dfurniture.destruction.sprite)
 		destructionSpriteNameLabel.text = dfurniture.destruction.sprite
 		set_visibility_for_children(destructionTextEdit, true)
 	else:

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -1220,7 +1220,7 @@ func generate_chunk_mesh_for_level(y_level: int):
 # Rebuilds the navigationmesh for all blocks in the chunk
 # We can't do this for a specific level, since we have 1 navigationmesh
 # If we had multiple navigationmeshes, we could create one per level, which is more optimized
-# See also https://docs.godotengine.org/en/latest/tutorials/navigation/navigation_using_navigationmeshes.html#baking-navigation-mesh-chunks-for-large-worlds
+# See also (Godot 4.3) https://docs.godotengine.org/en/latest/tutorials/navigation/navigation_using_navigationmeshes.html#baking-navigation-mesh-chunks-for-large-worlds
 # We can try to align the edges for more seamless navigation
 #If you know your final chunk size and the border size  increase the bake bound by 2*border_size
 #in general the border size should be large enough to have all the important source geometry from the neighbours included. If not enough geometry from the neighbour chunks is included or the border size is too small edges might end up not aligned again when baked. 

--- a/Scripts/Gamedata/DItemgroup.gd
+++ b/Scripts/Gamedata/DItemgroup.gd
@@ -76,7 +76,7 @@ class Item:
 var id: String
 var name: String
 var description: String
-var mode: String
+var mode: String # can be "Collection" or "Distribution". See the itemgroup editor for info
 var spriteid: String
 var sprite: Texture
 var items: Array[Item] = []

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -194,6 +194,16 @@ func data_changed(oldmap: DMap):
 				if not new_entities[entity_type].has(entity_id):
 					var furniture: DFurniture = Gamedata.furnitures.by_id(entity_id)
 					furniture.remove_reference("core","maps",id)
+		elif entity_type == "itemgroups":
+			for entity_id in old_entities[entity_type]:
+				if not new_entities[entity_type].has(entity_id):
+					var itemgroup: DItemgroup = Gamedata.itemgroups.by_id(entity_id)
+					itemgroup.remove_reference("core","maps",id)
+		elif entity_type == "mobs":
+			for entity_id in old_entities[entity_type]:
+				if not new_entities[entity_type].has(entity_id):
+					var mob: DMob = Gamedata.mobs.by_id(entity_id)
+					mob.remove_reference("core","maps",id)
 		else:
 			for entity_id in old_entities[entity_type]:
 				if not new_entities[entity_type].has(entity_id):

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -182,9 +182,10 @@ func data_changed(oldmap: DMap):
 			for entity_id in new_entities[entity_type]:
 				var dmob: DMob = Gamedata.mobs.by_id(entity_id)
 				dmob.add_reference("core","maps",id)
-		else:
+		elif entity_type == "itemgroups":
 			for entity_id in new_entities[entity_type]:
-				Gamedata.add_reference(Gamedata.data[entity_type], "core", "maps", entity_id, id)
+				var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(entity_id)
+				ditemgroup.add_reference("core","maps",id)
 
 	# Remove references for entities not present in new data
 	for entity_type in old_entities.keys():

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -175,7 +175,7 @@ func _on_container_clicked(containerListItemInstance: Control):
 			proximity_inventory_control.set_inventory(container_inventory)
 
 
-# Function to remove a container from the containerList
+# Function to remove a container from the containerLista
 func remove_container_from_list(container: Node3D):
 	var was_selected = false
 	var first_container = null
@@ -184,25 +184,32 @@ func remove_container_from_list(container: Node3D):
 	if proximity_inventory_control.get_inventory() == container.get_inventory():
 		was_selected = true
 
-	# Remove the container from the list and count remaining containers
-	var remaining_containers = 0
+	# Remove the container from the list
 	for child in containerList.get_children():
 		if child.containerInstance == container:
 			child.queue_free()
-		elif not child.is_queued_for_deletion():  # Only count children not queued for deletion
-			remaining_containers += 1
-			if first_container == null:
-				first_container = child.containerInstance
+			break
 
-	# If the removed container was selected, update the inventory to the first remaining container's inventory
-	if was_selected and remaining_containers > 0:
-		var first_container_inventory = first_container.get_inventory()
-		if first_container_inventory:
-			proximity_inventory_control.set_inventory(first_container_inventory)
-	elif was_selected or remaining_containers == 0:
-		# Reset the inventory to proximity_inventory and hide the control
-		proximity_inventory_control.set_inventory(proximity_inventory)
-		proximity_inventory_control.visible = false
+	# Find the first non-queued container if it exists
+	for child in containerList.get_children():
+		if not child.is_queued_for_deletion():
+			first_container = child.containerInstance
+			break
+
+	# Update the proximity inventory control based on the remaining containers
+	if was_selected:
+		if first_container:
+			var first_container_inventory = first_container.get_inventory()
+			if first_container_inventory:
+				proximity_inventory_control.set_inventory(first_container_inventory)
+		else:
+			# Reset the inventory to proximity_inventory and hide the control
+			proximity_inventory_control.set_inventory(proximity_inventory)
+			proximity_inventory_control.visible = false
+
+	# Ensure visibility of the proximity inventory control based on whether there are remaining containers
+	proximity_inventory_control.visible = first_container != null
+
 
 
 # Called when the user has pressed a button that will equip the selected item

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -189,9 +189,9 @@ func _physics_process(_delta):
 		# Check if the mob has crossed into a new chunk
 		current_chunk = get_chunk_from_position(global_transform.origin)
 		if current_chunk != last_chunk:
-			last_chunk = current_chunk
 			# We have crossed over to another chunk so we use that navigationmap now.
 			update_navigation_agent_map(current_chunk)
+			last_chunk = current_chunk
 
 	var current_rotation = int(rotation_degrees.y)
 	if current_rotation != last_rotation:
@@ -204,7 +204,9 @@ func update_navigation_agent_map(chunk_position: Vector2):
 	if navigation_map_id:
 		nav_agent.set_navigation_map(navigation_map_id)
 	else:
-		print_debug("Tried to set navigation_map_id at "+str(chunk_position)+", but it was null")
+		print_debug("Tried to set navigation_map_id at "+str(chunk_position)+", but it was null. last_position = " + str(last_position) + ", last_chunk = " + str(last_chunk))
+		# Set the last chunk to one that doesn't exist so it will try to get a new map
+		last_chunk = Vector2(0.1,0.1)
 
 # When the mob gets hit by an attack
 # attack: a dictionary with the "damage" and "hit_chance" properties

--- a/Scripts/MobFollow.gd
+++ b/Scripts/MobFollow.gd
@@ -28,11 +28,11 @@ func Physics_Update(_delta: float):
 	if mob.terminated:
 		Transistioned.emit(self, "mobterminate") 
 	
-	if nav_agent.get_navigation_map() == null:
-		var current_chunk = mob.get_chunk_from_position(mob.global_transform.origin)
+	var next_pos: Vector3 = nav_agent.get_next_path_position()
+	if nav_agent.get_navigation_map() == null or next_pos == mob.global_transform.origin:
+		var current_chunk = mob.get_chunk_from_position(target_location)
 		mob.update_navigation_agent_map(current_chunk)
 		return
-	var next_pos: Vector3 = nav_agent.get_next_path_position()
 	var dir = mob.to_local(next_pos).normalized()
 	mob.velocity = dir * mob.current_move_speed
 	mob.move_and_slide()

--- a/Scripts/MobFollow.gd
+++ b/Scripts/MobFollow.gd
@@ -27,6 +27,11 @@ func Exit():
 func Physics_Update(_delta: float):
 	if mob.terminated:
 		Transistioned.emit(self, "mobterminate") 
+	
+	if nav_agent.get_navigation_map() == null:
+		var current_chunk = mob.get_chunk_from_position(mob.global_transform.origin)
+		mob.update_navigation_agent_map(current_chunk)
+		return
 	var next_pos: Vector3 = nav_agent.get_next_path_position()
 	var dir = mob.to_local(next_pos).normalized()
 	mob.velocity = dir * mob.current_move_speed
@@ -41,7 +46,7 @@ func Physics_Update(_delta: float):
 	if !targeted_player:
 		return
 	var space_state = get_world_3d().direct_space_state
-	# TO-DO Change playerCol to group of players
+	# TODO Change playerCol to group of players
 	var query = PhysicsRayQueryParameters3D.create(mobCol.global_position, targeted_player.global_position, int(pow(2, 1-1) + pow(2, 3-1)),[self])
 	var result = space_state.intersect_ray(query)
 	

--- a/Scripts/MobIdle.gd
+++ b/Scripts/MobIdle.gd
@@ -8,7 +8,7 @@ var mob: CharacterBody3D # The mob we provide idle behavour for
 var move_distance: float = 50.0
 var moving_timer: Timer
 
-@onready var target_location
+@onready var target_location: Vector3
 
 var is_looking_to_move = false
 
@@ -30,14 +30,28 @@ func Exit():
 
 func Physics_Update(_delta: float):
 	if mob.terminated:
-		Transistioned.emit(self, "mobterminate") 
+		Transistioned.emit(self, "mobterminate")
+	
 	if is_looking_to_move:
-		var dir = mob.to_local(nav_agent.get_next_path_position()).normalized()
-		mob.velocity = dir * mob.current_idle_move_speed
-		mob.move_and_slide()
+		handle_mob_movement()
 
-		if Vector3(mob.global_position).distance_to(target_location) <= 0.5:
-			is_looking_to_move = false
+func handle_mob_movement():
+	var chunk_position = mob.get_chunk_from_position(target_location)
+	
+	# Check if the target location has a navigation map
+	if Helper.chunk_navigation_maps.has(chunk_position):
+		move_mob_to_target() # Continue moving
+	else:
+		# If there's no navigation map for the target location, stop moving
+		is_looking_to_move = false
+
+func move_mob_to_target():
+	var dir = mob.to_local(nav_agent.get_next_path_position()).normalized()
+	mob.velocity = dir * mob.current_idle_move_speed
+	mob.move_and_slide()
+	
+	if Vector3(mob.global_position).distance_to(target_location) <= 0.5:
+		is_looking_to_move = false
 
 
 func _on_detection_player_spotted(_player):

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -60,7 +60,11 @@ func create_loot():
 	
 	# Check if the itemgroup data exists and has items
 	if ditemgroup:
-		item_added = _add_items_to_inventory(ditemgroup.items)
+		var groupmode: String = ditemgroup.mode # can be "Collection" or "Distribution".
+		if groupmode == "Collection":
+			item_added = _add_items_to_inventory_collection_mode(ditemgroup.items)
+		elif groupmode == "Distribution":
+			item_added = _add_items_to_inventory_distribution_mode(ditemgroup.items)
 
 	# Set the texture if an item was successfully added and if it hasn't been set by set_texture
 	if item_added and sprite_3d.texture == Gamedata.textures.container:
@@ -75,8 +79,8 @@ func create_loot():
 		_on_item_removed(null)
 
 
-# Takes a list of items and adds them to the inventory of the chance allows it.
-func _add_items_to_inventory(items: Array[DItemgroup.Item]) -> bool:
+# Takes a list of items and adds them to the inventory in Collection mode.
+func _add_items_to_inventory_collection_mode(items: Array[DItemgroup.Item]) -> bool:
 	var item_added: bool = false
 	# Loop over each item object in the itemgroup's 'items' property
 	for item_object: DItemgroup.Item in items:
@@ -89,6 +93,30 @@ func _add_items_to_inventory(items: Array[DItemgroup.Item]) -> bool:
 			var quantity = randi_range(item_object.minc, item_object.maxc)
 			_add_item_to_inventory(item_id, quantity)
 	return item_added
+
+
+# Takes a list of items and adds one to the inventory based on probabilities in Distribution mode.
+func _add_items_to_inventory_distribution_mode(items: Array[DItemgroup.Item]) -> bool:
+	var total_probability = 0
+	# Calculate the total probability
+	for item_object in items:
+		total_probability += item_object.probability
+
+	# Generate a random value between 0 and total_probability - 1
+	var random_value = randi_range(0, total_probability - 1)
+	var cumulative_probability = 0
+
+	# Iterate through items to select one based on the random value
+	for item_object: DItemgroup.Item in items:
+		cumulative_probability += item_object.probability
+		# Check if the random value falls within the current item's range
+		if random_value < cumulative_probability:
+			var item_id = item_object.id
+			var quantity = randi_range(item_object.minc, item_object.maxc)
+			_add_item_to_inventory(item_id, quantity)
+			return true  # One item is added, return immediately
+
+	return false  # In case no item is added, though this is highly unlikely
 
 
 # Takes an item_id and quantity and adds it to the inventory

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -63,11 +63,11 @@ func create_loot():
 		item_added = _add_items_to_inventory(ditemgroup.items)
 
 	# Set the texture if an item was successfully added and if it hasn't been set by set_texture
-	if item_added and sprite_3d.texture == load("res://Textures/container_32.png"):
+	if item_added and sprite_3d.texture == Gamedata.textures.container:
 		# If this container is attached to the furniture, we set the container filled
 		var parent = get_parent()
 		if parent is FurniturePhysics or parent is FurnitureStatic:
-			sprite_3d.texture = load("res://Textures/container_filled_32.png")
+			sprite_3d.texture = Gamedata.textures.container_filled
 		else: # Set the sprite to one it the item's sprites
 			set_random_inventory_item_texture()
 	elif not item_added:
@@ -108,11 +108,11 @@ func _add_item_to_inventory(item_id: String, quantity: int):
 func deserialize_and_apply_items(items_data: Dictionary):
 	inventory.deserialize(items_data)
 	
-	var default_texture: Texture = load("res://Textures/container_32.png")
+	var default_texture: Texture = Gamedata.textures.container
 	
 	if inventory.get_items().size() > 0:
 		if sprite_3d.texture == default_texture:
-			sprite_3d.texture = load("res://Textures/container_filled_32.png")
+			sprite_3d.texture = Gamedata.textures.container_filled
 		# Else, some other texture has been set so we keep that
 	else:
 		sprite_3d.texture = default_texture
@@ -154,7 +154,7 @@ func create_sprite():
 	sprite_3d.texture_filter = BaseMaterial3D.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
 	sprite_3d.render_priority = 10
 	set_texture(texture_id)
-	#sprite_3d.texture = load("res://Textures/container_32.png")
+	#sprite_3d.texture = Gamedata.textures.container
 
 	# Add to the scene tree
 	add_child.call_deferred(sprite_3d)
@@ -163,14 +163,14 @@ func create_sprite():
 # Updates the texture of this container. If no texture is provided, we use the default
 func set_texture(mytex: String):
 	if not mytex:
-		sprite_3d.texture = load("res://Textures/container_32.png")
+		sprite_3d.texture = Gamedata.textures.container
 		return
 	var newsprite: Texture = Gamedata.furnitures.sprite_by_file(mytex)
 	if newsprite:
 		sprite_3d.texture = newsprite
 		texture_id = mytex  # Save the texture ID
 	else:
-		sprite_3d.texture = load("res://Textures/container_32.png")
+		sprite_3d.texture = Gamedata.textures.container
 
 
 # This area will be used to check if the player can reach into the inventory with ItemDetector
@@ -212,7 +212,7 @@ func get_sprite():
 		if parent is FurniturePhysics or parent is FurnitureStatic:
 			return parent.get_sprite()
 		else:
-			return load("res://Textures/container_32.png")
+			return Gamedata.textures.container
 
 
 # Returns the inventorystacked that this container holds
@@ -233,7 +233,7 @@ func _on_item_removed(_item: InventoryItem):
 				queue_free.call_deferred()
 			else:
 				# It's a child of some node, probably furniture
-				sprite_3d.texture = load("res://Textures/container_32.png")
+				sprite_3d.texture = Gamedata.textures.container
 			
 	else: # There are still items in the container
 		if is_inside_tree():

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -97,11 +97,15 @@ func _add_item_to_inventory(item_id: String, quantity: int):
 	var ditem: DItem = Gamedata.items.by_id(item_id)
 	# Check if the item data is valid before adding
 	if ditem and quantity > 0:
-		# Create and add the item to the inventory and keep a reference
-		var item = inventory.create_and_add_item(item_id)
-		# Set the item stack size, limited by max_stack_size
-		var stack_size = min(quantity, ditem.max_stack_size)
-		InventoryStacked.set_item_stack_size(item, stack_size)
+		while quantity > 0:
+			# Calculate the stack size for this iteration, limited by max_stack_size
+			var stack_size = min(quantity, ditem.max_stack_size)
+			# Create and add the item to the inventory
+			var item = inventory.create_and_add_item(item_id)
+			# Set the item stack size
+			InventoryStacked.set_item_stack_size(item, stack_size)
+			# Decrease the remaining quantity
+			quantity -= stack_size
 
 
 # Function to deserialize inventory and apply the correct sprite

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -20,6 +20,11 @@ const DATA_CATEGORIES = {
 	"quests": {"dataPath": "./Mods/Core/Quests/Quests.json", "spritePath": "./Mods/Core/Items/"}
 }
 
+# Dictionary to store loaded textures
+var textures: Dictionary = {
+	"container": load("res://Textures/container_32.png"),
+	"container_filled": load("res://Textures/container_filled_32.png")
+}
 
 # We write down the associated paths for the files to load
 # Next, sprites are loaded from spritesPath into the .sprites property


### PR DESCRIPTION
Requires #327 

Adds distribution mode for itemgroups. Until now we only used collection mode, but this wasn't fitting for the forest_finds group.

Now items are neatly distributed in the forest instead of finding a stack of items in one place.