### PR TITLE
Construction fix

### DIFF
--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -52,8 +52,14 @@ func _on_hud_construction_chosen(_construction: String):
 func on_construction_clicked(construction_data: Dictionary):
 	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
 	if chunk:
-		chunk.add_block(construction_data.id,construction_data.pos)
-		print_debug("Block placed at: ", construction_data.pos, " with type ", construction_data.id)
+		# Calculate local position within the chunk
+		var local_x = int(construction_data.pos.x - chunk.position.x) % 32
+		var local_z = int(construction_data.pos.z - chunk.position.z) % 32
+		var local_position = Vector3(local_x, construction_data.pos.y, local_z)
+		
+		# Pass the local position to the add_block function
+		chunk.add_block(construction_data.id, local_position)
+		print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
 
 
 # Respond to visibility changes of this node
@@ -63,3 +69,5 @@ func _on_build_menu_visibility_change(buildmenu):
 	# Set the visibility of the construction_ghost to match the building menu's visibility
 	construction_ghost.visible = buildmenu.is_visible()
 	is_building = buildmenu.is_visible()
+	if not buildmenu.is_visible():
+		General.is_allowed_to_shoot = true 

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -1,73 +1,56 @@
 extends Node3D
 
-@export var construction_ghost : MeshInstance3D
+@export var construction_ghost: MeshInstance3D
 var is_building = false
 
 @export var LevelGenerator: Node3D
-@export var hud : NodePath
+@export var hud: NodePath
 
-# Called when the node enters the scene tree for the first time.
 func _ready():
 	# Connect the build menu visibility_changed signal to a local method
 	Helper.signal_broker.build_window_visibility_changed.connect(_on_build_menu_visibility_change)
-#	tile_map = get_node(tile_map_path)
-	
-	#3D
-#	ghost_sprite = get_node(ghost_sprite_path)
-#	ghost_sprite.visible = false
-	pass
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	if is_building:
 		construction_ghost.visible = true
-		
-		# 3d
-#		ghost_sprite.global_position = get_global_mouse_position()
 
+func _input(event: InputEvent):
+	if event.is_action_pressed("click_right") and is_building:
+		cancel_building()
 
-func _input(_event):
-	#3D
-	
-#	if Input.is_action_pressed("click") && is_building && get_node(hud).try_to_spend_item("plank", 2):
-		
-#		if get_node(player_path).check_if_visible(get_global_mouse_position()) && Vector2(get_node(player_path).global_position).distance_to(get_global_mouse_position()) <= build_range:
-#			tile_map.set_cell(0, tile_map.local_to_map(get_global_mouse_position()), 0, Vector2i(9,3))
-		
-	if Input.is_action_pressed("click_right") && is_building:
-		is_building = false
-		General.is_allowed_to_shoot = true
-		construction_ghost.visible = false
-
-func make_tile_ghost():
-	pass
+func cancel_building():
+	is_building = false
+	General.is_allowed_to_shoot = true
+	construction_ghost.visible = false
 
 func _on_hud_construction_chosen(_construction: String):
-	print("Building test")
+	start_building()
+
+func start_building():
 	is_building = true
 	General.is_allowed_to_shoot = false
-
 
 func on_construction_clicked(construction_data: Dictionary):
 	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
 	if chunk:
-		# Calculate local position within the chunk
-		var local_x = int(construction_data.pos.x - chunk.position.x) % 32
-		var local_z = int(construction_data.pos.z - chunk.position.z) % 32
-		var local_position = Vector3(local_x, construction_data.pos.y, local_z)
-		
-		# Pass the local position to the add_block function
+		var local_position = calculate_local_position(construction_data.pos, chunk.position)
 		chunk.add_block(construction_data.id, local_position)
 		print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
 
