### PR TITLE
Refactor content list

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -73,6 +73,7 @@ func _on_close_button_button_up() -> void:
 # The function will signal to Gamedata that the data has changed and needs to be saved
 func _on_save_button_button_up() -> void:
 	dmob.spriteid = PathTextLabel.text
+	dmob.sprite = mobImageDisplay.texture
 	dmob.name = NameTextEdit.text
 	dmob.description = DescriptionTextEdit.text
 	dmob.melee_damage = int(melee_damage_numedit.value)

--- a/Scenes/ContentManager/Custom_Editors/Scripts/SkillsEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/SkillsEditor.gd
@@ -1,9 +1,9 @@
 extends Control
 
-#This scene is intended to be used inside the content editor
-#It is supposed to edit exactly one skill
-#It expects to save the data to a JSON file
-#To load data, provide the name of the skill data file and an ID
+# This scene is intended to be used inside the content editor
+# It is supposed to edit exactly one Skill
+# It expects to save the data to a JSON file
+# To load data, provide the name of the skill data file and an ID
 
 @export var skillImageDisplay: TextureRect = null
 @export var IDTextLabel: Label = null
@@ -12,64 +12,57 @@ extends Control
 @export var DescriptionTextEdit: TextEdit = null
 @export var skillSelector: Popup = null
 
-
 # This signal will be emitted when the user presses the save button
 # This signal should alert Gamedata that the skill data array should be saved to disk
-signal data_changed(game_data: Dictionary, new_data: Dictionary, old_data: Dictionary)
+signal data_changed()
 
-var olddata: Dictionary # Remember what the value of the data was before editing
+var olddata: DSkill # Remember what the value of the data was before editing
+
 # The data that represents this skill
-# The data is selected from the Gamedata.data.skills.data array
+# The data is selected from the Gamedata.skills
 # based on the ID that the user has selected in the content editor
-var contentData: Dictionary = {}:
+var dskill: DSkill = null:
 	set(value):
-		contentData = value
+		dskill = value
 		load_skill_data()
-		skillSelector.sprites_collection = Gamedata.data.skills.sprites
-		olddata = contentData.duplicate(true)
+		skillSelector.sprites_collection = Gamedata.skills.sprites
+		olddata = DSkill.new(dskill.get_data().duplicate(true))
 
-
-func _ready():
-	data_changed.connect(Gamedata.on_data_changed)
-
-
-#This function update the form based on the contentData that has been loaded
+# This function updates the form based on the DSkill that has been loaded
 func load_skill_data() -> void:
-	if skillImageDisplay != null and contentData.has("sprite") and \
-	not contentData["sprite"] == "" and Gamedata.data.skills.sprites.has(contentData["sprite"]):
-		skillImageDisplay.texture = Gamedata.data.skills.sprites[contentData["sprite"]]
-		PathTextLabel.text = contentData["sprite"]
+	if skillImageDisplay != null and dskill.spriteid != "":
+		skillImageDisplay.texture = dskill.sprite
+		PathTextLabel.text = dskill.spriteid
 	if IDTextLabel != null:
-		IDTextLabel.text = str(contentData["id"])
-	if NameTextEdit != null and contentData.has("name"):
-		NameTextEdit.text = contentData["name"]
-	if DescriptionTextEdit != null and contentData.has("description"):
-		DescriptionTextEdit.text = contentData["description"]
-	
+		IDTextLabel.text = str(dskill.id)
+	if NameTextEdit != null:
+		NameTextEdit.text = dskill.name
+	if DescriptionTextEdit != null:
+		DescriptionTextEdit.text = dskill.description
 
-#The editor is closed, destroy the instance
-#TODO: Check for unsaved changes
+# The editor is closed, destroy the instance
+# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
 	queue_free()
 
-# This function takes all data fro the form elements stores them in the contentData
-# Since contentData is a reference to an item in Gamedata.data.skills.data
-# the central array for skilldata is updated with the changes as well
+# This function takes all data from the form elements and stores them in the DSkill instance
+# Since dskill is a reference to an item in Gamedata.skills
+# the central array for skill data is updated with the changes as well
 # The function will signal to Gamedata that the data has changed and needs to be saved
 func _on_save_button_button_up() -> void:
-	contentData["sprite"] = PathTextLabel.text
-	contentData["name"] = NameTextEdit.text
-	contentData["description"] = DescriptionTextEdit.text
-	data_changed.emit(Gamedata.data.skills, contentData, olddata)
-	olddata = contentData.duplicate(true)
+	dskill.spriteid = PathTextLabel.text
+	dskill.name = NameTextEdit.text
+	dskill.description = DescriptionTextEdit.text
+	dskill.sprite = skillImageDisplay.texture
+	dskill.save_to_disk()
+	data_changed.emit()
+	olddata = DSkill.new(dskill.get_data().duplicate(true))
 
-
-#When the skillImageDisplay is clicked, the user will be prompted to select an image from 
-# "res://Mods/Core/skills/". The texture of the skillImageDisplay will change to the selected image
+# When the skillImageDisplay is clicked, the user will be prompted to select an image from 
+# "res://Mods/Core/Skills/". The texture of the skillImageDisplay will change to the selected image
 func _on_skill_image_display_gui_input(event) -> void:
 	if event is InputEventMouseButton and event.pressed:
 		skillSelector.show()
-
 
 func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	var skillTexture: Resource = clicked_sprite.get_texture()

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/EntitiesContainer.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/EntitiesContainer.gd
@@ -17,7 +17,7 @@ func _ready():
 
 # loop over Gamedata.maps and creates tilebrushes for each map sprite in the list. 
 func loadMaps():
-	var mapsList: Dictionary = Gamedata.maps.get_maps()
+	var mapsList: Dictionary = Gamedata.maps.get_all()
 	var newTilesList: Control = scrolling_Flow_Container.instantiate()
 	newTilesList.header = "maps"
 	add_child(newTilesList)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditor.gd
@@ -14,24 +14,28 @@ var mapHeight: int = 3:
 		mapHeight = newHeight
 		if not mapheightTextEdit.value == newHeight:
 			mapheightTextEdit.value = newHeight
+
 var mapWidth: int = 3:
 	set(newWidth):
 		mapWidth = newWidth
 		if not mapwidthTextEdit.value == newWidth:
 			mapwidthTextEdit.value = newWidth
-var contentSource: String = "":
-	set(newSource):
-		contentSource = newSource
-		tileGrid.load_tacticalmap_json_file()
+
+var oldmap: DTacticalmap #Used to remember the mapdata before it was changed
+var currentMap: DTacticalmap:
+	set(newMap):
+		currentMap = newMap
+		oldmap = newMap
+		mapWidth = currentMap.mapwidth
+		mapHeight = currentMap.mapheight
 		setPanWindowSize()  # To adjust the size after loading
+		tileGrid.loadLevel()
 
 
 # In tacticalmapeditor.gd
 func _ready() -> void:
 	# For properly using the tab key to switch elements
 	control_elements = [mapwidthTextEdit,mapheightTextEdit]
-	# Connect the signal from TileGrid to this script
-	tileGrid.map_dimensions_changed.connect(_on_map_dimensions_changed)
 	setPanWindowSize()
 
 

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTile.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditorTile.gd
@@ -2,16 +2,15 @@ extends Control
 
 #If a tile has no data, we save an empty object. Tiledata can have:
 # id, rotation, mob
-const defaultTileData: Dictionary = {}
 const defaultTexture: String = "res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png"
 const aboveTexture: String = "res://Scenes/ContentManager/Mapeditor/Images/tileAbove.png"
-var tileData: Dictionary = defaultTileData.duplicate():
+# The TChunk is a subclass of the DTacticalmap class. It has id and rotation properties
+var tileData: DTacticalmap.TChunk = DTacticalmap.TChunk.new({}):
 	set(data):
 		tileData = data
-		if tileData.has("id") and tileData.id != "":
+		if not tileData.id == "":
 			$TileSprite.texture = Gamedata.maps.by_id(tileData.id).sprite
-			if tileData.has("rotation"):
-				set_rotation_amount(tileData.rotation)
+			set_rotation_amount(tileData.rotation)
 		else:
 			$TileSprite.texture = load(defaultTexture)
 signal tile_clicked(clicked_tile: Control)
@@ -28,10 +27,7 @@ func _on_texture_rect_gui_input(event: InputEvent) -> void:
 func set_rotation_amount(amount: int) -> void:
 	$TileSprite.pivot_offset = size / 2
 	$TileSprite.rotation_degrees = amount
-	if amount == 0:
-		tileData.erase("rotation")
-	else:
-		tileData.rotation = amount
+	tileData.rotation = amount
 
 
 func get_rotation_amount() -> int:
@@ -39,11 +35,10 @@ func get_rotation_amount() -> int:
 
 
 func set_tile_id(id: String) -> void:
+	tileData.id = id
 	if id == "":
-		tileData.erase("id")
 		$TileSprite.texture = load(defaultTexture)
 	else:
-		tileData.id = id
 		$TileSprite.texture = Gamedata.maps.by_id(id).sprite
 
 
@@ -53,7 +48,7 @@ func _on_texture_rect_mouse_entered() -> void:
 
 
 func set_default() -> void:
-	tileData = defaultTileData.duplicate()
+	tileData = DTacticalmap.TChunk.new({})
 
 
 func highlight() -> void:

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -45,7 +45,7 @@ func loadMobs():
 
 
 func loadFurniture():
-	var furnitureList: Dictionary = Gamedata.furnitures.get_furnitures()
+	var furnitureList: Dictionary = Gamedata.furnitures.get_all()
 	var newFurnitureList: Control = scrolling_Flow_Container.instantiate()
 	newFurnitureList.header = "Furniture"
 	newFurnitureList.collapse_button_pressed.connect(_on_collapse_button_pressed)

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -21,7 +21,7 @@ func _ready():
 	
 # this function will read all files in Gamedata.data.mobs.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the mobs belong to.
 func loadMobs():
-	var mobList: Dictionary = Gamedata.mobs.get_mobs()
+	var mobList: Dictionary = Gamedata.mobs.get_all()
 	var newMobsList: Control = scrolling_Flow_Container.instantiate()
 	newMobsList.header = "Mobs"
 	newMobsList.collapse_button_pressed.connect(_on_collapse_button_pressed)
@@ -65,7 +65,7 @@ func loadFurniture():
 
 # this function will read all files in Gamedata.tiles and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
 func loadTiles():
-	var tileList: Dictionary = Gamedata.tiles.get_tiles()
+	var tileList: Dictionary = Gamedata.tiles.get_all()
 
 	for tile: DTile in tileList.values():
 		if tile.spriteid:

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -357,7 +357,7 @@ func load_collapse_state():
 
 
 func load_map_list():
-	var maplist: Dictionary = Gamedata.maps.get_maps()
+	var maplist: Dictionary = Gamedata.maps.get_all()
 	for map: String in maplist.keys():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(map)
@@ -369,7 +369,7 @@ func load_map_list():
 
 
 func load_tacticalmap_list():
-	var maplist: Dictionary = Gamedata.tacticalmaps.get_maps()
+	var maplist: Dictionary = Gamedata.tacticalmaps.get_all()
 	for map: String in maplist.keys():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(map)
@@ -391,7 +391,7 @@ func load_furnitures_list():
 
 # Load the itemgroups list
 func load_itemgroups_list():
-	var itemgrouplist: Dictionary = Gamedata.itemgroups.get_itemgroups()
+	var itemgrouplist: Dictionary = Gamedata.itemgroups.get_all()
 	for itemgroup: DItemgroup in itemgrouplist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(itemgroup.id)
@@ -403,7 +403,7 @@ func load_itemgroups_list():
 
 # Load the items list
 func load_items_list():
-	var itemlist: Dictionary = Gamedata.items.get_items()
+	var itemlist: Dictionary = Gamedata.items.get_all()
 	for item: DItem in itemlist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(item.id)
@@ -415,7 +415,7 @@ func load_items_list():
 
 # Load the tiles list
 func load_tiles_list():
-	var tilelist: Dictionary = Gamedata.tiles.get_tiles()
+	var tilelist: Dictionary = Gamedata.tiles.get_all()
 	for tile: DTile in tilelist.values():
 		# Add all the filenames to the Contenttiles list as child nodes
 		var tile_index: int = contentItems.add_item(tile.id)
@@ -427,7 +427,7 @@ func load_tiles_list():
 
 # Load the mobs list
 func load_mobs_list():
-	var moblist: Dictionary = Gamedata.mobs.get_mobs()
+	var moblist: Dictionary = Gamedata.mobs.get_all()
 	for mob: DMob in moblist.values():
 		# Add all the filenames to the Contentmobs list as child nodes
 		var mob_index: int = contentItems.add_item(mob.id)
@@ -440,7 +440,7 @@ func load_mobs_list():
 
 # Load the playerattribute list
 func load_playerattributes_list():
-	var playerattributelist: Dictionary = Gamedata.playerattributes.get_playerattributes()
+	var playerattributelist: Dictionary = Gamedata.playerattributes.get_all()
 	for playerattribute: DPlayerAttribute in playerattributelist.values():
 		# Add all the filenames to the Contentmobs list as child nodes
 		var attribute_index: int = contentItems.add_item(playerattribute.id)
@@ -453,7 +453,7 @@ func load_playerattributes_list():
 
 # Load the wearableslot list
 func load_wearableslots_list():
-	var wearableslotlist: Dictionary = Gamedata.wearableslots.get_wearableslots()
+	var wearableslotlist: Dictionary = Gamedata.wearableslots.get_all()
 	for wearableslot: DWearableSlot in wearableslotlist.values():
 		# Add all the filenames to the Contentmobs list as child nodes
 		var attribute_index: int = contentItems.add_item(wearableslot.id)
@@ -466,7 +466,7 @@ func load_wearableslots_list():
 
 # Load the stats list
 func load_stats_list():
-	var statslist: Dictionary = Gamedata.stats.get_stats()
+	var statslist: Dictionary = Gamedata.stats.get_all()
 	for stat: DStat in statslist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(stat.id)
@@ -479,7 +479,7 @@ func load_stats_list():
 
 # Load the skills list
 func load_skills_list():
-	var skillslist: Dictionary = Gamedata.skills.get_skills()
+	var skillslist: Dictionary = Gamedata.skills.get_all()
 	for skill: DSkill in skillslist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(skill.id)
@@ -492,7 +492,7 @@ func load_skills_list():
 
 # Load the quests list
 func load_quests_list():
-	var questslist: Dictionary = Gamedata.quests.get_quests()
+	var questslist: Dictionary = Gamedata.quests.get_all()
 	for quest: DQuest in questslist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(quest.id)
@@ -508,9 +508,9 @@ func add_map_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.maps.add_new_map(myText)
+		Gamedata.maps.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.maps.duplicate_map_to_disk(get_selected_item_text(), myText)
+		Gamedata.maps.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -523,9 +523,9 @@ func add_tacticalmap_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.tacticalmaps.add_new_tacticalmap(myText)
+		Gamedata.tacticalmaps.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.tacticalmaps.duplicate_tacticalmap_to_disk(get_selected_item_text(), myText)
+		Gamedata.tacticalmaps.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -538,9 +538,9 @@ func add_playerattribute_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.playerattributes.add_new_playerattribute(myText)
+		Gamedata.playerattributes.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.playerattributes.duplicate_playerattribute_to_disk(get_selected_item_text(), myText)
+		Gamedata.playerattributes.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -553,9 +553,9 @@ func add_wearableslot_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.wearableslots.add_new_wearableslot(myText)
+		Gamedata.wearableslots.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.wearableslots.duplicate_wearableslots_to_disk(get_selected_item_text(), myText)
+		Gamedata.wearableslots.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -583,9 +583,9 @@ func add_itemgroup_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.itemgroups.add_new_itemgroup(myText)
+		Gamedata.itemgroups.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.itemgroups.duplicate_itemgroup_to_disk(get_selected_item_text(), myText)
+		Gamedata.itemgroups.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -598,9 +598,9 @@ func add_stat_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.stats.add_new_stat(myText)
+		Gamedata.stats.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.stats.duplicate_stat_to_disk(get_selected_item_text(), myText)
+		Gamedata.stats.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -613,9 +613,9 @@ func add_skill_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.skills.add_new_skill(myText)
+		Gamedata.skills.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.skills.duplicate_skill_to_disk(get_selected_item_text(), myText)
+		Gamedata.skills.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -628,9 +628,9 @@ func add_quest_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.quests.add_new_quest(myText)
+		Gamedata.quests.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.quests.duplicate_quest_to_disk(get_selected_item_text(), myText)
+		Gamedata.quests.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -643,9 +643,9 @@ func add_item_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.items.add_new_item(myText)
+		Gamedata.items.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.items.duplicate_item_to_disk(get_selected_item_text(), myText)
+		Gamedata.items.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -658,9 +658,9 @@ func add_tile_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.tiles.add_new_tile(myText)
+		Gamedata.tiles.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.tiles.duplicate_tile_to_disk(get_selected_item_text(), myText)
+		Gamedata.tiles.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -673,9 +673,9 @@ func add_mob_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.mobs.add_new_mob(myText)
+		Gamedata.mobs.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.mobs.duplicate_mob_to_disk(get_selected_item_text(), myText)
+		Gamedata.mobs.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -684,11 +684,11 @@ func add_mob_popup_ok():
 
 
 func delete_map(selected_id) -> void:
-	Gamedata.maps.delete_map(selected_id)
+	Gamedata.maps.delete_by_id(selected_id)
 	load_data()
 
 func delete_tacticalmap(selected_id) -> void:
-	Gamedata.tacticalmaps.delete_map(selected_id)
+	Gamedata.tacticalmaps.delete_by_id(selected_id)
 	load_data()
 
 func delete_furniture(selected_id) -> void:
@@ -696,37 +696,37 @@ func delete_furniture(selected_id) -> void:
 	load_data()
 
 func delete_itemgroup(selected_id) -> void:
-	Gamedata.itemgroups.delete_itemgroup(selected_id)
+	Gamedata.itemgroups.delete_by_id(selected_id)
 	load_data()
 
 func delete_item(selected_id) -> void:
-	Gamedata.items.delete_item(selected_id)
+	Gamedata.items.delete_by_id(selected_id)
 	load_data()
 
 func delete_tile(selected_id) -> void:
-	Gamedata.tiles.delete_tile(selected_id)
+	Gamedata.tiles.delete_by_id(selected_id)
 	load_data()
 
 func delete_mob(selected_id) -> void:
-	Gamedata.mobs.delete_mob(selected_id)
+	Gamedata.mobs.delete_by_id(selected_id)
 	load_data()
 
 func delete_playerattribute(selected_id) -> void:
-	Gamedata.playerattributes.delete_playerattribute(selected_id)
+	Gamedata.playerattributes.delete_by_id(selected_id)
 	load_data()
 
 func delete_wearableslot(selected_id) -> void:
-	Gamedata.wearableslots.delete_playerattribute(selected_id)
+	Gamedata.wearableslots.delete_by_id(selected_id)
 	load_data()
 
 func delete_stat(selected_id) -> void:
-	Gamedata.stats.delete_stat(selected_id)
+	Gamedata.stats.delete_by_id(selected_id)
 	load_data()
 
 func delete_skill(selected_id) -> void:
-	Gamedata.skills.delete_skill(selected_id)
+	Gamedata.skills.delete_by_id(selected_id)
 	load_data()
 
 func delete_quest(selected_id) -> void:
-	Gamedata.quests.delete_quest(selected_id)
+	Gamedata.quests.delete_by_id(selected_id)
 	load_data()

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -10,11 +10,11 @@ extends Control
 @export var collapseButton: Button = null
 @export var pupup_ID: Popup = null
 @export var popup_textedit: TextEdit = null
-signal item_activated(data: Array, itemID: String, list: Control)
+signal item_activated(type: Gamedata.ContentType, itemID: String, list: Control)
 var popupAction: String = ""
-var contentData: Dictionary = {}:
+var contentType: Gamedata.ContentType:
 	set(newData):
-		contentData = newData
+		contentType = newData
 		load_data()
 
 var header: String = "Items":
@@ -22,8 +22,6 @@ var header: String = "Items":
 		header = newName
 		collapseButton.text = header
 
-func _ready():
-	Helper.signal_broker.data_sprites_changed.connect(_on_data_sprites_changed)
 
 var is_collapsed: bool = false:
 	get:
@@ -37,80 +35,23 @@ var is_collapsed: bool = false:
 # If the path is a directory, it will list all the files in the directory
 # If the path is a json file, it will list all the items in the json file
 func load_data():
-	if contentData.is_empty():
-		return
 	contentItems.clear()
-	# HACK Hacky implementation, need to find a better solution
 	var loaders = {
-		"maps": load_map_list,
-		"tacticalmaps": load_tacticalmap_list,
-		"furnitures": load_furnitures_list,
-		"itemgroups": load_itemgroups_list,
-		"items": load_items_list,
-		"tiles": load_tiles_list,
-		"mobs": load_mobs_list,
-		"playerattributes": load_playerattributes_list,
-		"wearableslots": load_wearableslots_list,
-		"stats": load_stats_list,
-		"skills": load_skills_list,
-		"quests": load_quests_list
+		Gamedata.ContentType.MAPS: load_map_list,
+		Gamedata.ContentType.TACTICALMAPS: load_tacticalmap_list,
+		Gamedata.ContentType.FURNITURES: load_furnitures_list,
+		Gamedata.ContentType.ITEMGROUPS: load_itemgroups_list,
+		Gamedata.ContentType.ITEMS: load_items_list,
+		Gamedata.ContentType.TILES: load_tiles_list,
+		Gamedata.ContentType.MOBS: load_mobs_list,
+		Gamedata.ContentType.PLAYERATTRIBUTES: load_playerattributes_list,
+		Gamedata.ContentType.WEARABLESLOTS: load_wearableslots_list,
+		Gamedata.ContentType.STATS: load_stats_list,
+		Gamedata.ContentType.SKILLS: load_skills_list,
+		Gamedata.ContentType.QUESTS: load_quests_list
 	}
-
-	for key in loaders.keys():
-		if contentData == {key: true}:
-			loaders[key].call()
-			load_collapse_state()
-			return
-
-	if not contentData.has("data") or contentData.data.is_empty():
-		return
-	
-	# If the datapath ends with json, it's a list of items
-	# Otherwise, it's a folder with json files in it
-	if contentData.dataPath.ends_with(".json"):
-		make_item_list()
-	else:
-		make_file_list()
+	loaders[contentType].call()
 	load_collapse_state()
-
-
-# Loops over all the items in contentData.data (which are dictionaries)
-# Creates a new item in the list with the id of the item as text
-func make_item_list():
-	for item in contentData.data:
-		# get the id of the item, "missing_id" if not found
-		var item_id: String = item.get("id", "missing_id")
-		# Add the item and save the index number
-		var item_index: int = contentItems.add_item(item_id)
-		contentItems.set_item_metadata(item_index, item_id)
-		contentItems.set_item_icon(item_index, get_item_sprite(item))
-
-func get_item_sprite(item) -> Texture2D:
-	if item.has("sprite") and contentData.sprites.has(item["sprite"]):
-		var mySprite: Resource = contentData.sprites[item["sprite"]]
-		if mySprite is BaseMaterial3D:
-			return mySprite.albedo_texture
-		else:
-			return mySprite
-	return null
-
-# Loops over the files in contentData.data (which are filenames)
-# For each file, a new item will be added to the list
-func make_file_list() -> void:
-	for file_name in contentData.data:
-		# Extract the base name without the extension
-		var base_name = file_name.get_basename()
-
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(base_name)
-		# Add the ID as metadata which can be used to load the item data
-		contentItems.set_item_metadata(item_index, base_name)
-
-		# If the file has an image to represent it's content, load it
-		if contentData.has("sprites") and contentData.sprites.has(base_name + ".png"):
-			var mySprite: Resource = contentData.sprites[base_name + ".png"]
-			if mySprite:
-				contentItems.set_item_icon(item_index, mySprite)
 
 # Executed when an item in ContentItems is double-clicked or 
 # when the user selects an item in ContentItems and presses enter
@@ -119,14 +60,14 @@ func _on_content_items_item_activated(index: int):
 	# Get the id of the item from the metadata
 	var strItemID: String = contentItems.get_item_metadata(index)
 	if strItemID:
-		item_activated.emit(contentData, strItemID, self)
+		item_activated.emit(contentType, strItemID, self)
 	else:
 		print_debug("Tried to signal that item with ID (" + str(index) + ") was activated,\
 		 but the item has no metadata")
 
 # This function will append an item to the game data
 func add_item_to_data(id: String):
-	Gamedata.add_id_to_data(contentData, id)
+	Gamedata.add_id_to_data(contentType, id)
 	load_data()
 
 # This function will show a pop-up asking the user to input an ID
@@ -152,54 +93,48 @@ func _on_duplicate_button_button_up():
 # Called after the user enters an ID into the popup textbox and presses OK
 func _on_ok_button_up():
 	pupup_ID.hide()
-	# HACK Hacky exception for maps, need to find a better solution
-	if contentData == {"maps": true}:
-		add_map_popup_ok()
-		return
-	# HACK Hacky exception for itemgroups, need to find a better solution
-	if contentData == {"itemgroups": true}:
-		add_itemgroup_popup_ok()
-		return
-	# HACK Hacky exception for furniture, need to find a better solution
-	if contentData == {"furnitures": true}:
-		add_furniture_popup_ok()
-		return
-	# HACK Hacky exception for player attributes, need to find a better solution
-	if contentData == {"playerattributes": true}:
-		add_playerattribute_popup_ok()
-		return
-	# HACK Hacky exception for wearableslots, need to find a better solution
-	if contentData == {"wearableslots": true}:
-		add_wearableslot_popup_ok()
-		return
-	# HACK Hacky exception for stats, need to find a better solution
-	if contentData == {"stats": true}:
-		add_stat_popup_ok()
-		return
-	# HACK Hacky exception for skills, need to find a better solution
-	if contentData == {"skills": true}:
-		add_skill_popup_ok()
-		return
-	# HACK Hacky exception for quests, need to find a better solution
-	if contentData == {"quests": true}:
-		add_quest_popup_ok()
-		return
+	
+	match contentType:
+		Gamedata.ContentType.MAPS:
+			add_map_popup_ok()
+		
+		Gamedata.ContentType.TACTICALMAPS:
+			add_tacticalmap_popup_ok()
+		
+		Gamedata.ContentType.ITEMGROUPS:
+			add_itemgroup_popup_ok()
+		
+		Gamedata.ContentType.FURNITURES:
+			add_furniture_popup_ok()
+		
+		Gamedata.ContentType.PLAYERATTRIBUTES:
+			add_playerattribute_popup_ok()
+		
+		Gamedata.ContentType.WEARABLESLOTS:
+			add_wearableslot_popup_ok()
+		
+		Gamedata.ContentType.STATS:
+			add_stat_popup_ok()
+		
+		Gamedata.ContentType.SKILLS:
+			add_skill_popup_ok()
+		
+		Gamedata.ContentType.QUESTS:
+			add_quest_popup_ok()
+		
+		Gamedata.ContentType.ITEMS:
+			add_item_popup_ok()
+		
+		Gamedata.ContentType.TILES:
+			add_tile_popup_ok()
+		
+		Gamedata.ContentType.MOBS:
+			add_mob_popup_ok()
+		
+		_:
+			# Handle unexpected content types or provide a default action
+			print("Unknown content type:", contentType)
 
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.add_id_to_data(contentData, myText)
-	if popupAction == "Duplicate":
-		if contentData.dataPath.ends_with(".json"):  # It's a json file with items
-			Gamedata.duplicate_item_in_data(contentData, get_selected_item_text(), myText)
-		else: # It's folder with json files
-			Gamedata.duplicate_file_in_data(contentData, get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
 
 # Called after the users presses cancel on the popup asking for an ID
 func _on_cancel_button_up():
@@ -213,54 +148,48 @@ func _on_delete_button_button_up():
 	var selected_id: String = get_selected_item_text()
 	if selected_id == "":
 		return
-	# HACK Exception for maps, need to find a better solution
-	if contentData == {"maps": true}:
-		delete_map(selected_id)
-		return
-	# HACK Exception for furnitures, need to find a better solution
-	if contentData == {"furnitures": true}:
-		delete_furniture(selected_id)
-		return
-	# HACK Exception for furnitures, need to find a better solution
-	if contentData == {"itemgroups": true}:
-		delete_itemgroup(selected_id)
-		return
-	# HACK Exception for items, need to find a better solution
-	if contentData == {"items": true}:
-		delete_item(selected_id)
-		return
-	# HACK Exception for tiles, need to find a better solution
-	if contentData == {"tiles": true}:
-		delete_tile(selected_id)
-		return
-	# HACK Exception for mobs, need to find a better solution
-	if contentData == {"mobs": true}:
-		delete_mob(selected_id)
-		return
-	# HACK Exception for playerattributes, need to find a better solution
-	if contentData == {"playerattributes": true}:
-		delete_playerattribute(selected_id)
-		return
-	# HACK Exception for wearableslots, need to find a better solution
-	if contentData == {"wearableslots": true}:
-		delete_wearableslot(selected_id)
-		return
-	# HACK Exception for stats, need to find a better solution
-	if contentData == {"stats": true}:
-		delete_stat(selected_id)
-		return
-	# HACK Exception for skills, need to find a better solution
-	if contentData == {"skills": true}:
-		delete_skill(selected_id)
-		return
-	# HACK Exception for quests, need to find a better solution
-	if contentData == {"quests": true}:
-		delete_quest(selected_id)
-		return
+	
+	match contentType:
+		Gamedata.ContentType.MAPS:
+			delete_map(selected_id)
+		
+		Gamedata.ContentType.TACTICALMAPS:
+			delete_tacticalmap(selected_id)
+		
+		Gamedata.ContentType.FURNITURES:
+			delete_furniture(selected_id)
+		
+		Gamedata.ContentType.ITEMGROUPS:
+			delete_itemgroup(selected_id)
+		
+		Gamedata.ContentType.ITEMS:
+			delete_item(selected_id)
+		
+		Gamedata.ContentType.TILES:
+			delete_tile(selected_id)
+		
+		Gamedata.ContentType.MOBS:
+			delete_mob(selected_id)
+		
+		Gamedata.ContentType.PLAYERATTRIBUTES:
+			delete_playerattribute(selected_id)
+		
+		Gamedata.ContentType.WEARABLESLOTS:
+			delete_wearableslot(selected_id)
+		
+		Gamedata.ContentType.STATS:
+			delete_stat(selected_id)
+		
+		Gamedata.ContentType.SKILLS:
+			delete_skill(selected_id)
+		
+		Gamedata.ContentType.QUESTS:
+			delete_quest(selected_id)
+		
+		_:
+			# Handle unexpected content types or provide a default action
+			print("Unknown content type:", contentType)
 
-	contentItems.remove_item(contentItems.get_selected_items()[0])
-	Gamedata.remove_item_from_data(contentData, selected_id)
-	load_data()
 
 func get_selected_item_text() -> String:
 	if not contentItems.is_anything_selected():
@@ -318,32 +247,48 @@ func _drop_data(newpos, data) -> void:
 # Helper function to create a preview Control for dragging
 func _create_drag_preview(item_id: String) -> Control:
 	var preview = TextureRect.new()
-	# HACK Hacky exception for furniture, need to find a better solution
-	if contentData == {"furnitures": true}:
-		preview.texture = Gamedata.furnitures.sprite_by_id(item_id)
-	elif contentData == {"itemgroups": true}:
-		preview.texture = Gamedata.itemgroups.sprite_by_id(item_id)
-	elif contentData == {"maps": true}:
-		preview.texture = Gamedata.maps.by_id(item_id).sprite
-	elif contentData == {"tiles": true}:
-		preview.texture = Gamedata.tiles.by_id(item_id).sprite
-	elif contentData == {"mobs": true}:
-		preview.texture = Gamedata.mobs.by_id(item_id).sprite
-	elif contentData == {"items": true}:
-		preview.texture = Gamedata.items.by_id(item_id).sprite
-	elif contentData == {"playerattributes": true}:
-		preview.texture = Gamedata.playerattributes.by_id(item_id).sprite
-	elif contentData == {"wearableslots": true}:
-		preview.texture = Gamedata.wearableslots.by_id(item_id).sprite
-	elif contentData == {"stats": true}:
-		preview.texture = Gamedata.stats.by_id(item_id).sprite
-	elif contentData == {"skills": true}:
-		preview.texture = Gamedata.skills.by_id(item_id).sprite
-	elif contentData == {"quests": true}:
-		preview.texture = Gamedata.quests.by_id(item_id).sprite
+	
+	match contentType:
+		Gamedata.ContentType.FURNITURES:
+			preview.texture = Gamedata.furnitures.sprite_by_id(item_id)
+		
+		Gamedata.ContentType.ITEMGROUPS:
+			preview.texture = Gamedata.itemgroups.sprite_by_id(item_id)
+		
+		Gamedata.ContentType.MAPS:
+			preview.texture = Gamedata.maps.by_id(item_id).sprite
+		
+		Gamedata.ContentType.TILES:
+			preview.texture = Gamedata.tiles.by_id(item_id).sprite
+		
+		Gamedata.ContentType.MOBS:
+			preview.texture = Gamedata.mobs.by_id(item_id).sprite
+		
+		Gamedata.ContentType.ITEMS:
+			preview.texture = Gamedata.items.by_id(item_id).sprite
+		
+		Gamedata.ContentType.PLAYERATTRIBUTES:
+			preview.texture = Gamedata.playerattributes.by_id(item_id).sprite
+		
+		Gamedata.ContentType.WEARABLESLOTS:
+			preview.texture = Gamedata.wearableslots.by_id(item_id).sprite
+		
+		Gamedata.ContentType.STATS:
+			preview.texture = Gamedata.stats.by_id(item_id).sprite
+		
+		Gamedata.ContentType.SKILLS:
+			preview.texture = Gamedata.skills.by_id(item_id).sprite
+		
+		Gamedata.ContentType.QUESTS:
+			preview.texture = Gamedata.quests.by_id(item_id).sprite
+		
+		_:
+			# Handle unexpected content types or provide a default action
+			print("Unknown content type:", contentType)
 
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview
 	return preview
+
 
 
 var start_point
@@ -409,11 +354,6 @@ func load_collapse_state():
 	else:
 		print("Failed to load settings for:", header, "with error:", err)
 
-
-# When a sprite has been added or changed in the gamedata
-func _on_data_sprites_changed(data: Dictionary, _spriteid: String):
-	if data == contentData:
-		load_data()
 
 
 func load_map_list():
@@ -578,6 +518,21 @@ func add_map_popup_ok():
 	load_data()
 
 
+func add_tacticalmap_popup_ok():
+	var myText = popup_textedit.text
+	if myText == "":
+		return
+	if popupAction == "Add":
+		Gamedata.tacticalmaps.add_new_tacticalmap(myText)
+	if popupAction == "Duplicate":
+		Gamedata.tacticalmaps.duplicate_tacticalmap_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
+
+
 func add_playerattribute_popup_ok():
 	var myText = popup_textedit.text
 	if myText == "":
@@ -683,8 +638,57 @@ func add_quest_popup_ok():
 	load_data()
 
 
+func add_item_popup_ok():
+	var myText = popup_textedit.text
+	if myText == "":
+		return
+	if popupAction == "Add":
+		Gamedata.items.add_new_item(myText)
+	if popupAction == "Duplicate":
+		Gamedata.items.duplicate_item_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
+
+
+func add_tile_popup_ok():
+	var myText = popup_textedit.text
+	if myText == "":
+		return
+	if popupAction == "Add":
+		Gamedata.tiles.add_new_tile(myText)
+	if popupAction == "Duplicate":
+		Gamedata.tiles.duplicate_tile_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
+
+
+func add_mob_popup_ok():
+	var myText = popup_textedit.text
+	if myText == "":
+		return
+	if popupAction == "Add":
+		Gamedata.mobs.add_new_mob(myText)
+	if popupAction == "Duplicate":
+		Gamedata.mobs.duplicate_mob_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
+
+
 func delete_map(selected_id) -> void:
 	Gamedata.maps.delete_map(selected_id)
+	load_data()
+
+func delete_tacticalmap(selected_id) -> void:
+	Gamedata.tacticalmaps.delete_map(selected_id)
 	load_data()
 
 func delete_furniture(selected_id) -> void:

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -148,47 +148,7 @@ func _on_delete_button_button_up():
 	var selected_id: String = get_selected_item_text()
 	if selected_id == "":
 		return
-	
-	match contentType:
-		Gamedata.ContentType.MAPS:
-			delete_map(selected_id)
-		
-		Gamedata.ContentType.TACTICALMAPS:
-			delete_tacticalmap(selected_id)
-		
-		Gamedata.ContentType.FURNITURES:
-			delete_furniture(selected_id)
-		
-		Gamedata.ContentType.ITEMGROUPS:
-			delete_itemgroup(selected_id)
-		
-		Gamedata.ContentType.ITEMS:
-			delete_item(selected_id)
-		
-		Gamedata.ContentType.TILES:
-			delete_tile(selected_id)
-		
-		Gamedata.ContentType.MOBS:
-			delete_mob(selected_id)
-		
-		Gamedata.ContentType.PLAYERATTRIBUTES:
-			delete_playerattribute(selected_id)
-		
-		Gamedata.ContentType.WEARABLESLOTS:
-			delete_wearableslot(selected_id)
-		
-		Gamedata.ContentType.STATS:
-			delete_stat(selected_id)
-		
-		Gamedata.ContentType.SKILLS:
-			delete_skill(selected_id)
-		
-		Gamedata.ContentType.QUESTS:
-			delete_quest(selected_id)
-		
-		_:
-			# Handle unexpected content types or provide a default action
-			print("Unknown content type:", contentType)
+	delete(selected_id)
 
 
 func get_selected_item_text() -> String:
@@ -682,51 +642,6 @@ func add_mob_popup_ok():
 		is_collapsed = false
 	load_data()
 
-
-func delete_map(selected_id) -> void:
-	Gamedata.maps.delete_by_id(selected_id)
-	load_data()
-
-func delete_tacticalmap(selected_id) -> void:
-	Gamedata.tacticalmaps.delete_by_id(selected_id)
-	load_data()
-
-func delete_furniture(selected_id) -> void:
-	Gamedata.furnitures.delete_by_id(selected_id)
-	load_data()
-
-func delete_itemgroup(selected_id) -> void:
-	Gamedata.itemgroups.delete_by_id(selected_id)
-	load_data()
-
-func delete_item(selected_id) -> void:
-	Gamedata.items.delete_by_id(selected_id)
-	load_data()
-
-func delete_tile(selected_id) -> void:
-	Gamedata.tiles.delete_by_id(selected_id)
-	load_data()
-
-func delete_mob(selected_id) -> void:
-	Gamedata.mobs.delete_by_id(selected_id)
-	load_data()
-
-func delete_playerattribute(selected_id) -> void:
-	Gamedata.playerattributes.delete_by_id(selected_id)
-	load_data()
-
-func delete_wearableslot(selected_id) -> void:
-	Gamedata.wearableslots.delete_by_id(selected_id)
-	load_data()
-
-func delete_stat(selected_id) -> void:
-	Gamedata.stats.delete_by_id(selected_id)
-	load_data()
-
-func delete_skill(selected_id) -> void:
-	Gamedata.skills.delete_by_id(selected_id)
-	load_data()
-
-func delete_quest(selected_id) -> void:
-	Gamedata.quests.delete_by_id(selected_id)
+func delete(selected_id) -> void:
+	Gamedata.get_data_of_type(contentType).delete_by_id(selected_id)
 	load_data()

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -50,7 +50,8 @@ func load_data():
 		"mobs": load_mobs_list,
 		"playerattributes": load_playerattributes_list,
 		"wearableslots": load_wearableslots_list,
-		"stats": load_stats_list
+		"stats": load_stats_list,
+		"skills": load_skills_list
 	}
 
 	for key in loaders.keys():