+func calculate_local_position(global_pos: Vector3, chunk_pos: Vector3) -> Vector3:
+	# Calculate local position within the chunk
+	var local_x = int(global_pos.x - chunk_pos.x) % 32
+	var local_z = int(global_pos.z - chunk_pos.z) % 32
+	return Vector3(local_x, global_pos.y, local_z)
 
-# Respond to visibility changes of this node
 func _on_build_menu_visibility_change(buildmenu):
 	if !is_building:
 		return
-	# Set the visibility of the construction_ghost to match the building menu's visibility
-	construction_ghost.visible = buildmenu.is_visible()
-	is_building = buildmenu.is_visible()
-	if not buildmenu.is_visible():
-		General.is_allowed_to_shoot = true 
+	# Update construction ghost visibility based on build menu visibility
+	set_building_state(buildmenu.is_visible())
+
+func set_building_state(visible: bool):
+	construction_ghost.visible = visible
+	is_building = visible
+	if not visible:
+		General.is_allowed_to_shoot = true

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -7,13 +7,14 @@ extends MeshInstance3D
 
 # Settings
 var grid_size = 1.0
-var y_offset = 0.0  # This is the y-coordinate offset relative to the player's position
+var y_offset = 0.0  # Offset relative to the player's position in the Y-axis
 var build_range = 5.0  # Maximum build range from the player
 var construction_data: Dictionary
 
 signal construction_clicked(data: Dictionary)
 
 func _ready():
+	# Connect the signal for construction clicks to the build manager
 	construction_clicked.connect(buildmanager.on_construction_clicked)
 
 
@@ -21,40 +22,41 @@ func _process(_delta):
 	if !visible:
 		return
 
-	# Project the mouse position onto the ground plane at the player's Y position
-	var mouse_position_2d = get_viewport().get_mouse_position()
-	var plane = Plane(Vector3.UP, player.global_position.y + y_offset)
-	var mouse_position = sceneCam.project_ray_origin(mouse_position_2d) + sceneCam.project_ray_normal(mouse_position_2d) * sceneCam.global_transform.origin.distance_to(plane.project(sceneCam.project_ray_origin(mouse_position_2d)))
-
-	# Calculate the position relative to the player
-	var raw_position = Vector3(
-		mouse_position.x,
-		player.global_position.y + y_offset,
-		mouse_position.z
-	)
+	# Get the 3D position from the mouse's 2D position on the screen
+	var mouse_position = get_mouse_3d_position()
 	
 	# Ensure the position stays within the build range from the player
-	var x_diff = raw_position.x - player.global_position.x
-	var z_diff = raw_position.z - player.global_position.z
+	var x_diff = mouse_position.x - player.global_position.x
+	var z_diff = mouse_position.z - player.global_position.z
 	
 	if x_diff > build_range:
-		raw_position.x = player.global_position.x + build_range
+		mouse_position.x = player.global_position.x + build_range
 	elif x_diff < -build_range:
-		raw_position.x = player.global_position.x - build_range
+		mouse_position.x = player.global_position.x - build_range
 		
 	if z_diff > build_range:
-		raw_position.z = player.global_position.z + build_range
+		mouse_position.z = player.global_position.z + build_range
 	elif z_diff < -build_range:
-		raw_position.z = player.global_position.z - build_range
+		mouse_position.z = player.global_position.z - build_range
 	
 	# Snap the position to the grid
-	var snapped_x = round(raw_position.x / grid_size) * grid_size
-	var snapped_z = round(raw_position.z / grid_size) * grid_size
-	var snapped_y = round(raw_position.y / grid_size) * grid_size
+	var snapped_x = round(mouse_position.x / grid_size) * grid_size
+	var snapped_z = round(mouse_position.z / grid_size) * grid_size
+	var snapped_y = round(mouse_position.y / grid_size) * grid_size
 	
 	# Update the position of the constructionghost
 	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z)
 