@@ -173,6 +174,10 @@ func _on_ok_button_up():
 	if contentData == {"stats": true}:
 		add_stat_popup_ok()
 		return
+	# HACK Hacky exception for skills, need to find a better solution
+	if contentData == {"skills": true}:
+		add_skill_popup_ok()
+		return
 
 	var myText = popup_textedit.text
 	if myText == "":
@@ -237,6 +242,10 @@ func _on_delete_button_button_up():
 	# HACK Exception for stats, need to find a better solution
 	if contentData == {"stats": true}:
 		delete_stat(selected_id)
+		return
+	# HACK Exception for skills, need to find a better solution
+	if contentData == {"skills": true}:
+		delete_skill(selected_id)
 		return
 
 	contentItems.remove_item(contentItems.get_selected_items()[0])
@@ -316,6 +325,10 @@ func _create_drag_preview(item_id: String) -> Control:
 		preview.texture = Gamedata.playerattributes.by_id(item_id).sprite
 	elif contentData == {"wearableslots": true}:
 		preview.texture = Gamedata.wearableslots.by_id(item_id).sprite
+	elif contentData == {"stats": true}:
+		preview.texture = Gamedata.stats.by_id(item_id).sprite
+	elif contentData == {"skills": true}:
+		preview.texture = Gamedata.skills.by_id(item_id).sprite
 	else:
 		preview.texture = Gamedata.get_sprite_by_id(contentData, item_id)
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview
@@ -504,6 +517,19 @@ func load_stats_list():
 			contentItems.set_item_icon(item_index, mySprite)
 
 
+# Load the skills list
+func load_skills_list():
+	var skillslist: Dictionary = Gamedata.skills.get_skills()
+	for skill: DSkill in skillslist.values():
+		# Add all the filenames to the ContentItems list as child nodes
+		var item_index: int = contentItems.add_item(skill.id)
+		# Add the ID as metadata which can be used to load the skill data
+		contentItems.set_item_metadata(item_index, skill.id)
+		var mySprite: Texture = skill.sprite
+		if mySprite:
+			contentItems.set_item_icon(item_index, mySprite)
+
+
 func add_map_popup_ok():
 	var myText = popup_textedit.text
 	if myText == "":
@@ -594,6 +620,21 @@ func add_stat_popup_ok():
 	load_data()
 
 
+func add_skill_popup_ok():
+	var myText = popup_textedit.text
+	if myText == "":
+		return
+	if popupAction == "Add":
+		Gamedata.skills.add_new_skill(myText)
+	if popupAction == "Duplicate":
+		Gamedata.skills.duplicate_skill_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
+
+
 func delete_map(selected_id) -> void:
 	Gamedata.maps.delete_map(selected_id)
 	load_data()
@@ -628,4 +669,8 @@ func delete_wearableslot(selected_id) -> void:
 
 func delete_stat(selected_id) -> void:
 	Gamedata.stats.delete_stat(selected_id)
+	load_data()
+
+func delete_skill(selected_id) -> void:
+	Gamedata.skills.delete_skill(selected_id)
 	load_data()

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -51,7 +51,8 @@ func load_data():
 		"playerattributes": load_playerattributes_list,
 		"wearableslots": load_wearableslots_list,
 		"stats": load_stats_list,
-		"skills": load_skills_list
+		"skills": load_skills_list,
+		"quests": load_quests_list
 	}
 
 	for key in loaders.keys():
@@ -178,6 +179,10 @@ func _on_ok_button_up():
 	if contentData == {"skills": true}:
 		add_skill_popup_ok()
 		return
+	# HACK Hacky exception for quests, need to find a better solution
+	if contentData == {"quests": true}:
+		add_quest_popup_ok()
+		return
 
 	var myText = popup_textedit.text
 	if myText == "":
@@ -246,6 +251,10 @@ func _on_delete_button_button_up():
 	# HACK Exception for skills, need to find a better solution
 	if contentData == {"skills": true}:
 		delete_skill(selected_id)
+		return
+	# HACK Exception for quests, need to find a better solution
+	if contentData == {"quests": true}:
+		delete_quest(selected_id)
 		return
 
 	contentItems.remove_item(contentItems.get_selected_items()[0])
@@ -329,6 +338,8 @@ func _create_drag_preview(item_id: String) -> Control:
 		preview.texture = Gamedata.stats.by_id(item_id).sprite
 	elif contentData == {"skills": true}:
 		preview.texture = Gamedata.skills.by_id(item_id).sprite
+	elif contentData == {"quests": true}:
+		preview.texture = Gamedata.quests.by_id(item_id).sprite
 	else:
 		preview.texture = Gamedata.get_sprite_by_id(contentData, item_id)
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview
@@ -530,6 +541,19 @@ func load_skills_list():
 			contentItems.set_item_icon(item_index, mySprite)
 
 
+# Load the quests list
+func load_quests_list():
+	var questslist: Dictionary = Gamedata.quests.get_quests()
+	for quest: DQuest in questslist.values():
+		# Add all the filenames to the ContentItems list as child nodes
+		var item_index: int = contentItems.add_item(quest.id)
+		# Add the ID as metadata which can be used to load the quest data
+		contentItems.set_item_metadata(item_index, quest.id)
+		var mySprite: Texture = quest.sprite
+		if mySprite:
+			contentItems.set_item_icon(item_index, mySprite)
+
+
 func add_map_popup_ok():
 	var myText = popup_textedit.text
 	if myText == "":
@@ -635,6 +659,21 @@ func add_skill_popup_ok():
 	load_data()
 
 
+func add_quest_popup_ok():
+	var myText = popup_textedit.text
+	if myText == "":
+		return
+	if popupAction == "Add":
+		Gamedata.quests.add_new_quest(myText)
+	if popupAction == "Duplicate":
+		Gamedata.quests.duplicate_quest_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
+
+
 func delete_map(selected_id) -> void:
 	Gamedata.maps.delete_map(selected_id)
 	load_data()
@@ -673,4 +712,8 @@ func delete_stat(selected_id) -> void:
 
 func delete_skill(selected_id) -> void:
 	Gamedata.skills.delete_skill(selected_id)
+	load_data()
+
+func delete_quest(selected_id) -> void:
+	Gamedata.quests.delete_quest(selected_id)
 	load_data()

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -379,7 +379,7 @@ func load_tacticalmap_list():
 
 # Load the furniture list
 func load_furnitures_list():
-	var furniturelist: Dictionary = Gamedata.furnitures.get_furnitures()
+	var furniturelist: Dictionary = Gamedata.furnitures.get_all()
 	for furniture: DFurniture in furniturelist.values():
 		# Add all the filenames to the ContentItems list as child nodes
 		var item_index: int = contentItems.add_item(furniture.id)
@@ -568,9 +568,9 @@ func add_furniture_popup_ok():
 	if myText == "":
 		return
 	if popupAction == "Add":
-		Gamedata.furnitures.add_new_furniture(myText)
+		Gamedata.furnitures.add_new(myText)
 	if popupAction == "Duplicate":
-		Gamedata.furnitures.duplicate_furniture_to_disk(get_selected_item_text(), myText)
+		Gamedata.furnitures.duplicate_to_disk(get_selected_item_text(), myText)
 	popupAction = ""
 	# Check if the list is collapsed and expand it if true
 	if is_collapsed:
@@ -692,7 +692,7 @@ func delete_tacticalmap(selected_id) -> void:
 	load_data()
 
 func delete_furniture(selected_id) -> void:
-	Gamedata.furnitures.delete_furniture(selected_id)
+	Gamedata.furnitures.delete_by_id(selected_id)
 	load_data()
 
 func delete_itemgroup(selected_id) -> void:

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -43,6 +43,7 @@ func load_data():
 	# HACK Hacky implementation, need to find a better solution
 	var loaders = {
 		"maps": load_map_list,
+		"tacticalmaps": load_tacticalmap_list,
 		"furnitures": load_furnitures_list,
 		"itemgroups": load_itemgroups_list,
 		"items": load_items_list,
@@ -340,8 +341,7 @@ func _create_drag_preview(item_id: String) -> Control:
 		preview.texture = Gamedata.skills.by_id(item_id).sprite
 	elif contentData == {"quests": true}:
 		preview.texture = Gamedata.quests.by_id(item_id).sprite
-	else:
-		preview.texture = Gamedata.get_sprite_by_id(contentData, item_id)
+
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview
 	return preview
 
@@ -426,6 +426,15 @@ func load_map_list():
 		var mySprite: Texture = maplist[map].sprite
 		if mySprite:
 			contentItems.set_item_icon(item_index, mySprite)
+
+
+func load_tacticalmap_list():
+	var maplist: Dictionary = Gamedata.tacticalmaps.get_maps()
+	for map: String in maplist.keys():
+		# Add all the filenames to the ContentItems list as child nodes
+		var item_index: int = contentItems.add_item(map)
+		# Add the ID as metadata which can be used to load the item data
+		contentItems.set_item_metadata(item_index, map)
 
 
 # Load the furniture list

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -38,21 +38,7 @@ var is_collapsed: bool = false:
 # If the path is a json file, it will list all the items in the json file
 func load_data():
 	contentItems.clear()
-	var loaders = {
-		Gamedata.ContentType.MAPS: load_map_list,
-		Gamedata.ContentType.TACTICALMAPS: load_tacticalmap_list,
-		Gamedata.ContentType.FURNITURES: load_furnitures_list,
-		Gamedata.ContentType.ITEMGROUPS: load_itemgroups_list,
-		Gamedata.ContentType.ITEMS: load_items_list,
-		Gamedata.ContentType.TILES: load_tiles_list,
-		Gamedata.ContentType.MOBS: load_mobs_list,
-		Gamedata.ContentType.PLAYERATTRIBUTES: load_playerattributes_list,
-		Gamedata.ContentType.WEARABLESLOTS: load_wearableslots_list,
-		Gamedata.ContentType.STATS: load_stats_list,
-		Gamedata.ContentType.SKILLS: load_skills_list,
-		Gamedata.ContentType.QUESTS: load_quests_list
-	}
-	loaders[contentType].call()
+	load_list()
 	load_collapse_state()
 
 # Executed when an item in ContentItems is double-clicked or 
@@ -252,152 +238,15 @@ func load_collapse_state():
 		print("Failed to load settings for:", header, "with error:", err)
 
 
-
-func load_map_list():
-	var maplist: Dictionary = Gamedata.maps.get_all()
-	for map: String in maplist.keys():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(map)
-		# Add the ID as metadata which can be used to load the item data
-		contentItems.set_item_metadata(item_index, map)
-		var mySprite: Texture = maplist[map].sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
-
-
-func load_tacticalmap_list():
-	var maplist: Dictionary = Gamedata.tacticalmaps.get_all()
-	for map: String in maplist.keys():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(map)
-		# Add the ID as metadata which can be used to load the item data
-		contentItems.set_item_metadata(item_index, map)
-
-
-# Load the furniture list
-func load_furnitures_list():
-	var furniturelist: Dictionary = Gamedata.furnitures.get_all()
-	for furniture: DFurniture in furniturelist.values():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(furniture.id)
-		# Add the ID as metadata which can be used to load the item data
-		contentItems.set_item_metadata(item_index, furniture.id)
-		var mySprite: Texture = furniture.sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
-
-# Load the itemgroups list
-func load_itemgroups_list():
-	var itemgrouplist: Dictionary = Gamedata.itemgroups.get_all()
-	for itemgroup: DItemgroup in itemgrouplist.values():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(itemgroup.id)
-		# Add the ID as metadata which can be used to load the item data
-		contentItems.set_item_metadata(item_index, itemgroup.id)
-		var mySprite: Texture = itemgroup.sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
-
-# Load the items list
-func load_items_list():
-	var itemlist: Dictionary = Gamedata.items.get_all()
-	for item: DItem in itemlist.values():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(item.id)
-		# Add the ID as metadata which can be used to load the item data
-		contentItems.set_item_metadata(item_index, item.id)
-		var mySprite: Texture = item.sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
-
-# Load the tiles list
-func load_tiles_list():
-	var tilelist: Dictionary = Gamedata.tiles.get_all()
-	for tile: DTile in tilelist.values():
-		# Add all the filenames to the Contenttiles list as child nodes
-		var tile_index: int = contentItems.add_item(tile.id)
-		# Add the ID as metadata which can be used to load the tile data
-		contentItems.set_item_metadata(tile_index, tile.id)
-		var mySprite: Texture = tile.sprite
-		if mySprite:
-			contentItems.set_item_icon(tile_index, mySprite)
-
-# Load the mobs list
-func load_mobs_list():
-	var moblist: Dictionary = Gamedata.mobs.get_all()
-	for mob: DMob in moblist.values():
-		# Add all the filenames to the Contentmobs list as child nodes
-		var mob_index: int = contentItems.add_item(mob.id)
-		# Add the ID as metadata which can be used to load the mob data
-		contentItems.set_item_metadata(mob_index, mob.id)
-		var mySprite: Texture = mob.sprite
-		if mySprite:
-			contentItems.set_item_icon(mob_index, mySprite)
-
-
-# Load the playerattribute list
-func load_playerattributes_list():
-	var playerattributelist: Dictionary = Gamedata.playerattributes.get_all()
-	for playerattribute: DPlayerAttribute in playerattributelist.values():
-		# Add all the filenames to the Contentmobs list as child nodes
-		var attribute_index: int = contentItems.add_item(playerattribute.id)
-		# Add the ID as metadata which can be used to load the mob data
-		contentItems.set_item_metadata(attribute_index, playerattribute.id)
-		var mySprite: Texture = playerattribute.sprite
-		if mySprite:
-			contentItems.set_item_icon(attribute_index, mySprite)
-
-
-# Load the wearableslot list
-func load_wearableslots_list():
-	var wearableslotlist: Dictionary = Gamedata.wearableslots.get_all()
-	for wearableslot: DWearableSlot in wearableslotlist.values():
-		# Add all the filenames to the Contentmobs list as child nodes
-		var attribute_index: int = contentItems.add_item(wearableslot.id)
-		# Add the ID as metadata which can be used to load the mob data
-		contentItems.set_item_metadata(attribute_index, wearableslot.id)
-		var mySprite: Texture = wearableslot.sprite
-		if mySprite:
-			contentItems.set_item_icon(attribute_index, mySprite)
-
-
-# Load the stats list
-func load_stats_list():
-	var statslist: Dictionary = Gamedata.stats.get_all()
-	for stat: DStat in statslist.values():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(stat.id)
-		# Add the ID as metadata which can be used to load the stat data
-		contentItems.set_item_metadata(item_index, stat.id)
-		var mySprite: Texture = stat.sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
-
-
-# Load the skills list
-func load_skills_list():
-	var skillslist: Dictionary = Gamedata.skills.get_all()
-	for skill: DSkill in skillslist.values():
-		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(skill.id)
-		# Add the ID as metadata which can be used to load the skill data
-		contentItems.set_item_metadata(item_index, skill.id)
-		var mySprite: Texture = skill.sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
-
-
 # Load the quests list
-func load_quests_list():
-	var questslist: Dictionary = Gamedata.quests.get_all()
-	for quest: DQuest in questslist.values():
+func load_list():
+	for entry: RefCounted in datainstance.get_all().values():
 		# Add all the filenames to the ContentItems list as child nodes
-		var item_index: int = contentItems.add_item(quest.id)
+		var item_index: int = contentItems.add_item(entry.id)
 		# Add the ID as metadata which can be used to load the quest data
-		contentItems.set_item_metadata(item_index, quest.id)
-		var mySprite: Texture = quest.sprite
-		if mySprite:
-			contentItems.set_item_icon(item_index, mySprite)
+		contentItems.set_item_metadata(item_index, entry.id)
+		if "sprite" in entry:
+			contentItems.set_item_icon(item_index, entry.sprite)
 
 func delete(selected_id) -> void:
 	Gamedata.get_data_of_type(contentType).delete_by_id(selected_id)

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -93,47 +93,19 @@ func _on_duplicate_button_button_up():
 # Called after the user enters an ID into the popup textbox and presses OK
 func _on_ok_button_up():
 	pupup_ID.hide()
-	
-	match contentType:
-		Gamedata.ContentType.MAPS:
-			add_map_popup_ok()
-		
-		Gamedata.ContentType.TACTICALMAPS:
-			add_tacticalmap_popup_ok()
-		
-		Gamedata.ContentType.ITEMGROUPS:
-			add_itemgroup_popup_ok()
-		
-		Gamedata.ContentType.FURNITURES:
-			add_furniture_popup_ok()
-		
-		Gamedata.ContentType.PLAYERATTRIBUTES:
-			add_playerattribute_popup_ok()
-		
-		Gamedata.ContentType.WEARABLESLOTS:
-			add_wearableslot_popup_ok()
-		
-		Gamedata.ContentType.STATS:
-			add_stat_popup_ok()
-		
-		Gamedata.ContentType.SKILLS:
-			add_skill_popup_ok()
-		
-		Gamedata.ContentType.QUESTS:
-			add_quest_popup_ok()
-		
-		Gamedata.ContentType.ITEMS:
-			add_item_popup_ok()
-		
-		Gamedata.ContentType.TILES:
-			add_tile_popup_ok()
-		
-		Gamedata.ContentType.MOBS:
-			add_mob_popup_ok()
-		
-		_:
-			# Handle unexpected content types or provide a default action
-			print("Unknown content type:", contentType)
+	var myText = popup_textedit.text
+	var datainstance: RefCounted = Gamedata.get_data_of_type(contentType)
+	if myText == "":
+		return
+	if popupAction == "Add":
+		datainstance.add_new(myText)
+	if popupAction == "Duplicate":
+		datainstance.duplicate_to_disk(get_selected_item_text(), myText)
+	popupAction = ""
+	# Check if the list is collapsed and expand it if true
+	if is_collapsed:
+		is_collapsed = false
+	load_data()
 
 
 # Called after the users presses cancel on the popup asking for an ID
@@ -461,186 +433,6 @@ func load_quests_list():
 		var mySprite: Texture = quest.sprite
 		if mySprite:
 			contentItems.set_item_icon(item_index, mySprite)
-
-
-func add_map_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.maps.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.maps.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_tacticalmap_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.tacticalmaps.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.tacticalmaps.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_playerattribute_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.playerattributes.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.playerattributes.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_wearableslot_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.wearableslots.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.wearableslots.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_furniture_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.furnitures.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.furnitures.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_itemgroup_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.itemgroups.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.itemgroups.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_stat_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.stats.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.stats.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_skill_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.skills.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.skills.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_quest_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.quests.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.quests.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_item_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.items.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.items.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_tile_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.tiles.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.tiles.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
-
-
-func add_mob_popup_ok():
-	var myText = popup_textedit.text
-	if myText == "":
-		return
-	if popupAction == "Add":
-		Gamedata.mobs.add_new(myText)
-	if popupAction == "Duplicate":
-		Gamedata.mobs.duplicate_to_disk(get_selected_item_text(), myText)
-	popupAction = ""
-	# Check if the list is collapsed and expand it if true
-	if is_collapsed:
-		is_collapsed = false
-	load_data()
 
 func delete(selected_id) -> void:
 	Gamedata.get_data_of_type(contentType).delete_by_id(selected_id)

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -12,9 +12,11 @@ extends Control
 @export var popup_textedit: TextEdit = null
 signal item_activated(type: Gamedata.ContentType, itemID: String, list: Control)
 var popupAction: String = ""
+var datainstance: RefCounted # One of the data classes like DMap, DTile, DMob and so on
 var contentType: Gamedata.ContentType:
 	set(newData):
 		contentType = newData
+		datainstance = Gamedata.get_data_of_type(contentType)
 		load_data()
 
 var header: String = "Items":
@@ -94,7 +96,6 @@ func _on_duplicate_button_button_up():
 func _on_ok_button_up():
 	pupup_ID.hide()
 	var myText = popup_textedit.text
-	var datainstance: RefCounted = Gamedata.get_data_of_type(contentType)
 	if myText == "":
 		return
 	if popupAction == "Add":
@@ -179,44 +180,8 @@ func _drop_data(newpos, data) -> void:
 # Helper function to create a preview Control for dragging
 func _create_drag_preview(item_id: String) -> Control:
 	var preview = TextureRect.new()
-	
-	match contentType:
-		Gamedata.ContentType.FURNITURES:
-			preview.texture = Gamedata.furnitures.sprite_by_id(item_id)
-		
-		Gamedata.ContentType.ITEMGROUPS:
-			preview.texture = Gamedata.itemgroups.sprite_by_id(item_id)
-		
-		Gamedata.ContentType.MAPS:
-			preview.texture = Gamedata.maps.by_id(item_id).sprite
-		
-		Gamedata.ContentType.TILES:
-			preview.texture = Gamedata.tiles.by_id(item_id).sprite
-		
-		Gamedata.ContentType.MOBS:
-			preview.texture = Gamedata.mobs.by_id(item_id).sprite
-		
-		Gamedata.ContentType.ITEMS:
-			preview.texture = Gamedata.items.by_id(item_id).sprite
-		
-		Gamedata.ContentType.PLAYERATTRIBUTES:
-			preview.texture = Gamedata.playerattributes.by_id(item_id).sprite
-		
-		Gamedata.ContentType.WEARABLESLOTS:
-			preview.texture = Gamedata.wearableslots.by_id(item_id).sprite
-		
-		Gamedata.ContentType.STATS:
-			preview.texture = Gamedata.stats.by_id(item_id).sprite
-		
-		Gamedata.ContentType.SKILLS:
-			preview.texture = Gamedata.skills.by_id(item_id).sprite
-		
-		Gamedata.ContentType.QUESTS:
-			preview.texture = Gamedata.quests.by_id(item_id).sprite
-		
-		_:
-			# Handle unexpected content types or provide a default action
-			print("Unknown content type:", contentType)
+	if not contentType == Gamedata.ContentType.TACTICALMAPS:
+		preview.texture = datainstance.sprite_by_id(item_id)
 
 	preview.custom_minimum_size = Vector2(32, 32)  # Set the desired size for your preview
 	return preview

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -32,7 +32,7 @@ func _ready():
 	load_content_list({"playerattributes": true}, "Player Attributes")
 	load_content_list({"wearableslots": true}, "Wearable Slots")
 	load_content_list({"stats": true}, "Stats")
-	load_content_list(Gamedata.data.skills, "Skills")
+	load_content_list({"skills": true}, "Skills")
 	load_content_list(Gamedata.data.quests, "Quests")
 
 
@@ -71,7 +71,8 @@ func _on_content_item_activated(data: Dictionary, itemID: String, list: Control)
 		"maps": mapEditor,
 		"playerattributes": playerattributesEditor,
 		"wearableslots": wearableslotEditor,
-		"stats": statsEditor
+		"stats": statsEditor,
+		"skills": skillsEditor
 	}
 
 	for key in editors.keys():
@@ -81,8 +82,6 @@ func _on_content_item_activated(data: Dictionary, itemID: String, list: Control)
 	
 	if data == Gamedata.data.tacticalmaps:
 		instantiate_editor(data, itemID, tacticalmapEditor, list)
-	elif data == Gamedata.data.skills:
-		instantiate_editor(data, itemID, skillsEditor, list)
 	elif data == Gamedata.data.quests:
 		instantiate_editor(data, itemID, questsEditor, list)
 
@@ -140,6 +139,10 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 		return
 	if data == {"stats": true}:# HACK Hacky exception for stats, need to find a better solution
 		newContentEditor.dstat = Gamedata.stats.by_id(itemID)
+		newContentEditor.data_changed.connect(list.load_data)
+		return
+	if data == {"skills": true}:  # HACK Hacky exception for skills, need to find a better solution
+		newContentEditor.dskill = Gamedata.skills.by_id(itemID)
 		newContentEditor.data_changed.connect(list.load_data)
 		return
 		

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -33,7 +33,7 @@ func _ready():
 	load_content_list({"wearableslots": true}, "Wearable Slots")
 	load_content_list({"stats": true}, "Stats")
 	load_content_list({"skills": true}, "Skills")
-	load_content_list(Gamedata.data.quests, "Quests")
+	load_content_list({"quests": true}, "Quests")
 
 
 func load_content_list(data: Dictionary, strHeader: String):
@@ -72,7 +72,8 @@ func _on_content_item_activated(data: Dictionary, itemID: String, list: Control)
 		"playerattributes": playerattributesEditor,
 		"wearableslots": wearableslotEditor,
 		"stats": statsEditor,
-		"skills": skillsEditor
+		"skills": skillsEditor,
+		"quests": questsEditor
 	}
 
 	for key in editors.keys():
@@ -82,8 +83,6 @@ func _on_content_item_activated(data: Dictionary, itemID: String, list: Control)
 	
 	if data == Gamedata.data.tacticalmaps:
 		instantiate_editor(data, itemID, tacticalmapEditor, list)
-	elif data == Gamedata.data.quests:
-		instantiate_editor(data, itemID, questsEditor, list)
 
 
 # This will add an editor to the content editor tab view. 
@@ -143,6 +142,10 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 		return
 	if data == {"skills": true}:  # HACK Hacky exception for skills, need to find a better solution
 		newContentEditor.dskill = Gamedata.skills.by_id(itemID)
+		newContentEditor.data_changed.connect(list.load_data)
+		return
+	if data == {"quests": true}:  # HACK Hacky exception for quests, need to find a better solution
+		newContentEditor.dquest = Gamedata.quests.by_id(itemID)
 		newContentEditor.data_changed.connect(list.load_data)
 		return
 		

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -20,9 +20,9 @@ var selectedMod: String = "Core"
 
 # This function will load the contents of the data into the contentListInstance
 func _ready():
-	load_content_list(Gamedata.data.tacticalmaps, "Tactical Maps")
 	# Hacky exception for maps, need to find a better solution
 	load_content_list({"maps": true}, "Maps")
+	load_content_list({"tacticalmaps": true}, "Tactical Maps")
 	load_content_list({"items": true}, "Items")
 	load_content_list({"tiles": true}, "Terrain Tiles")
 	load_content_list({"mobs": true}, "Mobs")
@@ -69,6 +69,7 @@ func _on_content_item_activated(data: Dictionary, itemID: String, list: Control)
 		"items": itemEditor,
 		"mobs": mobEditor,
 		"maps": mapEditor,
+		"tacticalmaps": tacticalmapEditor,
 		"playerattributes": playerattributesEditor,
 		"wearableslots": wearableslotEditor,
 		"stats": statsEditor,
@@ -80,9 +81,6 @@ func _on_content_item_activated(data: Dictionary, itemID: String, list: Control)
 		if data == {key: true}:
 			instantiate_editor(data, itemID, editors[key], list)
 			return
-	
-	if data == Gamedata.data.tacticalmaps:
-		instantiate_editor(data, itemID, tacticalmapEditor, list)
 
 
 # This will add an editor to the content editor tab view. 
@@ -107,6 +105,9 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 	
 	if data == {"maps": true}:# HACK Hacky exception for maps, need to find a better solution
 		newContentEditor.currentMap = Gamedata.maps.by_id(itemID)
+		return
+	if data == {"tacticalmaps": true}:# HACK Hacky exception for maps, need to find a better solution
+		newContentEditor.currentMap = Gamedata.tacticalmaps.by_id(itemID)
 		return
 	if data == {"furnitures": true}:# HACK Hacky exception for furniture, need to find a better solution
 		newContentEditor.dfurniture = Gamedata.furnitures.by_id(itemID)
@@ -148,17 +149,6 @@ func instantiate_editor(data: Dictionary, itemID: String, newEditor: PackedScene
 		newContentEditor.dquest = Gamedata.quests.by_id(itemID)
 		newContentEditor.data_changed.connect(list.load_data)
 		return
-		
-		
-	if data.dataPath.ends_with(".json"):
-		var itemdata: Dictionary = data.data[Gamedata.get_array_index_by_id(data, itemID)]
-		# We only pass the data for the specific id to the editor
-		newContentEditor.contentData = itemdata
-		newContentEditor.data_changed.connect(_on_editor_data_changed)
-	else:
-		# If the data source does not end with json, it's a directory
-		# So now we pass in the file we want the editor to edit
-		newContentEditor.contentSource = data.dataPath + itemID + ".json"
 
 
 # The content_list that had its data changed refreshes

--- a/Scripts/CharacterWindow.gd
+++ b/Scripts/CharacterWindow.gd
@@ -38,7 +38,7 @@ func _on_player_skill_changed(player_node: CharacterBody3D):
 		return
 	clear_container(skillsContainer)  # Clear existing content
 	for skill_id in player_node.skills:
-		var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, skill_id)
+		var skill_data: DSkill = Gamedata.skills.by_id(skill_id)
 		if skill_data:
 			var skill_value = player_node.skills[skill_id]
 			var skill_entry = create_skill_entry(skill_data, skill_value)
@@ -46,17 +46,17 @@ func _on_player_skill_changed(player_node: CharacterBody3D):
 
 
 # Utility function to create an HBoxContainer for a stat or skill entry
-func create_skill_entry(data: Dictionary, value: Variant) -> HBoxContainer:
+func create_skill_entry(dskill: DSkill, value: Variant) -> HBoxContainer:
 	var hbox = HBoxContainer.new()
 	var icon = TextureRect.new()
-	icon.texture = Gamedata.get_sprite_by_id(Gamedata.data.skills, data["id"])  # Fetch sprite using the ID
+	icon.texture = dskill.sprite
 	hbox.add_child(icon)
 
 	var label = Label.new()
 	# For skills, display level and XP with a maximum of 2 decimal places
 	var xp_value = str(round(value["xp"] * 100) / 100.0)  # Round XP to 2 decimal places
-	label.text = data["name"] + ": Level " + str(value["level"]) + ", XP: " + xp_value
-	label.tooltip_text = data["description"]
+	label.text = dskill.name + ": Level " + str(value["level"]) + ", XP: " + xp_value
+	label.tooltip_text = dskill.description
 	hbox.add_child(label)
 
 	return hbox

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -47,11 +47,11 @@ func save_furnitures_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 
-func get_furnitures() -> Dictionary:
+func get_all() -> Dictionary:
 	return furnituredict
 
 
-func duplicate_furniture_to_disk(furnitureid: String, newfurnitureid: String) -> void:
+func duplicate_to_disk(furnitureid: String, newfurnitureid: String) -> void:
 	var furnituredata: Dictionary = furnituredict[furnitureid].get_data().duplicate(true)
 	furnituredata.id = newfurnitureid
 	var newfurniture: DFurniture = DFurniture.new(furnituredata)
@@ -59,13 +59,13 @@ func duplicate_furniture_to_disk(furnitureid: String, newfurnitureid: String) ->
 	save_furnitures_to_disk()
 
 
-func add_new_furniture(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newfurniture: DFurniture = DFurniture.new({"id":newid})
 	furnituredict[newfurniture.id] = newfurniture
 	save_furnitures_to_disk()
 
 
-func delete_furniture(furnitureid: String) -> void:
+func delete_by_id(furnitureid: String) -> void:
 	furnituredict[furnitureid].delete()
 	furnituredict.erase(furnitureid)
 	save_furnitures_to_disk()

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -524,20 +524,22 @@ func delete():
 	
 	# This callable will handle the removal of this item from all steps in quests
 	var remove_from_quest: Callable = func(quest_id: String):
-		Gamedata.quests.remove_item_from_quest(quest_id,id)
+		Gamedata.quests.remove_item_from_quest(quest_id, id)
 
 	# Pass the callable to every quest in the item's references
 	# It will call remove_from_quest on every item in item_data.references.core.quests
 	execute_callable_on_references_of_type("core", "quests", remove_from_quest)
 	
-	# For each recipe and for each item in each recipe, remove the reference to this item
-	for resource in craft.get_all_used_items():
-		changes_made["value"] = remove_reference("core", "items", resource) or changes_made["value"]
-
-	# Collect unique skill IDs from the item's recipes
 	var skill_ids: Dictionary = {}
-	for skillid in craft.get_used_skill_ids():
-		skill_ids[skillid] = true
+	# Check if 'craft' is not null before proceeding
+	if craft:
+		# For each recipe and for each item in each recipe, remove the reference to this item
+		for resource in craft.get_all_used_items():
+			changes_made["value"] = remove_reference("core", "items", resource) or changes_made["value"]
+
+		# Collect unique skill IDs from the item's recipes
+		for skillid in craft.get_used_skill_ids():
+			skill_ids[skillid] = true
 
 	# Add the ranged skill to the skill list
 	if ranged and ranged.used_skill:
@@ -556,6 +558,7 @@ func delete():
 		Gamedata.items.save_items_to_disk()
 	else:
 		print_debug("No changes needed for item", id)
+
 
 
 # Executes a callable function on each reference of the given type

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -474,8 +474,6 @@ func changed(olddata: DItem):
 
 # Collects all skills defined in an item and updates the references to that skill
 func update_item_skill_references(olddata: DItem):
-	var changes_made = false
-
 	# Function to collect skill IDs from a list of used skills
 	var collect_skill_ids: Callable = func (item: DItem):
 		var skill_ids = []
@@ -494,18 +492,11 @@ func update_item_skill_references(olddata: DItem):
 	# Remove old skill references that are not in the new list
 	for old_skill_id in old_skill_ids:
 		if not new_skill_ids.has(old_skill_id):
-			changes_made = Gamedata.remove_reference(Gamedata.data.skills, "core", "items", old_skill_id, id) or changes_made
+			Gamedata.skills.remove_reference(old_skill_id, "core", "items", id)
 	
 	# Add new skill references
 	for new_skill_id in new_skill_ids:
-		changes_made = Gamedata.add_reference(Gamedata.data.skills, "core", "items", new_skill_id, id) or changes_made
-		
-	# Save changes if any modifications were made
-	if changes_made:
-		Gamedata.save_data_to_file(Gamedata.data.skills)
-		print_debug("Item skill changes saved successfully.")
-	else:
-		print_debug("No skill changes were made to item.")
+		Gamedata.skills.add_reference(new_skill_id, "core", "items", id)
 
 
 # An item is being deleted from the data
@@ -564,12 +555,10 @@ func delete():
 
 	# Remove the reference of this item from each skill
 	for skill_id in skill_ids.keys():
-		changes_made["value"] = Gamedata.remove_reference(Gamedata.data.skills, "core", \
-		"items", skill_id, id) or changes_made["value"]
+		Gamedata.skills.remove_reference(skill_id, "core", "items", id)
 
 	# Save changes to the data file if any changes were made
 	if changes_made["value"]:
-		Gamedata.save_data_to_file(Gamedata.data.skills)
 		Gamedata.save_data_to_file(Gamedata.data.quests)
 		Gamedata.items.save_items_to_disk()
 	else:

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -524,13 +524,7 @@ func delete():
 	
 	# This callable will handle the removal of this item from all steps in quests
 	var remove_from_quest: Callable = func(quest_id: String):
-		var quest_data = Gamedata.get_data_by_id(Gamedata.data.quests, quest_id)
-		# Removes all steps where the item is equal to item_id
-		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, \
-		"steps.item", id) or changes_made["value"]
-		# Removes all rewards where the reward's item_id is equal to item_id
-		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, \
-		"rewards.item_id", id) or changes_made["value"]
+		Gamedata.quests.remove_item_from_quest(quest_id,id)
 
 	# Pass the callable to every quest in the item's references
 	# It will call remove_from_quest on every item in item_data.references.core.quests
@@ -559,7 +553,6 @@ func delete():
 
 	# Save changes to the data file if any changes were made
 	if changes_made["value"]:
-		Gamedata.save_data_to_file(Gamedata.data.quests)
 		Gamedata.items.save_items_to_disk()
 	else:
 		print_debug("No changes needed for item", id)

--- a/Scripts/Gamedata/DItemgroups.gd
+++ b/Scripts/Gamedata/DItemgroups.gd
@@ -48,11 +48,11 @@ func save_itemgroups_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 
-func get_itemgroups() -> Dictionary:
+func get_all() -> Dictionary:
 	return itemgroupdict
 
 
-func duplicate_itemgroup_to_disk(itemgroupid: String, newitemgroupid: String) -> void:
+func duplicate_to_disk(itemgroupid: String, newitemgroupid: String) -> void:
 	var itemgroupdata: Dictionary = itemgroupdict[itemgroupid].get_data().duplicate(true)
 	itemgroupdata.id = newitemgroupid
 	var newitemgroup: DItemgroup = DItemgroup.new(itemgroupdata)
@@ -60,13 +60,13 @@ func duplicate_itemgroup_to_disk(itemgroupid: String, newitemgroupid: String) ->
 	save_itemgroups_to_disk()
 
 