+
+# Calculate the 3D position based on the mouse's 2D position and the player's Y offset
+func get_mouse_3d_position() -> Vector3:
+	var mouse_position_2d = get_viewport().get_mouse_position()
+	var plane = Plane(Vector3.UP, player.global_position.y + y_offset)
+	var ray_origin = sceneCam.project_ray_origin(mouse_position_2d)
+	var ray_direction = sceneCam.project_ray_normal(mouse_position_2d)
+	var mouse_position = ray_origin + ray_direction * sceneCam.global_transform.origin.distance_to(plane.project(ray_origin))
+	
+	return Vector3(mouse_position.x, player.global_position.y + y_offset, mouse_position.z)
 
 
 func _input(event):

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -20,35 +20,41 @@ func _ready():
 func _process(_delta):
 	if !visible:
 		return
-	var mouse_position = sceneCam.project_position(get_viewport().get_mouse_position(), sceneCam.global_transform.origin.z)
+
+	# Project the mouse position onto the ground plane at the player's Y position
+	var mouse_position_2d = get_viewport().get_mouse_position()
+	var plane = Plane(Vector3.UP, player.global_position.y + y_offset)
+	var mouse_position = sceneCam.project_ray_origin(mouse_position_2d) + sceneCam.project_ray_normal(mouse_position_2d) * sceneCam.global_transform.origin.distance_to(plane.project(sceneCam.project_ray_origin(mouse_position_2d)))
+
+	# Calculate the position relative to the player
+	var raw_position = Vector3(
+		mouse_position.x,
+		player.global_position.y + y_offset,
+		mouse_position.z
+	)
 	
-	# Calculate the raw x, y, and z positions
-	var raw_x = mouse_position.x
-	var raw_z = mouse_position.z
-	var raw_y = player.global_position.y + y_offset  # Adjust y by a fixed offset
-	
-	# Limit x and z to be within the build range from the player before snapping
-	var x_diff = raw_x - player.global_position.x
-	var z_diff = raw_z - player.global_position.z
+	# Ensure the position stays within the build range from the player
+	var x_diff = raw_position.x - player.global_position.x
+	var z_diff = raw_position.z - player.global_position.z
 	
 	if x_diff > build_range:
-		raw_x = player.global_position.x + build_range
+		raw_position.x = player.global_position.x + build_range
 	elif x_diff < -build_range:
-		raw_x = player.global_position.x - build_range
+		raw_position.x = player.global_position.x - build_range
 		
 	if z_diff > build_range:
-		raw_z = player.global_position.z + build_range
+		raw_position.z = player.global_position.z + build_range
 	elif z_diff < -build_range:
-		raw_z = player.global_position.z - build_range
+		raw_position.z = player.global_position.z - build_range
 	
-	# Snap the adjusted positions to the grid
-	var snapped_x = floor(raw_x / grid_size) * grid_size
-	var snapped_z = floor(raw_z / grid_size) * grid_size
-	var snapped_y = floor(raw_y / grid_size) * grid_size  # Snap y-position
+	# Snap the position to the grid
+	var snapped_x = round(raw_position.x / grid_size) * grid_size
+	var snapped_z = round(raw_position.z / grid_size) * grid_size
+	var snapped_y = round(raw_position.y / grid_size) * grid_size
 	
-	# Assign the snapped positions
-	var snapped_position = Vector3(snapped_x, snapped_y, snapped_z)
-	global_transform.origin = snapped_position
+	# Update the position of the constructionghost
+	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z)
+
 
 
 func _input(event):
@@ -56,4 +62,4 @@ func _input(event):
 		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		construction_data = {"pos": global_transform.origin, "id": "concrete_00"}
-		emit_signal("construction_clicked", construction_data)
+		construction_clicked.emit(construction_data)


### PR DESCRIPTION
Requires #359 
Fixes #358 

Set the is_allowed_to_shoot to true if the construction menu is closed. Now the player can fire the weapon again.

I also noticed a bug with the construction ghost when the player was away from the 0,0 chunk. I re-did the calculations and now the position works as it should.