-func add_new_itemgroup(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newitemgroup: DItemgroup = DItemgroup.new({"id":newid})
 	itemgroupdict[newitemgroup.id] = newitemgroup
 	save_itemgroups_to_disk()
 
 
-func delete_itemgroup(itemgroupid: String) -> void:
+func delete_by_id(itemgroupid: String) -> void:
 	itemgroupdict[itemgroupid].delete()
 	itemgroupdict.erase(itemgroupid)
 	save_itemgroups_to_disk()

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -49,11 +49,11 @@ func save_items_to_disk() -> void:
 	update_item_protoset_json_data("res://ItemProtosets.tres", JSON.stringify(save_data, "\t"))
 
 
-func get_items() -> Dictionary:
+func get_all() -> Dictionary:
 	return itemdict
 
 
-func duplicate_item_to_disk(itemid: String, newitemid: String) -> void:
+func duplicate_to_disk(itemid: String, newitemid: String) -> void:
 	var itemdata: Dictionary = itemdict[itemid].get_data().duplicate(true)
 	itemdata.id = newitemid
 	var newitem: DItem = DItem.new(itemdata)
@@ -61,13 +61,13 @@ func duplicate_item_to_disk(itemid: String, newitemid: String) -> void:
 	save_items_to_disk()
 
 
-func add_new_item(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newitem: DItem = DItem.new({"id":newid})
 	itemdict[newitem.id] = newitem
 	save_items_to_disk()
 
 
-func delete_item(itemid: String) -> void:
+func delete_by_id(itemid: String) -> void:
 	itemdict[itemid].delete()
 	itemdict.erase(itemid)
 	save_items_to_disk()

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -102,17 +102,7 @@ func get_sprite_path() -> String:
 
 
 func remove_self_from_tacticalmap(tacticalmap_id: String) -> void:
-	var tfile = Gamedata.data.tacticalmaps.dataPath + tacticalmap_id
-	var tmapdata: Dictionary = Helper.json_helper.load_json_dictionary_file(tfile)
-
-	# Check if the "chunks" key exists and is an array
-	if tmapdata.has("chunks") and tmapdata["chunks"] is Array:
-		# Filter out chunks that match the map_id, leaving only valid ones in the tacticalmap
-		tmapdata["chunks"] = tmapdata["chunks"].filter(func(chunk):
-			return not (chunk.has("id") and chunk["id"] == id)
-		)
-		var map_data_json = JSON.stringify(tmapdata.duplicate(), "\t")
-		Helper.json_helper.write_json_file(tfile, map_data_json)
+	Gamedata.tacticalmaps.by_id(tacticalmap_id).remove_chunk_by_mapid(id)
 
 
 # A map is being deleted. Remove all references to this map

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -44,7 +44,7 @@ func delete_map(mapid: String) -> void:
 
 
 func by_id(mapid: String) -> DMap:
-	return mapdict[mapid]
+	return mapdict[mapid.replace(".json","")]
 
 # Loop over all maps and delete the entity from it. It will be removed from all levels and areas
 # entity_type: "tile", "furniture", "mob", "itemgroup"
@@ -75,7 +75,7 @@ func remove_reference_from_map(mapid: String, module: String, type: String, refi
 # type: The type of entity, for example "tacticlmaps"
 # refid: The id of the entity to reference, for example "town_00"
 func add_reference_to_map(mapid: String, module: String, type: String, refid: String):
-	var mymap: DMap = mapdict[mapid]
+	var mymap: DMap = by_id(mapid)
 	mymap.add_reference(module, type, refid)
 
 

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -36,6 +36,7 @@ func duplicate_to_disk(mapid: String, newmapid: String) -> void:
 func add_new(newid: String) -> void:
 	var newmap: DMap = DMap.new(newid, dataPath)
 	newmap.save_data_to_disk()
+	mapdict[newid] = newmap
 	
 
 func delete_by_id(mapid: String) -> void:

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -22,23 +22,23 @@ func load_maps_from_disk() -> void:
 		mapdict[mapid] = map
 
 
-func get_maps() -> Dictionary:
+func get_all() -> Dictionary:
 	return mapdict
 
 
-func duplicate_map_to_disk(mapid: String, newmapid: String) -> void:
+func duplicate_to_disk(mapid: String, newmapid: String) -> void:
 	var newmap: DMap = DMap.new(newmapid, dataPath)
 	newmap.set_data(mapdict[mapid].get_data().duplicate(true))
 	newmap.save_data_to_disk()
 	mapdict[newmapid] = newmap
 
 
-func add_new_map(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newmap: DMap = DMap.new(newid, dataPath)
 	newmap.save_data_to_disk()
 	
 
-func delete_map(mapid: String) -> void:
+func delete_by_id(mapid: String) -> void:
 	mapdict[mapid].delete()
 	mapdict.erase(mapid)
 

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -47,6 +47,11 @@ func delete_by_id(mapid: String) -> void:
 func by_id(mapid: String) -> DMap:
 	return mapdict[mapid.replace(".json","")]
 
+# Returns the sprite of the map
+func sprite_by_id(mapid: String) -> Texture:
+	return by_id(mapid).sprite
+
+
 # Loop over all maps and delete the entity from it. It will be removed from all levels and areas
 # entity_type: "tile", "furniture", "mob", "itemgroup"
 # entity_id: the id of the entity

--- a/Scripts/Gamedata/DMob.gd
+++ b/Scripts/Gamedata/DMob.gd
@@ -128,7 +128,6 @@ func changed(olddata: DMob):
 # A mob is being deleted from the data
 # We have to remove it from everything that references it
 func delete():
-	var changes_made = { "value": false }
 	Gamedata.itemgroups.remove_reference(loot_group, "core", "mobs", id)
 	
 	# Check if the mob has references to maps and remove it from those maps
@@ -138,18 +137,11 @@ func delete():
 	
 	# This callable will handle the removal of this mob from all steps in quests
 	var remove_from_quest: Callable = func(quest_id: String):
-		var quest_data = Gamedata.get_data_by_id(Gamedata.data.quests, quest_id)
-		changes_made["value"] = Helper.json_helper.remove_object_by_id(quest_data, "steps.mob", id) or changes_made["value"]
+		Gamedata.quests.remove_mob_from_quest(quest_id,id)
 		
 	# Pass the callable to every quest in the mob's references
 	# It will call remove_from_quest on every mob in mob_data.references.core.quests
 	execute_callable_on_references_of_type("core", "quests", remove_from_quest)
-
-	# Save changes to the data file if any changes were made
-	if changes_made["value"]:
-		Gamedata.save_data_to_file(Gamedata.data.quests)
-	else:
-		print_debug("No changes needed for mob", id)
 
 
 # Executes a callable function on each reference of the given type

--- a/Scripts/Gamedata/DMobs.gd
+++ b/Scripts/Gamedata/DMobs.gd
@@ -48,11 +48,11 @@ func save_mobs_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 
-func get_mobs() -> Dictionary:
+func get_all() -> Dictionary:
 	return mobdict
 
 
-func duplicate_mob_to_disk(mobid: String, newmobid: String) -> void:
+func duplicate_to_disk(mobid: String, newmobid: String) -> void:
 	var mobdata: Dictionary = mobdict[mobid].get_data().duplicate(true)
 	mobdata.id = newmobid
 	var newmob: DMob = DMob.new(mobdata)
@@ -60,13 +60,13 @@ func duplicate_mob_to_disk(mobid: String, newmobid: String) -> void:
 	save_mobs_to_disk()
 
 
-func add_new_mob(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newmob: DMob = DMob.new({"id":newid})
 	mobdict[newmob.id] = newmob
 	save_mobs_to_disk()
 
 
-func delete_mob(mobid: String) -> void:
+func delete_by_id(mobid: String) -> void:
 	mobdict[mobid].delete()
 	mobdict.erase(mobid)
 	save_mobs_to_disk()

--- a/Scripts/Gamedata/DMobs.gd
+++ b/Scripts/Gamedata/DMobs.gd
@@ -86,7 +86,7 @@ func sprite_by_id(mobid: String) -> Texture:
 	return mobdict[mobid].sprite
 
 # Returns the sprite of the mob
-# mobid: The id of the mob to return the sprite of
+# spritefile: The file of the sprite to return the sprite of
 func sprite_by_file(spritefile: String) -> Texture:
 	return sprites[spritefile]
 
@@ -106,4 +106,3 @@ func remove_reference(mobid: String, module: String, type: String, refid: String
 func add_reference(mobid: String, module: String, type: String, refid: String):
 	var mymob: DMob = mobdict[mobid]
 	mymob.add_reference(module, type, refid)
-

--- a/Scripts/Gamedata/DPlayerAttributes.gd
+++ b/Scripts/Gamedata/DPlayerAttributes.gd
@@ -49,11 +49,11 @@ func save_playerattributes_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 
-func get_playerattributes() -> Dictionary:
+func get_all() -> Dictionary:
 	return playerattributedict
 
 
-func duplicate_playerattribute_to_disk(playerattributeid: String, newplayerattributeid: String) -> void:
+func duplicate_to_disk(playerattributeid: String, newplayerattributeid: String) -> void:
 	var playerattributedata: Dictionary = playerattributedict[playerattributeid].get_data().duplicate(true)
 	playerattributedata.id = newplayerattributeid
 	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new(playerattributedata)
@@ -61,13 +61,13 @@ func duplicate_playerattribute_to_disk(playerattributeid: String, newplayerattri
 	save_playerattributes_to_disk()
 
 
-func add_new_playerattribute(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new({"id":newid})
 	playerattributedict[newplayerattribute.id] = newplayerattribute
 	save_playerattributes_to_disk()
 
 
-func delete_playerattribute(playerattributeid: String) -> void:
+func delete_by_id(playerattributeid: String) -> void:
 	playerattributedict[playerattributeid].delete()
 	playerattributedict.erase(playerattributeid)
 	save_playerattributes_to_disk()

--- a/Scripts/Gamedata/DQuest.gd
+++ b/Scripts/Gamedata/DQuest.gd
@@ -1,0 +1,147 @@
+class_name DQuest
+extends RefCounted
+
+# This class represents a quest with its properties
+# Example quest data:
+# {
+#   "description": "This will teach you the basics of survival...",
+#   "id": "starter_tutorial_00",
+#   "name": "Beginnings",
+#   "rewards": [
+#       {
+#           "amount": 10,
+#           "item_id": "berries_wild"
+#       }
+#   ],
+#   "sprite": "spear_stone_32.png",
+#   "steps": [
+#			{
+#				"amount": 1,
+#				"item": "long_stick",
+#				"tip": "You can find one in the forest",
+#				"type": "collect"
+#			}
+#			{
+#				"item": "stone_spear",
+#				"tip": "Press c to open the craft menu",
+#				"type": "craft"
+#			},
+#			{
+#				"amount": 2,
+#				"mob": "scrapwalker",
+#				"tip": "You can find them in town",
+#				"type": "kill"
+#			}
+#   ]
+# }
+
+# Properties defined in the quest
+var id: String
+var name: String
+var description: String
+var spriteid: String
+var sprite: Texture
+var rewards: Array = []
+var steps: Array = []
+
+# Constructor to initialize quest properties from a dictionary
+func _init(data: Dictionary):
+	id = data.get("id", "")
+	name = data.get("name", "")
+	description = data.get("description", "")
+	spriteid = data.get("sprite", "")
+	rewards = data.get("rewards", [])
+	steps = data.get("steps", [])
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	return {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid,
+		"rewards": rewards,
+		"steps": steps
+	}
+
+# Method to save any changes to the quest back to disk
+func save_to_disk():
+	Gamedata.quests.save_quests_to_disk()
+
+
+# Handles quest deletion
+func delete():
+	var stepitems: Array = steps.filter(func(step): return step.has("item"))
+	for collectstep in stepitems:
+		Gamedata.items.remove_reference(collectstep.item, "core", "quests", id)
+	var stepmobs: Array =  steps.filter(func(step): return step.has("mob"))
+	for killstep in stepmobs:
+		Gamedata.mobs.remove_reference(killstep.mob, "core", "quests", id)
+	var steprewards: Array = rewards.filter(func(reward): return reward.has("item_id"))
+	for reward in steprewards: # Remove the reference to this quest from the reward item
+		Gamedata.items.remove_reference(reward.item_id, "core", "quests", id)
+
+
+# Handles quest changes
+func changed(olddata: DQuest):
+	var quest_id: String = id
+
+	# Get items and mobs from the old steps
+	var old_quest_items: Array = olddata.steps.filter(func(step): return step.has("item"))
+	var old_quest_mobs: Array = olddata.steps.filter(func(step): return step.has("mob"))
+	# Get rewards from the old data
+	var old_quest_rewards: Array = olddata.rewards.filter(func(reward): return reward.has("item_id"))
+
+	# Get items and mobs from the new steps
+	var new_quest_items: Array = steps.filter(func(step): return step.has("item"))
+	var new_quest_mobs: Array = steps.filter(func(step): return step.has("mob"))
+	# Get rewards from the new data
+	var new_quest_rewards: Array = rewards.filter(func(reward): return reward.has("item_id"))
+
+	# Remove references for old items and rewards that are not in the new data
+	for old_item in old_quest_items:
+		if old_item not in new_quest_items:
+			Gamedata.items.remove_reference(old_item.item, "core", "quests", quest_id)
+
+	for old_reward in old_quest_rewards:
+		if old_reward not in new_quest_rewards:
+			Gamedata.items.remove_reference(old_reward.item_id, "core", "quests", quest_id)
+
+	# Remove references for old mobs that are not in the new data
+	for old_mob in old_quest_mobs:
+		if old_mob not in new_quest_mobs:
+			Gamedata.mobs.remove_reference(old_mob.mob, "core", "quests", quest_id)
+
+	# Add references for new items and rewards
+	for new_item in new_quest_items:
+		Gamedata.items.add_reference(new_item.item, "core", "quests", quest_id)
+
+	for new_reward in new_quest_rewards:
+		Gamedata.items.add_reference(new_reward.item_id, "core", "quests", quest_id)
+
+	# Add references for new mobs
+	for new_mob in new_quest_mobs:
+		Gamedata.mobs.add_reference(new_mob.mob, "core", "quests", quest_id)
+
+	save_to_disk()
+
+# Removes all steps where the mob property matches the given mob_id
+func remove_steps_by_mob(mob_id: String) -> void:
+	steps = steps.filter(func(step): 
+		return not (step.has("mob") and step.mob == mob_id)
+	)
+	save_to_disk()
+
+# Removes all steps where the item property matches the given item_id
+func remove_steps_by_item(item_id: String) -> void:
+	steps = steps.filter(func(step): 
+		return not (step.has("item") and step.item == item_id)
+	)
+	save_to_disk()
+
+# Removes all rewards where the item_id matches the given item_id
+func remove_rewards_by_item(item_id: String) -> void:
+	rewards = rewards.filter(func(reward): 
+		return not (reward.has("item_id") and reward.item_id == item_id)
+	)
+	save_to_disk()

--- a/Scripts/Gamedata/DQuests.gd
+++ b/Scripts/Gamedata/DQuests.gd
@@ -45,11 +45,11 @@ func save_quests_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 # Returns the dictionary containing all quests
-func get_quests() -> Dictionary:
+func get_all() -> Dictionary:
 	return questdict
 
 # Duplicates a quest and saves it to disk with a new ID
-func duplicate_quest_to_disk(questid: String, newquestid: String) -> void:
+func duplicate_to_disk(questid: String, newquestid: String) -> void:
 	var questdata: Dictionary = questdict[questid].get_data().duplicate(true)
 	questdata["id"] = newquestid
 	var newquest: DQuest = DQuest.new(questdata)
@@ -57,13 +57,13 @@ func duplicate_quest_to_disk(questid: String, newquestid: String) -> void:
 	save_quests_to_disk()
 
 # Adds a new quest with a given ID
-func add_new_quest(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newquest: DQuest = DQuest.new({"id": newid})
 	questdict[newquest.id] = newquest
 	save_quests_to_disk()
 
 # Deletes a quest by its ID and saves changes to disk
-func delete_quest(questid: String) -> void:
+func delete_by_id(questid: String) -> void:
 	questdict[questid].delete()
 	questdict.erase(questid)
 	save_quests_to_disk()

--- a/Scripts/Gamedata/DSkill.gd
+++ b/Scripts/Gamedata/DSkill.gd
@@ -1,0 +1,99 @@
+class_name DSkill
+extends RefCounted
+
+# This class represents a skill with its properties
+# Example skill data:
+#	{
+#		"description": "Skill in crafting objects from raw materials, including tools, weapons, and other gear, often essential for survival.",
+#		"id": "fabrication",
+#		"name": "Fabrication",
+#		"sprite": "crafting_32.png",
+#		"references": {
+#			"core": {
+#				"items": [
+#					"pistol_magazine",
+#					"cutting_board"
+#				]
+#			}
+#		}
+#	}
+
+# Properties defined in the skill
+var id: String
+var name: String
+var description: String
+var spriteid: String
+var sprite: Texture
+var references: Dictionary = {}
+
+# Constructor to initialize skill properties from a dictionary
+func _init(data: Dictionary):
+	id = data.get("id", "")
+	name = data.get("name", "")
+	description = data.get("description", "")
+	spriteid = data.get("sprite", "")
+	references = data.get("references", {})
+
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid
+	}
+	if not references.is_empty():
+		data["references"] = references
+	return data
+
+# Method to save any changes to the skill back to disk
+func save_to_disk():
+	Gamedata.skills.save_skills_to_disk()
+
+# Removes the provided reference from references
+func remove_reference(module: String, type: String, refid: String):
+	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
+	if changes_made:
+		Gamedata.skills.save_skills_to_disk()
+
+# Adds a reference to the references list
+func add_reference(module: String, type: String, refid: String):
+	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
+	if changes_made:
+		Gamedata.skills.save_skills_to_disk()
+
+# Some skill has been changed
+# INFO if the skill references other entities, update them here
+func changed(_olddata: DSkill):
+	Gamedata.skills.save_skills_to_disk()
+
+# A skill is being deleted from the data
+# We have to remove it from everything that references it
+func delete():
+	var changes: Dictionary = {"made":false}
+	
+	# This callable will remove this skill from items that reference this skill.
+	var myfunc: Callable = func (item_id):
+		var item_data: DItem = Gamedata.items.by_id(item_id)
+		item_data.remove_skill(id)
+		changes.made = true
+	
+	# Pass the callable to every item in the skill's references
+	# It will call myfunc on every item in skill_data.references.core.items
+	execute_callable_on_references_of_type("core", "items", myfunc)
+	
+	# Save changes to the data file if any changes were made
+	if changes.made:
+		Gamedata.items.save_items_to_disk()
+	else:
+		print_debug("No changes needed for skill", id)
+
+
+# Executes a callable function on each reference of the given type
+func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
+	# Check if it contains the specified 'module' and 'type'
+	if references.has(module) and references[module].has(type):
+		# If the type exists, execute the callable on each ID found under this type
+		for ref_id in references[module][type]:
+			callable.call(ref_id)

--- a/Scripts/Gamedata/DSkills.gd
+++ b/Scripts/Gamedata/DSkills.gd
@@ -1,0 +1,106 @@
+class_name DSkills
+extends RefCounted
+
+# There's a D in front of the class name to indicate this class only handles skills data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the list of skills. You can access it through Gamedata.skills
+
+# Paths for skills data and sprites
+var dataPath: String = "./Mods/Core/Skills/Skills.json"
+var spritePath: String = "./Mods/Core/Skills/"
+var skilldict: Dictionary = {}
+var sprites: Dictionary = {}
+
+# Constructor
+func _init():
+	load_sprites()
+	load_skills_from_disk()
+
+# Load all skills data from disk into memory
+func load_skills_from_disk() -> void:
+	var skillslist: Array = Helper.json_helper.load_json_array_file(dataPath)
+	for myskill in skillslist:
+		var skill: DSkill = DSkill.new(myskill)
+		skill.sprite = sprites[skill.spriteid]
+		skilldict[skill.id] = skill
+
+# Loads sprites and assigns them to the proper dictionary
+func load_sprites() -> void:
+	var png_files: Array = Helper.json_helper.file_names_in_dir(spritePath, ["png"])
+	for png_file in png_files:
+		# Load the .png file as a texture
+		var texture := load(spritePath + png_file)
+		# Add the texture to the dictionary
+		sprites[png_file] = texture
+
+# Called when data changes and needs to be saved
+func on_data_changed():
+	save_skills_to_disk()
+
+# Saves all skills to disk
+func save_skills_to_disk() -> void:
+	var save_data: Array = []
+	for skill in skilldict.values():
+		save_data.append(skill.get_data())
+	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+
+# Returns the dictionary containing all skills
+func get_skills() -> Dictionary:
+	return skilldict
+
+# Duplicates a skill and saves it to disk with a new ID
+func duplicate_skill_to_disk(skillid: String, newskillid: String) -> void:
+	var skilldata: Dictionary = skilldict[skillid].get_data().duplicate(true)
+	skilldata["id"] = newskillid
+	var newskill: DSkill = DSkill.new(skilldata)
+	skilldict[newskillid] = newskill
+	save_skills_to_disk()
+
+# Adds a new skill with a given ID
+func add_new_skill(newid: String) -> void:
+	var newskill: DSkill = DSkill.new({"id": newid})
+	skilldict[newskill.id] = newskill
+	save_skills_to_disk()
+
+# Deletes a skill by its ID and saves changes to disk
+func delete_skill(skillid: String) -> void:
+	skilldict[skillid].delete()
+	skilldict.erase(skillid)
+	save_skills_to_disk()
+
+# Returns a skill by its ID
+func by_id(skillid: String) -> DSkill:
+	return skilldict[skillid]
+
+# Checks if a skill exists by its ID
+func has_id(skillid: String) -> bool:
+	return skilldict.has(skillid)
+
+# Returns the sprite of the skill
+func sprite_by_id(skillid: String) -> Texture:
+	return skilldict[skillid].sprite
+
+# Returns the sprite by its file name
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites[spritefile]
+
+# Removes a reference from the selected skill
+func remove_reference(skillid: String, module: String, type: String, refid: String):
+	var myskill: DSkill = skilldict[skillid]
+	myskill.remove_reference(module, type, refid)
+
+# Adds a reference to the references list in the skill
+func add_reference(skillid: String, module: String, type: String, refid: String):
+	var myskill: DSkill = skilldict[skillid]
+	myskill.add_reference(module, type, refid)
+
+# Helper function to update references if they have changed
+func update_reference(old: String, new: String, type: String, refid: String) -> void:
+	if old == new:
+		return  # No change detected, exit early
+
+	# Remove from old group if necessary
+	if old != "":
+		remove_reference(old, "core", type, refid)
+	if new != "":
+		add_reference(new, "core", type, refid)

--- a/Scripts/Gamedata/DSkills.gd
+++ b/Scripts/Gamedata/DSkills.gd
@@ -45,11 +45,11 @@ func save_skills_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 # Returns the dictionary containing all skills
-func get_skills() -> Dictionary:
+func get_all() -> Dictionary:
 	return skilldict
 
 # Duplicates a skill and saves it to disk with a new ID
-func duplicate_skill_to_disk(skillid: String, newskillid: String) -> void:
+func duplicate_to_disk(skillid: String, newskillid: String) -> void:
 	var skilldata: Dictionary = skilldict[skillid].get_data().duplicate(true)
 	skilldata["id"] = newskillid
 	var newskill: DSkill = DSkill.new(skilldata)
@@ -57,13 +57,13 @@ func duplicate_skill_to_disk(skillid: String, newskillid: String) -> void:
 	save_skills_to_disk()
 
 # Adds a new skill with a given ID
-func add_new_skill(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newskill: DSkill = DSkill.new({"id": newid})
 	skilldict[newskill.id] = newskill
 	save_skills_to_disk()
 
 # Deletes a skill by its ID and saves changes to disk
-func delete_skill(skillid: String) -> void:
+func delete_by_id(skillid: String) -> void:
 	skilldict[skillid].delete()
 	skilldict.erase(skillid)
 	save_skills_to_disk()

--- a/Scripts/Gamedata/DStats.gd
+++ b/Scripts/Gamedata/DStats.gd
@@ -45,11 +45,11 @@ func save_stats_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 # Returns the dictionary containing all stats
-func get_stats() -> Dictionary:
+func get_all() -> Dictionary:
 	return statdict
 
 # Duplicates a stat and saves it to disk with a new ID
-func duplicate_stat_to_disk(statid: String, newstatid: String) -> void:
+func duplicate_to_disk(statid: String, newstatid: String) -> void:
 	var statdata: Dictionary = statdict[statid].get_data().duplicate(true)
 	statdata.id = newstatid
 	var newstat: DStat = DStat.new(statdata)
@@ -57,13 +57,13 @@ func duplicate_stat_to_disk(statid: String, newstatid: String) -> void:
 	save_stats_to_disk()
 
 # Adds a new stat with a given ID
-func add_new_stat(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newstat: DStat = DStat.new({"id": newid})
 	statdict[newstat.id] = newstat
 	save_stats_to_disk()
 
 # Deletes a stat by its ID and saves changes to disk
-func delete_stat(statid: String) -> void:
+func delete_by_id(statid: String) -> void:
 	statdict[statid].delete()
 	statdict.erase(statid)
 	save_stats_to_disk()

--- a/Scripts/Gamedata/DTacticalmap.gd
+++ b/Scripts/Gamedata/DTacticalmap.gd
@@ -1,0 +1,120 @@
+class_name DTacticalmap
+extends RefCounted
+
+# This class represents a tactical map with its properties
+# Example tactical map data:
+# {
+#   "chunks": [
+#       {"id": "field_grass_basic_00.json"},
+#       {"id": "urbanroad_corner.json", "rotation": 180},
+#       ...
+#   ],
+#   "mapheight": 6,
+#   "mapwidth": 6
+# }
+
+# Subclass to represent individual chunks in the tactical map
+class TChunk:
+	var id: String = ""
+	var rotation: int = 0
+
+	func _init(data: Dictionary):
+		id = data.get("id", "")
+		rotation = data.get("rotation", 0)
+
+	func get_data() -> Dictionary:
+		var data: Dictionary = {"id": id}
+		if not rotation == 0:
+			data["rotation"] = rotation
+		return data
+
+
+# Properties defined in the tactical map
+var id: String = "": # id is the filename without json
+	set(newid):
+		id = newid.replace(".json", "") # In case the filename is passed, we remove json
+var mapwidth: int = 6
+var mapheight: int = 6
+var chunks: Array[TChunk] = []
+var dataPath: String
+
+
+func _init(newid: String, newdataPath: String):
+	id = newid
+	dataPath = newdataPath
+
+
+# Constructor to initialize tactical map properties from a dictionary
+func set_data(newdata: Dictionary):
+	mapwidth = newdata.get("mapwidth", 6)
+	mapheight = newdata.get("mapheight", 6)
+
+	var chunk_data = newdata.get("chunks", [])
+	for chunk in chunk_data:
+		chunks.append(TChunk.new(chunk))
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var chunk_data = []
+	for chunk in chunks:
+		chunk_data.append(chunk.get_data())
+
+	return {
+		"mapwidth": mapwidth,
+		"mapheight": mapheight,
+		"chunks": chunk_data
+	}
+
+func load_data_from_disk():
+	set_data(Helper.json_helper.load_json_dictionary_file(get_file_path()))
+
+func save_data_to_disk() -> void:
+	var map_data_json = JSON.stringify(get_data().duplicate(), "\t")
+	Helper.json_helper.write_json_file(get_file_path(), map_data_json)
+
+func get_filename() -> String:
+	return id + ".json"
+	
+func get_file_path() -> String:
+	return dataPath + get_filename()
+
+# A tacticalmap is being deleted. Remove all references to this tacticalmap
+func delete(tacticalmap_id: String):
+	for chunk: TChunk in chunks:
+		Gamedata.maps.remove_reference_from_map(chunk.id,"core", "tacticalmaps",get_filename())
+	Helper.json_helper.delete_json_file(get_file_path())
+
+func changed(olddata: DTacticalmap):
+	# Collect unique IDs from the old data
+	var unique_old_ids: Array = []
+	var ids_dict_old: Dictionary = {}
+	for old_chunk in olddata.chunks:
+		ids_dict_old[old_chunk.id] = true
+	unique_old_ids = ids_dict_old.keys()
+
+	# Collect unique IDs from the new data (current instance)
+	var unique_new_ids: Array = []
+	var ids_dict_new: Dictionary = {}
+	for new_chunk in chunks:
+		ids_dict_new[new_chunk.id] = true
+	unique_new_ids = ids_dict_new.keys()
+
+	# Get the tactical map file name for reference management
+	var tacticalmap_id = get_filename()
+
+	# Add references for new IDs
+	for id in unique_new_ids:
+		Gamedata.maps.add_reference_to_map(id, "core", "tacticalmaps", tacticalmap_id)
+
+	# Remove references for IDs not present in new data
+	for id in unique_old_ids:
+		if id not in unique_new_ids:
+			Gamedata.maps.remove_reference_from_map(id, "core", "tacticalmaps", tacticalmap_id)
+
+
+# Removes all chunks where the map_id matches the given chunk id
+func remove_chunk_by_mapid(map_id: String) -> void:
+	chunks = chunks.filter(func(chunk): 
+		return not (chunk.has("id") and chunk.id == map_id)
+	)
+	save_data_to_disk()

--- a/Scripts/Gamedata/DTacticalmaps.gd
+++ b/Scripts/Gamedata/DTacticalmaps.gd
@@ -1,0 +1,49 @@
+class_name DTacticalmaps
+extends RefCounted
+
+# There's a D in front of the class name to indicate this class only handles tactical map data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the list of tactical maps. You can access it through Gamedata.tacticalmaps
+
+var dataPath: String = "./Mods/Core/TacticalMaps/"
+var mapdict: Dictionary = {}
+
+func _init():
+	load_maps_from_disk()
+
+# Load all tactical map data from disk into memory
+func load_maps_from_disk() -> void:
+	var maplist: Array = Helper.json_helper.file_names_in_dir(dataPath, ["json"])
+	for mapitem in maplist:
+		var mapid: String = mapitem.replace(".json", "")
+		var map: DTacticalmap = DTacticalmap.new(mapid, dataPath)
+		map.load_data_from_disk()
+		mapdict[mapid] = map
+
+func get_maps() -> Dictionary:
+	return mapdict
+
+func duplicate_map_to_disk(mapid: String, newmapid: String) -> void:
+	var newmap: DTacticalmap = DTacticalmap.new(newmapid, dataPath)
+	newmap.set_data(mapdict[mapid].get_data().duplicate(true))
+	newmap.save_data_to_disk()
+	mapdict[newmapid] = newmap
+
+func add_new_map(newid: String) -> void:
+	var newmap: DTacticalmap = DTacticalmap.new(newid, dataPath)
+	newmap.save_data_to_disk()
+
+func delete_map(mapid: String) -> void:
+	mapdict[mapid].delete()
+	mapdict.erase(mapid)
+
+func by_id(mapid: String) -> DTacticalmap:
+	return mapdict[mapid]
+
+# Returns a random map
+func get_random_map() -> DTacticalmap:
+	var map_ids = mapdict.keys()
+	if map_ids.is_empty():
+		return null
+	var random_id = map_ids[randi() % map_ids.size()]
+	return mapdict[random_id]

--- a/Scripts/Gamedata/DTacticalmaps.gd
+++ b/Scripts/Gamedata/DTacticalmaps.gd
@@ -20,20 +20,20 @@ func load_maps_from_disk() -> void:
 		map.load_data_from_disk()
 		mapdict[mapid] = map
 
-func get_maps() -> Dictionary:
+func get_all() -> Dictionary:
 	return mapdict
 
-func duplicate_map_to_disk(mapid: String, newmapid: String) -> void:
+func duplicate_to_disk(mapid: String, newmapid: String) -> void:
 	var newmap: DTacticalmap = DTacticalmap.new(newmapid, dataPath)
 	newmap.set_data(mapdict[mapid].get_data().duplicate(true))
 	newmap.save_data_to_disk()
 	mapdict[newmapid] = newmap
 
-func add_new_map(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newmap: DTacticalmap = DTacticalmap.new(newid, dataPath)
 	newmap.save_data_to_disk()
 
-func delete_map(mapid: String) -> void:
+func delete_by_id(mapid: String) -> void:
 	mapdict[mapid].delete()
 	mapdict.erase(mapid)
 

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -79,15 +79,6 @@ func add_reference(module: String, type: String, refid: String):
 func get_sprite_path() -> String:
 	return Gamedata.tiles.spritePath + spriteid
 
-# Handles tile changes and updates references if necessary
-func on_data_changed(_oldtile: DTile):
-	var changes_made = false
-
-	# If any references were updated, save the changes to the data file
-	if changes_made:
-		print_debug("Tile reference updates saved successfully.")
-		Gamedata.save_data_to_file(Gamedata.data.tilegroups)
-
 
 # Some tile has been changed
 # INFO if the tiles reference other entities, update them here

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -48,11 +48,11 @@ func save_tiles_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 
-func get_tiles() -> Dictionary:
+func get_all() -> Dictionary:
 	return tiledict
 
 
-func duplicate_tile_to_disk(tileid: String, newtileid: String) -> void:
+func duplicate_to_disk(tileid: String, newtileid: String) -> void:
 	var tiledata: Dictionary = tiledict[tileid].get_data().duplicate(true)
 	tiledata.id = newtileid
 	var newtile: DTile = DTile.new(tiledata)
@@ -60,13 +60,13 @@ func duplicate_tile_to_disk(tileid: String, newtileid: String) -> void:
 	save_tiles_to_disk()
 
 
-func add_new_tile(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newtile: DTile = DTile.new({"id":newid})
 	tiledict[newtile.id] = newtile
 	save_tiles_to_disk()
 
 
-func delete_tile(tileid: String) -> void:
+func delete_by_id(tileid: String) -> void:
 	tiledict[tileid].delete()
 	tiledict.erase(tileid)
 	save_tiles_to_disk()

--- a/Scripts/Gamedata/DWearableSlots.gd
+++ b/Scripts/Gamedata/DWearableSlots.gd
@@ -47,11 +47,11 @@ func save_wearableslots_to_disk() -> void:
 	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
 
 
-func get_wearableslots() -> Dictionary:
+func get_all() -> Dictionary:
 	return wearableslotdict
 
 
-func duplicate_wearableslot_to_disk(wearableslotid: String, newwearableslotid: String) -> void:
+func duplicate_to_disk(wearableslotid: String, newwearableslotid: String) -> void:
 	var wearableslotdata: Dictionary = wearableslotdict[wearableslotid].get_data().duplicate(true)
 	wearableslotdata.id = newwearableslotid
 	var newwearableslot: DWearableSlot = DWearableSlot.new(wearableslotdata)
@@ -59,13 +59,13 @@ func duplicate_wearableslot_to_disk(wearableslotid: String, newwearableslotid: S
 	save_wearableslots_to_disk()
 
 
-func add_new_wearableslot(newid: String) -> void:
+func add_new(newid: String) -> void:
 	var newwearableslot: DWearableSlot = DWearableSlot.new({"id":newid})
 	wearableslotdict[newwearableslot.id] = newwearableslot
 	save_wearableslots_to_disk()
 
 
-func delete_wearableslot(wearableslotid: String) -> void:
+func delete_by_id(wearableslotid: String) -> void:
 	wearableslotdict[wearableslotid].delete()
 	wearableslotdict.erase(wearableslotid)
 	save_wearableslots_to_disk()

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -559,13 +559,6 @@ func load_all_grids():
 		process_loaded_grid_data(loadedgrid)
 
 
-# Function to randomly load and return a tactical map
-func load_random_tactical_map() -> Dictionary:
-	var tacticalmaps = Helper.json_helper.file_names_in_dir(Gamedata.data.tacticalmaps.dataPath)
-	var random_tactical_map = tacticalmaps[randi() % tacticalmaps.size()]
-	return Helper.json_helper.load_json_dictionary_file(Gamedata.data.tacticalmaps.dataPath + random_tactical_map)
-
-
 # Function to find a valid position for placing a tactical map
 func find_valid_position(placed_positions: Array, map_width: int, map_height: int) -> Vector2:
 	var attempts = 0
@@ -596,11 +589,11 @@ func find_valid_position(placed_positions: Array, map_width: int, map_height: in
 func place_tactical_maps_on_grid(grid: map_grid):
 	var placed_positions = []
 	for n in range(10):
-		var tactical_map_data = load_random_tactical_map()
+		var dmap: DTacticalmap = Gamedata.tacticalmaps.get_random_map()
 
-		var map_width = tactical_map_data.get("mapwidth", 0)
-		var map_height = tactical_map_data.get("mapheight", 0)
-		var chunks = tactical_map_data.get("chunks", [])
+		var map_width = dmap.mapwidth
+		var map_height = dmap.mapheight
+		var chunks = dmap.chunks
 
 		var position = find_valid_position(placed_positions, map_width, map_height)
 		if position == Vector2(-1, -1):
@@ -617,8 +610,8 @@ func place_tactical_maps_on_grid(grid: map_grid):
 				if local_x < grid_width and local_y < grid_height:
 					var cell_key = Vector2(local_x, local_y)
 					var chunk_index = j * map_width + i
-					var chunk_data = chunks[chunk_index]
-					update_cell_map_id(grid, cell_key, chunk_data["id"], chunk_data.get("rotation", 0))
+					var dchunk: DTacticalmap.TChunk = chunks[chunk_index]
+					update_cell_map_id(grid, cell_key, dchunk.id, dchunk.rotation)
 					placed_positions.append(cell_key)
 
 

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -110,13 +110,13 @@ func _on_quest_reset(_quest_name: String):
 # Initialize quests by wiping player data and loading quest data
 func initialize_quests():
 	QuestManager.wipe_player_data()
-	for quest in Gamedata.data.quests.data:
+	for quest: DQuest in Gamedata.quests.get_quests().values():
 		create_quest_from_data(quest)
 
 
 # Takes a quest as defined by json (created in the contenteditor)
 # Create an instance of a ScriptQuest and add it to the QuestManager
-func create_quest_from_data(quest_data: Dictionary):
+func create_quest_from_data(quest_data: DQuest):
 	if quest_data.steps.size() < 1:
 		return # The quest has no steps
 	var quest = ScriptQuest.new(quest_data.id, quest_data.description)
@@ -125,8 +125,7 @@ func create_quest_from_data(quest_data: Dictionary):
 		steps_added = add_quest_step(quest, step) or steps_added
 
 	if steps_added:
-		quest.set_quest_meta_data(quest_data) # The json data that defines the quest
-		quest.set_rewards({"rewards": quest_data.get("rewards", [])})
+		quest.set_rewards({"rewards": quest_data.rewards})
 		# Finalize
 		quest.finalize_quest()
 		# Add quest to player quests
@@ -236,4 +235,3 @@ func _on_craft_successful(item: DItem, _recipe: DItem.CraftRecipe):
 					QuestManager.progress_quest(quest.quest_name)
 				
 			
-

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -110,7 +110,7 @@ func _on_quest_reset(_quest_name: String):
 # Initialize quests by wiping player data and loading quest data
 func initialize_quests():
 	QuestManager.wipe_player_data()
-	for quest: DQuest in Gamedata.quests.get_quests().values():
+	for quest: DQuest in Gamedata.quests.get_all().values():
 		create_quest_from_data(quest)
 
 

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -108,10 +108,6 @@ signal player_spawned(player: CharacterBody3D) # When the player has spawned in-
 @warning_ignore("unused_signal")
 signal player_y_level_updated(new_y:float) 
 
-# When sprites have been added or removed from gamedata
-@warning_ignore("unused_signal")
-signal data_sprites_changed(contentData: Dictionary, spriteid: String)
-
 # When a mob was killed
 @warning_ignore("unused_signal")
 signal mob_killed(mobinstance: Mob)

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -67,7 +67,7 @@ func equip_loaded_items():
 # The first to children of EquipmentSlotList are static slots and we should ignore them
 # It will get the "name" property from the slot data and set it to the instance's "myLabel" property
 func instantiate_wearable_slots():
-	var slots: Dictionary = Gamedata.wearableslots.get_wearableslots()
+	var slots: Dictionary = Gamedata.wearableslots.get_all()
 
 	# Clear any dynamically created slots first to avoid duplicates and skip the first two
 	while EquipmentSlotList.get_child_count() > 2:

--- a/Scripts/ItemCraftEditor.gd
+++ b/Scripts/ItemCraftEditor.gd
@@ -261,8 +261,7 @@ func skill_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> voi
 	# Assuming dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var skill_id = dropped_data["id"]
-		var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, skill_id)
-		if skill_data.is_empty():
+		if not Gamedata.skills.has_id(skill_id):
 			print_debug("No item data found for ID: " + skill_id)
 			return
 		texteditcontrol.set_text(skill_id)
@@ -276,8 +275,7 @@ func can_skill_drop(dropped_data: Dictionary):
 		return false
 	
 	# Fetch skill data by ID from the Gamedata to ensure it exists and is valid
-	var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, dropped_data["id"])
-	if skill_data.is_empty():
+	if not Gamedata.skills.has_id(dropped_data["id"]):
 		return false
 
 	# If all checks pass, return true

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -54,8 +54,7 @@ func skill_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> voi
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var skill_id = dropped_data["id"]
-		var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, skill_id)
-		if skill_data.is_empty():
+		if not Gamedata.skills.has_id(skill_id):
 			print_debug("No item data found for ID: " + skill_id)
 			return
 		texteditcontrol.set_text(skill_id)
@@ -69,8 +68,7 @@ func can_skill_drop(dropped_data: Dictionary):
 		return false
 	
 	# Fetch skill data by ID from the Gamedata to ensure it exists and is valid
-	var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, dropped_data["id"])
-	if skill_data.is_empty():
+	if not Gamedata.skills.has_id(dropped_data["id"]):
 		return false
 
 	# If all checks pass, return true

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -96,8 +96,7 @@ func skill_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> voi
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var skill_id = dropped_data["id"]
-		var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, skill_id)
-		if skill_data.is_empty():
+		if not Gamedata.skills.has_id(skill_id):
 			print_debug("No item data found for ID: " + skill_id)
 			return
 		texteditcontrol.set_text(skill_id)
@@ -111,8 +110,7 @@ func can_skill_drop(dropped_data: Dictionary):
 		return false
 	
 	# Fetch skill data by ID from the Gamedata to ensure it exists and is valid
-	var skill_data = Gamedata.get_data_by_id(Gamedata.data.skills, dropped_data["id"])
-	if skill_data.is_empty():
+	if not Gamedata.skills.has_id(dropped_data["id"]):
 		return false
 
 	# If all checks pass, return true

--- a/Scripts/ItemWearableEditor.gd
+++ b/Scripts/ItemWearableEditor.gd
@@ -29,7 +29,7 @@ func save_properties() -> void:
 
 # Refreshes the SlotOptionButton by loading slot IDs from the wearable slots data
 func refresh_wearableslots_optionbutton():
-	var wearableslots = Gamedata.wearableslots.get_wearableslots().keys()
+	var wearableslots = Gamedata.wearableslots.get_all().keys()
 	# Clear current items in the OptionButton to avoid duplicates
 	SlotOptionButton.clear()
 

--- a/Scripts/QuestWindow.gd
+++ b/Scripts/QuestWindow.gd
@@ -108,9 +108,9 @@ func _on_new_quest_added(quest_name: String):
 # quest_id: The id of the quest as defined by json
 # quest_list: An itemlist in the UI to which to add it
 func add_quest_to_list(quest_id: String, quest_list: ItemList):
-	var quest_icon: Texture = Gamedata.get_sprite_by_id(Gamedata.data.quests, quest_id)
-	var quest_meta_data: Dictionary = QuestManager.get_meta_data(quest_id)
-	var questname: String = quest_meta_data.get("name", "")
+	var dquest: DQuest = Gamedata.quests.by_id(quest_id)
+	var quest_icon: Texture = dquest.sprite
+	var questname: String = dquest.name
 	if questname != "":
 		var item_index: int = quest_list.add_item(questname, quest_icon)
 		quest_list.set_item_metadata(item_index, quest_id) # Add the quest id as metadata
@@ -139,13 +139,13 @@ func _update_quest_details():
 		return
 	
 	var quest_complete: bool = QuestManager.is_quest_complete(selected_quest)
-	var quest_meta_data: Dictionary = QuestManager.get_meta_data(selected_quest)
 	var current_step: Dictionary = QuestManager.get_current_step(selected_quest)
 	var quest: Dictionary = QuestManager.get_player_quest(selected_quest)
+	var dquest: DQuest = Gamedata.quests.by_id(quest.quest_name)
 	
 	# Update quest title and description
-	quest_details_section.get_node("QuestTitle").text = quest_meta_data.name
-	quest_details_section.get_node("QuestDescription").text = quest_meta_data.description
+	quest_details_section.get_node("QuestTitle").text = dquest.name
+	quest_details_section.get_node("QuestDescription").text = dquest.description
 	
 	# Update rewards details
 	update_rewards_details(quest)

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -25,42 +25,27 @@ var textures: Dictionary = {
 
 # Enums to define the different content types
 enum ContentType {
-	TACTICALMAPS,
-	MAPS,
-	FURNITURES,
-	ITEMGROUPS,
-	ITEMS,
-	TILES,
-	MOBS,
-	PLAYERATTRIBUTES,
-	WEARABLESLOTS,
-	STATS,
-	SKILLS,
-	QUESTS
+	TACTICALMAPS,       #0
+	MAPS,               #1
+	FURNITURES,         #2
+	ITEMGROUPS,         #3
+	ITEMS,              #4
+	TILES,              #5
+	MOBS,               #6
+	PLAYERATTRIBUTES,   #7
+	WEARABLESLOTS,      #8
+	STATS,              #9
+	SKILLS,             #10
+	QUESTS              #11
 }
+
 
 # Dictionary to map content types to Gamedata variables
-var gamedata_map: Dictionary = {
-	ContentType.TACTICALMAPS: tacticalmaps,
-	ContentType.MAPS: maps,
-	ContentType.FURNITURES: furnitures,
-	ContentType.ITEMGROUPS: itemgroups,
-	ContentType.ITEMS: items,
-	ContentType.TILES: tiles,
-	ContentType.MOBS: mobs,
-	ContentType.PLAYERATTRIBUTES: playerattributes,
-	ContentType.WEARABLESLOTS: wearableslots,
-	ContentType.STATS: stats,
-	ContentType.SKILLS: skills,
-	ContentType.QUESTS: quests
-}
+var gamedata_map: Dictionary = {}
 
-
-# We write down the associated paths for the files to load
-# Next, sprites are loaded from spritesPath into the .sprites property
-# Finally, the data is loaded from dataPath into the .data property
+# This function is called when the node is added to the scene.
 func _ready():
-	load_sprites()
+	# Instantiate the content type instances
 	maps = DMaps.new()
 	tacticalmaps = DTacticalmaps.new()
 	furnitures = DFurnitures.new()
@@ -73,6 +58,26 @@ func _ready():
 	stats = DStats.new()
 	skills = DSkills.new()
 	quests = DQuests.new()
+
+	# Now populate the gamedata_map with the instantiated objects
+	gamedata_map = {
+		ContentType.TACTICALMAPS: tacticalmaps,	
+		ContentType.MAPS: maps,	
+		ContentType.FURNITURES: furnitures,
+		ContentType.ITEMGROUPS: itemgroups,
+		ContentType.ITEMS: items,
+		ContentType.TILES: tiles,
+		ContentType.MOBS: mobs,
+		ContentType.PLAYERATTRIBUTES: playerattributes,
+		ContentType.WEARABLESLOTS: wearableslots,
+		ContentType.STATS: stats,
+		ContentType.SKILLS: skills,
+		ContentType.QUESTS: quests
+	}
+
+	load_sprites()
+
+
 
 
 # Loads sprites and assigns them to the proper dictionary
@@ -111,6 +116,11 @@ func save_data_to_file(contentData: Dictionary):
 	var datapath: String = contentData.dataPath
 	if datapath.ends_with(".json"):
 		Helper.json_helper.write_json_file(datapath, JSON.stringify(contentData.data, "\t"))
+
+
+# Returns one of the D- data types. We return it as refcounted since every class differs
+func get_data_of_type(type: ContentType) -> RefCounted:
+	return gamedata_map[type]
 
 
 # Removes the provided reference from references

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -23,6 +23,39 @@ var textures: Dictionary = {
 	"container_filled": load("res://Textures/container_filled_32.png")
 }
 
+# Enums to define the different content types
+enum ContentType {
+	TACTICALMAPS,
+	MAPS,
+	FURNITURES,
+	ITEMGROUPS,
+	ITEMS,
+	TILES,
+	MOBS,
+	PLAYERATTRIBUTES,
+	WEARABLESLOTS,
+	STATS,
+	SKILLS,
+	QUESTS
+}
+
+# Dictionary to map content types to Gamedata variables
+var gamedata_map: Dictionary = {
+	ContentType.TACTICALMAPS: tacticalmaps,
+	ContentType.MAPS: maps,
+	ContentType.FURNITURES: furnitures,
+	ContentType.ITEMGROUPS: itemgroups,
+	ContentType.ITEMS: items,
+	ContentType.TILES: tiles,
+	ContentType.MOBS: mobs,
+	ContentType.PLAYERATTRIBUTES: playerattributes,
+	ContentType.WEARABLESLOTS: wearableslots,
+	ContentType.STATS: stats,
+	ContentType.SKILLS: skills,
+	ContentType.QUESTS: quests
+}
+
+
 # We write down the associated paths for the files to load
 # Next, sprites are loaded from spritesPath into the .sprites property
 # Finally, the data is loaded from dataPath into the .data property

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -2,8 +2,9 @@ extends Node
 
 # Autoload singleton that loads all game data required to run the game
 # Accessible via Gamedata.property
-var data: Dictionary = {}
+var data: Dictionary = {"overmaptiles": {"sprites": {}, "spritePath":"./Mods/Core/OvermapTiles/"}}
 var maps: DMaps
+var tacticalmaps: DTacticalmaps
 var furnitures: DFurnitures
 var items: DItems
 var tiles: DTiles
@@ -15,11 +16,6 @@ var stats: DStats
 var skills: DSkills
 var quests: DQuests
 
-# Dictionary keys for game data categories
-const DATA_CATEGORIES = {
-	"overmaptiles": {"spritePath": "./Mods/Core/OvermapTiles/"},
-	"tacticalmaps": {"dataPath": "./Mods/Core/TacticalMaps/"}
-}
 
 # Dictionary to store loaded textures
 var textures: Dictionary = {
@@ -31,11 +27,9 @@ var textures: Dictionary = {
 # Next, sprites are loaded from spritesPath into the .sprites property
 # Finally, the data is loaded from dataPath into the .data property
 func _ready():
-	initialize_data_structures()
 	load_sprites()
-	load_data()
-	data.tacticalmaps.data = Helper.json_helper.file_names_in_dir(data.tacticalmaps.dataPath, ["json"])
 	maps = DMaps.new()
+	tacticalmaps = DTacticalmaps.new()
 	furnitures = DFurnitures.new()
 	items = DItems.new()
 	tiles = DTiles.new()
@@ -46,28 +40,6 @@ func _ready():
 	stats = DStats.new()
 	skills = DSkills.new()
 	quests = DQuests.new()
-
-
-# Initializes the data structures for each category defined in DATA_CATEGORIES
-func initialize_data_structures():
-	for category in DATA_CATEGORIES.keys():
-		data[category] = {"data": [], "sprites": {}}
-		if DATA_CATEGORIES[category].has("dataPath"):
-			data[category]["dataPath"] = DATA_CATEGORIES[category]["dataPath"]
-		if DATA_CATEGORIES[category].has("spritePath"):
-			data[category]["spritePath"] = DATA_CATEGORIES[category]["spritePath"]
-
-
-#Loads json data. If no json file exists, it will create an empty array in a new file
-func load_data() -> void:
-	for dict in data.keys():
-		if data[dict].has("dataPath"):
-			var dataPath: String = data[dict].dataPath
-			if FileAccess.file_exists(dataPath):
-				Helper.json_helper.create_new_json_file(dataPath)
-				data[dict].data = Helper.json_helper.load_json_array_file(dataPath)
-			else:
-				data[dict].data = []
 
 
 # Loads sprites and assigns them to the proper dictionary
@@ -83,85 +55,6 @@ func load_sprites() -> void:
 				# Add the material to the dictionary
 				loaded_sprites[png_file] = texture
 			data[dict].sprites = loaded_sprites
-
-
-# Adds a sprite to a specific dictionary and emits a signal if successful
-func add_sprite_to_dictionary(contentData: Dictionary, file_name: String, texture: Texture):
-	if texture:
-		contentData.sprites[file_name] = texture
-		Helper.signal_broker.data_sprites_changed.emit(contentData, file_name)
-		print("Sprite added:", file_name)
-	else:
-		print("Failed to add sprite:", file_name)
-
-
-# This function will duplicate a file with the provided original ID
-# and save it under a new ID within the same directory.
-func duplicate_file_in_data(contentData: Dictionary, original_id: String, new_id: String) -> void:
-	var data_path: String = contentData.dataPath
-	var original_file_path: String = data_path + original_id + ".json"
-	var new_file_path: String = data_path + new_id + ".json"
-
-	if not FileAccess.file_exists(original_file_path):
-		print_debug("Original file not found: " + original_file_path)
-		return
-
-	# Load the original file content.
-	var orig_content = Helper.json_helper.load_json_dictionary_file(original_file_path)
-
-	# Write the original content to a new file with the new ID.
-	var save_result = Helper.json_helper.write_json_file(new_file_path, JSON.stringify(orig_content, "\t"))
-	if save_result == OK:
-		print_debug("File duplicated successfully: " + new_file_path)
-		if contentData.data is Array and data_path.ends_with("/"):
-			contentData.data.append(new_id + ".json")
-	else:
-		print_debug("Failed to duplicate file to: " + new_file_path)
-
-
-# This function appends a new object to an existing array
-# Pass the contentData dictionary to this function and the value of the ID
-# If the data directory ends in .json, it will append an object
-# The object that will be appended will be nothing more then {"id": id}
-# if the data directory does not end in .json, a new file will be added
-# This file will get the name as specified by id, so for example "myhouse"
-# After the ID is added, the data array will be saved to disk
-func add_id_to_data(contentData: Dictionary, id: String):
-	if not contentData.has("data"):
-		return
-	if contentData.dataPath.ends_with(".json"):
-		if get_array_index_by_id(contentData, id) != -1:
-			print_debug("Tried to add an existing id to an array")
-			return
-		contentData.data.append({"id": id})
-		save_data_to_file(contentData)
-	else:
-		if id in contentData.data:
-			print_debug("Tried to add an existing file to a file array")
-			return
-		contentData.data.append(id + ".json")
-		#Create a new json file in the directory with only {} in the file
-		Helper.json_helper.create_new_json_file(contentData.dataPath + id + ".json", false)
-
-
-# Will remove an item from the data
-# If the first item in data is a dictionary, we remove an item that has the provided id
-# If the first item in data is a string, we remove the string and the associated json file
-func remove_item_from_data(contentData: Dictionary, id: String):
-	if contentData.data.is_empty():
-		return
-	if contentData.dataPath.ends_with(".json"): # It's a json file
-		remove_references_of_deleted_id(contentData, id)
-		contentData.data.remove_at(get_array_index_by_id(contentData, id))
-		save_data_to_file(contentData)
-	elif contentData.dataPath.ends_with("/"): # It's a folder
-		remove_references_of_deleted_id(contentData, id)
-		contentData.data.erase(id)
-		var json_file_path = contentData.dataPath + id + ".json"
-		Helper.json_helper.delete_json_file(json_file_path)
-	else:
-		print_debug("Tried to remove item from data, but the data's datapath ends with \
-		neither .json nor /")
 
 
 # Gets the array index of an item by its ID
@@ -185,135 +78,6 @@ func save_data_to_file(contentData: Dictionary):
 	var datapath: String = contentData.dataPath
 	if datapath.ends_with(".json"):
 		Helper.json_helper.write_json_file(datapath, JSON.stringify(contentData.data, "\t"))
-
-
-# Takes contentdata and an id and returns the json that belongs to an id
-# For example, contentData can be Gamedata.data.overmaps
-# and id can be "plain_grass" and it will return the json data for plain_grass
-func get_data_by_id(contentData: Dictionary, id: String) -> Dictionary:
-	var idnr: int = get_array_index_by_id(contentData, id)
-	if idnr < 0:
-		return {}
-	return contentData.data[idnr]
-
-
-# Takes contentData and an id and returns the sprite associated with the id
-# For example, contentData can be Gamedata.data.overmaps
-# and id can be "plain_grass" and it will return the sprite for plain_grass
-func get_sprite_by_id(contentData: Dictionary, id: String) -> Resource:
-	if contentData.sprites.is_empty() or contentData.data.is_empty():
-		return null
-	
-	# Check if the datapath ends with .json (indicating a list item)
-	if contentData.dataPath.ends_with(".json"):
-		var item_json = get_data_by_id(contentData, id)
-		if item_json.has("sprite"):
-			return contentData.sprites.get(item_json["sprite"], null)
-		else:
-			return null
-	else:
-		# Treat as a file in a folder
-		return contentData.sprites.get(id + ".png", null)
-
-
-# Removes all references of a deleted entity ID
-func remove_references_of_deleted_id(contentData: Dictionary, id: String):
-	if contentData == data.tacticalmaps:
-		on_tacticalmap_deleted(id)
-
-
-# Erases a nested property from a dictionary based on a dot-separated path
-func erase_property_by_path(mydata: Dictionary, item_id: String, property_path: String):
-	var entity_data = get_data_by_id(mydata, item_id)
-	if entity_data.is_empty():
-		print_debug("Entity with ID", item_id, "not found.")
-		return false
-
-	# Split the path and process the nesting
-	var path_parts = property_path.split(".")
-	var current_dict = entity_data
-	for i in range(path_parts.size() - 1):  # Navigate to the last dictionary
-		if path_parts[i] in current_dict:
-			current_dict = current_dict[path_parts[i]]
-		else:
-			print_debug("Path not found:", path_parts[i])
-			return false
-
-	# Last part of the path is the key to erase
-	var last_key = path_parts[-1]
-	if last_key in current_dict:
-		current_dict.erase(last_key)
-		print_debug("Property", last_key, "erased successfully.")
-		return true
-	else:
-		print_debug("Property", last_key, "not found.")
-		return false
-
-# Executes a callable function on each reference of the given type
-# data = json data representing one entity
-# module = name of the mod. for example "core"
-# type = the type of reference we want to handle. For example "item"
-# callable = a function to execute on each reference ID
-# We will check if data has the ["references"] and [type] properties and execute the callable on each found ID
-func execute_callable_on_references_of_type(mydata: Dictionary, module: String, type: String, callable: Callable):
-	# Check if 'data' contains a 'references' dictionary and if it contains the specified 'type'
-	if mydata.has("references") and mydata["references"].has(module) and mydata["references"][module].has(type):
-		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in mydata["references"][module][type]:
-			callable.call(ref_id)
-
-
-# Retrieves the value of a nested property from a dictionary based on a dot-separated path
-func get_property_by_path(mydata: Dictionary, property_path: String, entity_id: String) -> Variant:
-	var entity_data = get_data_by_id(mydata, entity_id)
-	if entity_data.is_empty():
-		print_debug("Entity with ID", entity_id, "not found.")
-		return null
-	return Helper.json_helper.get_nested_data(entity_data, property_path)
-
-
-# A tacticalmap is being deleted. Remove all references to this tacticalmap
-func on_tacticalmap_deleted(tacticalmap_id: String):
-	var file = data.tacticalmaps.dataPath + tacticalmap_id + ".json"
-	var tacticalmapdata: Dictionary = Helper.json_helper.load_json_dictionary_file(file)
-	if not tacticalmapdata.has("chunks"):
-		print("Tacticalmap data does not contain 'chunks'.")
-		return
-	for i in range(tacticalmapdata["chunks"].size()):
-		var chunk = tacticalmapdata["chunks"][i]
-		# If the chunk has the target id, remove the reference from the map
-		if chunk.has("id"):
-			maps.remove_reference_from_map(chunk["id"],"core", "tacticalmaps",tacticalmap_id + ".json")
-
-
-func on_tacticalmapdata_changed(tacticalmap_id: String, newdata: Dictionary, olddata: Dictionary):
-	# Collect unique IDs from old data
-	var unique_old_ids: Array = []
-	var ids_dict_old: Dictionary = {}
-	if olddata.has("chunks") and olddata["chunks"] is Array:
-		for chunk in olddata["chunks"]:
-			if chunk.has("id"):
-				ids_dict_old[chunk["id"]] = true
-	unique_old_ids = ids_dict_old.keys()
-
-	# Collect unique IDs from new data
-	var unique_new_ids: Array = []
-	var ids_dict_new: Dictionary = {}
-	if newdata.has("chunks") and newdata["chunks"] is Array:
-		for chunk in newdata["chunks"]:
-			if chunk.has("id"):
-				ids_dict_new[chunk["id"]] = true
-	unique_new_ids = ids_dict_new.keys()
-	tacticalmap_id = tacticalmap_id.get_file()
-	# Add references for new IDs
-	for id in unique_new_ids:
-		maps.add_reference_to_map(id, "core", "tacticalmaps", tacticalmap_id)
-	# Remove references for IDs not present in new data
-	for id in unique_old_ids:
-		if id not in unique_new_ids:
-			maps.remove_reference_from_map(id, "core", "tacticalmaps", tacticalmap_id)
-
-
 
 
 # Removes the provided reference from references

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -110,7 +110,7 @@ func initialize_condition():
 # The PlayerAttribute manages the actual control of the attribute while
 # DPlayerAttribute only provides the data
 func initialize_attributes():
-	var playerattributes: Dictionary = Gamedata.playerattributes.get_playerattributes()
+	var playerattributes: Dictionary = Gamedata.playerattributes.get_all()
 	for attribute: DPlayerAttribute in playerattributes.values():
 		attributes[attribute.id] = PlayerAttribute.new(attribute, self)
 
@@ -118,12 +118,12 @@ func initialize_attributes():
 # Initialize skills with level and XP
 func initialize_stats_and_skills():
 	# Initialize all stats with a value of 5
-	for stat in Gamedata.stats.get_stats().values():
+	for stat in Gamedata.stats.get_all().values():
 		stats[stat.id] = 5
 	Helper.signal_broker.player_stat_changed.emit(self)
 	
 	# Initialize all skills with a value of level 1 and 0 XP
-	for skill in Gamedata.skills.get_skills().values():
+	for skill in Gamedata.skills.get_all().values():
 		skills[skill.id] = {"level": 1, "xp": 0}
 	Helper.signal_broker.player_skill_changed.emit(self)
 

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -123,8 +123,8 @@ func initialize_stats_and_skills():
 	Helper.signal_broker.player_stat_changed.emit(self)
 	
 	# Initialize all skills with a value of level 1 and 0 XP
-	for skill in Gamedata.data.skills.data:
-		skills[skill["id"]] = {"level": 1, "xp": 0}
+	for skill in Gamedata.skills.get_skills().values():
+		skills[skill.id] = {"level": 1, "xp": 0}
 	Helper.signal_broker.player_skill_changed.emit(self)
 
 


### PR DESCRIPTION
Requires #339 

Refactors the content list loading. This required generalizing some functions in the data classes. It's almost like inheritance has it's uses instead of this mess. Now the data classes can be accessed trough Gamedata.maps for example but also trough Gamedata.get_data_of_type(Gamedata.contentType.MAPS). The last form being useful for iteration or dynamic selection.